### PR TITLE
Name extensions to guider workspaces (+ miscellaneous guider bug fixes)

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/dust/guider/guider_user_filters.dust
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/dust/guider/guider_user_filters.dust
@@ -6,7 +6,7 @@
         <li id="{type}-{id}">
           <a class="gt-filter-link" data-type="{type}" data-id="{id}">
             <span class="{iconClass}"></span>
-            <span>{name}</span>
+            <span>{name}{?nameExtension} ({nameExtension}){/nameExtension}</span>
           </a></li>    
         </li>    
       {/data}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/guider.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/guider.js
@@ -118,7 +118,11 @@
     
     _loadWorkspaces: function (callback) {
       mApi().workspace.workspaces
-        .read({ ownerIdentifier: MUIKKU_LOGGED_USER })
+        .read({
+          userIdentifier: MUIKKU_LOGGED_USER,
+          maxResults: 500,
+          orderBy: 'alphabet'
+        })
         .callback(function (err, workspaces) {
           if (err) {
             callback(err);


### PR DESCRIPTION
- added name extension to guider workspaces
- added correct workspace user filter
- upped guider workspace max results to 500
- sort guider workspaces by name
- resolves #1830