### PR TITLE
Fixes #582

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
@@ -52,14 +52,9 @@
         </ui:fragment>
   		</div>
       
-      <div class="workspace-publication-container" jsf:rendered="#{workspaceIndexBackingBean.canPublish}">
-        <ui:fragment rendered="#{!workspaceIndexBackingBean.published}">
-          <a class="workspace-publish-button" href="javascript:void(null)">#{i18n.text['plugin.workspace.index.publish']}</a>
-        </ui:fragment>
-        
-        <ui:fragment rendered="#{workspaceIndexBackingBean.published}">
-          <a class="workspace-unpublish-button" href="javascript:void(null)">#{i18n.text['plugin.workspace.index.unpublish']}</a>
-        </ui:fragment>
+      <div class="workspace-publication-container" jsf:rendered="#{workspaceIndexBackingBean.canPublish}" data-published="#{workspaceIndexBackingBean.published}">
+        <a class="workspace-publish-button" style="display:none;" href="javascript:void(null)">#{i18n.text['plugin.workspace.index.publish']}</a>
+        <a class="workspace-unpublish-button" style="display:none;" href="javascript:void(null)">#{i18n.text['plugin.workspace.index.unpublish']}</a>
       </div>
       
     </header>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace.js
@@ -13,7 +13,9 @@
           if (updErr) {
             $('.notification-queue').notificationQueue('notification', 'error', updErr);
           } else {
-            window.location.reload(true); 
+            $('.workspace-publish-button').hide();
+            $('.workspace-unpublish-button').show();
+            $('.workspace-publication-container').data('published', true);
           }
         });
       }
@@ -32,7 +34,9 @@
           if (updErr) {
             $('.notification-queue').notificationQueue('notification', 'error', updErr);
           } else {
-            window.location.reload(true); 
+            $('.workspace-publish-button').show();
+            $('.workspace-unpublish-button').hide();
+            $('.workspace-publication-container').data('published', false);
           }
         });
       }
@@ -47,8 +51,21 @@
     });
   }
 
+  window.onload = function(e) {
+    if ($('.workspace-publication-container')) {
+      var published = $('.workspace-publication-container').data('published');
+      if (published) {
+        $('.workspace-publish-button').hide();
+        $('.workspace-unpublish-button').show();
+      }
+      else {
+        $('.workspace-publish-button').show();
+        $('.workspace-unpublish-button').hide();
+      }
+    }
+  };
+
   $(document).ready(function() {
-    
     $('#staticNavigationWrapperWorkspace').waypoint('sticky', {
       stuckClass : 'stuckStNav'
     });


### PR DESCRIPTION
Publishing on Firefox seems to work just fine. There have, however, been reports that publish does not seem to do anything on first click. This might be due to the entire page being reloaded after publish (or unpublish). This could lead to a few seconds of seemingly nothing happening and an impatient user might end up clicking the button multiple times. Fixed by simply toggling the Publish and Unpublish buttons visible/hidden rather than reloading the entire page. Feedback is now practically instantaneous.