### PR TITLE
Front and help pages of a workspace should always be copied rather than linked

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/muikku/plugins/workspace/WorkspaceMaterialController.java
+++ b/muikku-core-plugins/src/main/java/fi/muikku/plugins/workspace/WorkspaceMaterialController.java
@@ -360,6 +360,18 @@ public class WorkspaceMaterialController {
       Material material = getMaterialForWorkspaceMaterial(workspaceMaterial);
       isHtmlMaterial = material instanceof HtmlMaterial;
       Material clonedMaterial = cloneMaterials && !overrideCloneMaterials ? materialController.cloneMaterial(material) : material;
+
+      // Implementation of feature #1232 (front and help pages should always be copies)
+      if (isHtmlMaterial && !cloneMaterials) {
+        WorkspaceNode parentNode = workspaceMaterial.getParent();
+        if (parentNode instanceof WorkspaceFolder) {
+          WorkspaceFolder parentFolder = (WorkspaceFolder) parentNode;
+          if (parentFolder.getFolderType() == WorkspaceFolderType.FRONT_PAGE || parentFolder.getFolderType() == WorkspaceFolderType.HELP_PAGE) {
+            clonedMaterial = materialController.cloneMaterial(material);
+          }
+        }
+      }
+      
       newNode = createWorkspaceMaterial(
           parent,
           clonedMaterial,


### PR DESCRIPTION
- resolves #1232