### PR TITLE
Removed zeroing of time in search

### DIFF
--- a/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
+++ b/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
@@ -128,9 +128,8 @@ public class ElasticSearchProvider implements SearchProvider {
       Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers, 
       Date startedStudiesBefore, Date studyTimeEndsBefore) {
     try {
-      
-      long now = OffsetDateTime.now().with(ChronoField.MILLI_OF_DAY, 0).toInstant().toEpochMilli() / 1000;      
-      
+      long now = OffsetDateTime.now().toEpochSecond();
+
       text = sanitizeSearchString(text);
 
       BoolQueryBuilder query = boolQuery();


### PR DESCRIPTION
Closes #2984 

The issue here is that if the OffsetDateTime.now() returned f.ex. "today 13:37+02:00" and we zero the time it will be "today 00:00+02:00" which actually is yesterday 22:00GMT. I.e. the timezone has unknown effect on the outcome.

The problem is f.ex. on line 228 where studyStartDate timestamp is saved as "today 00:00" but the translated date from current time is actually yesterday 22:00. So test of studyStartDate[today] <= "now[millis:0]" is never true for the same start day provided the time zone is not GMT.

This is a proposition and needs to be evaluated to minimize risk for further problems.