### PR TITLE
Fix problems with deletion and editing communicator messages in IE11

### DIFF
--- a/muikku/src/main/webapp/resources/scripts/api/api.js
+++ b/muikku/src/main/webapp/resources/scripts/api/api.js
@@ -121,6 +121,7 @@
         async: async,
         traditional: true,
         contentType: 'application/json', // http://stackoverflow.com/a/17660503
+        cache: false,
         beforeSend: $.proxy(function (xhr, settings) {
           this._xhrs.push(xhr);
         }, this),


### PR DESCRIPTION
So after fiddling with the nightmare that IE is I figured it was a caching issue that came from the mApi as there are several layers of catching, I disabled jQuery level one which by default would append a timestamp in order to try to be smart.

I figured I only had to add one line so yes this fix is very short, however we need to give some testing as this affects the way it behaves in all browsers. However since catching doesn't happen is rest endpoints (which is why it works right on chrome, firefox and safari) this seems to only affect IE making it work.

However if required I can make it so that the cache flag is only set to false if the browser is IE11.

Fixes #3041 ja #3040 
Please also do your own testing in a non VM IE11.