### PR TITLE
Fixes #828 (CKEditor HTML entities)

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/evaluation.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/evaluation.js
@@ -221,6 +221,9 @@
         
           CKEDITOR.replace($("#evaluateFormLiteralEvaluation")[0], {
             height : '200px',
+            entities: false,
+            entities_latin: false,
+            entities_greek: false,
             toolbar: [
                       { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat' ] },
                       { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'Undo', 'Redo' ] },
@@ -399,6 +402,9 @@
         
           CKEDITOR.replace($("#evaluateFormLiteralEvaluation")[0], {
             height : '200px',
+            entities: false,
+            entities_latin: false,
+            entities_greek: false,
             toolbar: [
                       { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat' ] },
                       { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'Undo', 'Redo' ] },

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/socialnavigation.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/socialnavigation.js
@@ -48,6 +48,9 @@
           
           CKEDITOR.replace(textarea, {
             height : '100px',
+            entities: false,
+            entities_latin: false,
+            entities_greek: false,
             toolbar: [
                       { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat' ] },
                       { name: 'clipboard', items: [ 'Cut', 'Copy', 'Paste', 'Undo', 'Redo' ] },

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-material-editor-html.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-material-editor-html.js
@@ -124,6 +124,9 @@
         editorOptions: {
           autoGrowOnStartup : true,
           allowedContent: true, // disable content filtering to preserve all formatting of imported documents; fix for #263
+          entities: false,
+          entities_latin: false,
+          entities_greek: false,
           skin : 'moono',
           height : 500,
           language: getLocale(),


### PR DESCRIPTION
Disabled HTML entities in CKEditor (materials, evaluation, and social navigation)