### PR TITLE
* Fixed issue #472

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/socialnavigation.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/socialnavigation.js
@@ -29,15 +29,13 @@
     if(result != null && result.actionType == "edit"){
       var textContent = result.message;
       var topic = result.title;
+      
+      $(textfields).each(function(index,textfield){        
+        $(textfield).val(topic);
+      });  
+      
     }
 
-     $(textfields).each(function(index,textfield){
-       
-       $(textfield).val(topic);
-
-       
-     });     
-     
      if(ckeditor == undefined){
        var ckeditor = true;
      }


### PR DESCRIPTION
* Fixed issue #472 where communicator's reply didn't work if caption was empty and it was not filled automatically. Discussion specific textfield handling was done outside if block which was also discussion specific.