### PR TITLE
Fix for bug #500

### DIFF
--- a/muikku-deus-nex-machina/src/main/java/fi/muikku/plugins/dnm/parser/content/ConnectFieldOption.java
+++ b/muikku-deus-nex-machina/src/main/java/fi/muikku/plugins/dnm/parser/content/ConnectFieldOption.java
@@ -1,33 +1,41 @@
 package fi.muikku.plugins.dnm.parser.content;
 
 public class ConnectFieldOption {
-	
-	public ConnectFieldOption(String answer, String equivalent, String term, Double points) {
-		this.answer = answer;
-		this.equivalent = equivalent;
-		this.term = term;
-		this.points = points;
-	}
+  
+  public ConnectFieldOption(String answer, String equivalent, String term, Double points) {
+    this.answer = answer;
+    this.equivalent = equivalent;
+    this.term = term;
+    this.points = points;
+  }
 
-	public String getAnswer() {
-		return answer;
-	}
-	
-	public String getEquivalent() {
-		return equivalent;
-	}
-	
-	public String getTerm() {
-		return term;
-	}
-	
-	public Double getPoints() {
-		return points;
-	}
-	
-	private String answer;
-	private String equivalent;
-	private String term;
-	private Double points;
+  public String getAnswer() {
+    return answer;
+  }
+  
+  public void setEquivalent(String equivalent) {
+    this.equivalent = equivalent;
+  }
+
+  public String getEquivalent() {
+    return equivalent;
+  }
+  
+  public void setTerm(String term) {
+    this.term = term;
+  }
+  
+  public String getTerm() {
+    return term;
+  }
+  
+  public Double getPoints() {
+    return points;
+  }
+  
+  private String answer;
+  private String equivalent;
+  private String term;
+  private Double points;
 
 }

--- a/muikku-deus-nex-machina/src/main/java/fi/muikku/plugins/dnm/translator/FieldTranslator.java
+++ b/muikku-deus-nex-machina/src/main/java/fi/muikku/plugins/dnm/translator/FieldTranslator.java
@@ -3,6 +3,8 @@ package fi.muikku.plugins.dnm.translator;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.muikku.plugins.dnm.parser.content.ConnectFieldOption;
 import fi.muikku.plugins.dnm.parser.content.OptionListOption;
 import fi.muikku.plugins.dnm.parser.content.RightAnswer;
@@ -85,6 +87,13 @@ public class FieldTranslator {
       ConnectFieldOption option = options.get(i);
       String fieldName = String.valueOf(i+1);
       String counterpartName = getExcelStyleLetterIndex(i);
+
+      if (StringUtils.length(option.getTerm()) > 255) {
+        option.setTerm(option.getTerm().substring(0, 254));
+      }
+      if (StringUtils.length(option.getEquivalent()) > 255) {
+        option.setEquivalent(option.getEquivalent().substring(0, 254));
+      }
       
       connectFieldOptionMetas.add(new ConnectFieldOptionMeta(fieldName, option.getTerm()));
       counterparts.add(new ConnectFieldOptionMeta(counterpartName, option.getEquivalent()));


### PR DESCRIPTION
Fixed simply by truncating connect field terms and equivalents over 255 characters to 255 characters. Hardly an elegant fix but values that long are absurd to begin with, so it makes no sense to modify the database schema to support them.