### PR TITLE
Don't show workspace name extension if null or empty (used to have only null check)

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
@@ -38,7 +38,7 @@
             <div class="workspace-study-level-text">#{workspaceIndexBackingBean.educationType}</div>
           </div>
         </ui:fragment>
-        <ui:fragment rendered="#{workspaceIndexBackingBean.workspaceNameExtension ne null}">
+        <ui:fragment rendered="#{not empty workspaceIndexBackingBean.workspaceNameExtension}">
           <div class="workspace-additional-info-wrapper"><span>#{workspaceIndexBackingBean.workspaceNameExtension}</span></div>
         </ui:fragment>
       </div>


### PR DESCRIPTION
- fixes #2085