### PR TITLE
Page should not scroll top when loading more messages in the discussion

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/discussion.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/discussion.js
@@ -1,15 +1,15 @@
 (function() {
   'use strict';
-  
+
   window.DiscussionIOController = function (options) {
     this.options = options;
   };
-  
+
   $.extend(window.DiscussionIOController.prototype, {
-    
+
     loadThreadDetails: function(thread, callback) {
       var tasks = [this._createUserInfoLoad(thread.creator), this._createLoadArea(thread.forumAreaId)];
-      
+
       async.parallel(tasks, $.proxy(function (err, results) {
         if (err) {
           callback(err);
@@ -18,9 +18,9 @@
           var area = results[1];
           var d = moment(thread.created).toDate();
           var ud = moment(thread.updated).toDate();
-          
+
           var creatorFullName;
-          
+
           if (user.nickName) {
             if (this.options.showFullNamePermission)
               creatorFullName = user.firstName + ' "' + user.nickName + '" ' + user.lastName;
@@ -29,7 +29,7 @@
           } else {
             creatorFullName = user.firstName + ' ' + user.lastName;
           }
-          
+
           // TODO: remove prettyDates...
           callback(null, $.extend({}, thread, {
             areaName: area.name,
@@ -46,17 +46,17 @@
         }
       }, this));
     },
-    
+
     loadThreadRepliesDetails: function(replies, callback) {
       var replyCreatedMap = {};
       $.each(replies, function (index, reply) {
         replyCreatedMap[reply.id] = reply.created;
       });
-      
+
       var calls = $.map(replies, $.proxy(function (reply) {
         return this._createUserInfoLoad(reply.creator);
       }, this));
-      
+
       async.parallel(calls, $.proxy(function (err, users) {
         if (err) {
           callback(err);
@@ -68,7 +68,7 @@
             var d = moment(reply.created).toDate();
             var ld = moment(reply.lastModified).toDate();
             var globalEdit = $('.discussion').discussion('mayEditMessages', reply.forumAreaId);
-            
+
             var creatorFullName;
 
             if (user.nickName) {
@@ -79,7 +79,7 @@
             } else {
               creatorFullName = user.firstName + ' ' + user.lastName;
             }
-            
+
             return {
               creatorFullName: creatorFullName,
               isEdited: reply.lastModified == reply.created ? false : true,
@@ -91,38 +91,38 @@
               nameLetter: creatorFullName.substring(0,1),
               isReply: reply.parentReplyId ? true : false,
               replyParentTime: reply.parentReplyId ? formatDate(moment(replyCreatedMap[reply.parentReplyId]).toDate()) + ' ' + formatTime(moment(replyCreatedMap[reply.parentReplyId]).toDate()) : null
-            }; 
+            };
           }, this)));
         }
       }, this));
     },
-    
+
     _createUserInfoLoad: function (userEntityId) {
       return $.proxy(function (callback) {
         this._loadUserInfo(userEntityId, callback);
       }, this);
     },
-    
+
     _createLoadArea: function (forumAreaId) {
       return $.proxy(function (callback) {
         this.loadArea(forumAreaId, callback);
       }, this);
     },
-    
+
     _loadUserInfo: function (userEntityId, callback) {
       mApi().user.users.basicinfo
         .read(userEntityId)
         .callback(callback);
     }
   });
-  
+
   $.widget("custom.discussion", {
-    
+
     _create : function() {
       this.element.addClass('discussion');
-      
+
       this._areaId = null;
-      
+
       this.element.on("change", "select[name='areas']", $.proxy(this._onAreaSelectChange, this));
       this.element.on("click", ".di-new-area-button", $.proxy(this._onNewAreaClick, this));
       this.element.on("click", ".di-new-message-button", $.proxy(this._onNewMessageClick, this));
@@ -134,18 +134,18 @@
         .discussionThreads({
           ioController: this.options.ioController
         });
-      
+
       this.element.find('.di-thread')
         .hide()
         .discussionThread({
           ioController: this.options.ioController
         });
-      
+
       this._load($.proxy(function () {
         var areaId = null;
         var threadId = null;
         this._allAreas = false;
-        
+
         if (window.location.hash.length > 1) {
           var hashParts = window.location.hash.substring(1).split('/');
           if (hashParts.length > 0) {
@@ -155,7 +155,7 @@
           if (hashParts.length > 1) {
             threadId = hashParts[1];
           }
-          
+
           if (areaId) {
             if (areaId.charAt(0) == 'a') {
               areaId = areaId.substring(1);
@@ -165,7 +165,7 @@
         } else {
           this._allAreas = true;
         }
-        
+
         if (areaId && threadId) {
           this.loadThread(areaId, threadId);
         } else {
@@ -175,9 +175,9 @@
             this.loadArea(areaId);
           }
         }
-      }, this)); 
+      }, this));
     },
-    
+
     loadAllAreas: function () {
       this._threadId = null;
       this._areaId = null;
@@ -186,7 +186,7 @@
       this.element.find("select[name='areas']").val('all');
       this._loadThreads('all');
     },
-    
+
     loadArea: function (areaId) {
       this._threadId = null;
       this._areaId = areaId;
@@ -195,7 +195,7 @@
       this.element.find("select[name='areas']").val(areaId);
       this._loadThreads(areaId);
     },
-    
+
     reloadArea: function () {
       if (this._allAreas) {
         this.loadAllAreas();
@@ -203,7 +203,7 @@
         this.loadArea(this._areaId);
       }
     },
-    
+
     reloadAreas: function () {
       var tasks = [this._createAreasLoad()];
       async.parallel(tasks, $.proxy(function (err, results) {
@@ -224,114 +224,114 @@
         }
       }, this));
     },
-    
+
     loadThread: function (areaId, threadId) {
       this._threadId = threadId;
       this._areaId = areaId;
       this._updateHash();
-      
+
       if (this._allAreas) {
-        this.element.find("select[name='areas']").val('all');      
+        this.element.find("select[name='areas']").val('all');
       } else {
         this.element.find("select[name='areas']").val(areaId);
       }
-      
+
       this._loadThread(areaId, threadId);
     },
-    
+
     reloadThread: function () {
       this.loadThread(this._areaId, this._threadId);
     },
-        
+
     newAreaDialog: function () {
       var dialog = $('<div>')
         .discussionNewAreaDialog({
           ioController: this.options.ioController
         });
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-        
+
     editAreaDialog: function (areaId) {
       var dialog = $('<div>')
         .discussionEditAreaDialog({
           ioController: this.options.ioController,
           areaId: areaId
         });
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-        
+
     deleteAreaDialog: function (areaId) {
       var dialog = $('<div>')
         .discussionDeleteAreaDialog({
           ioController: this.options.ioController,
           areaId: areaId
         });
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     newMessageDialog: function (options) {
       var dialog = $('<div>')
         .discussionNewMessageDialog($.extend({
           lockStickyPermission: this.options.lockStickyPermission,
           ioController: this.options.ioController
         }, options||{}));
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     replyMessageDialog: function (options) {
       var dialog = $('<div>')
         .discussionReplyMessageDialog($.extend({
           ioController: this.options.ioController
         }, options||{}));
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     editMessageDialog: function (options) {
       var dialog = $('<div>')
         .discussionEditMessageDialog($.extend({
           lockStickyPermission: this.options.lockStickyPermission,
           ioController: this.options.ioController
         }, options||{}));
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     editReplyDialog: function (options) {
       var dialog = $('<div>')
         .discussionEditReplyDialog($.extend({
           ioController: this.options.ioController
         }, options||{}));
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     mayRemoveThread: function (areaId) {
       return this.options.areaPermissions[areaId] && this.options.areaPermissions[areaId].removeThread;
     },
-    
+
     mayEditMessages: function (areaId) {
       return this.options.areaPermissions[areaId] && this.options.areaPermissions[areaId].editMessages;
     },
-    
+
     _updateHash: function () {
       if (this._allAreas) {
         if (this._areaId && this._threadId) {
@@ -355,7 +355,7 @@
         }
       }
     },
-    
+
     _load: function (callback) {
       var tasks = [this._createAreasLoad()];
       async.parallel(tasks, $.proxy(function (err, results) {
@@ -368,46 +368,46 @@
         }
       }, this));
     },
-    
+
     _createAreasLoad: function () {
       return $.proxy(function (callback) {
         this.options.ioController.loadAreas(callback);
       }, this);
     },
-    
+
     _buildAreaSelect: function (areas) {
       var areaSelect = $(this.element)
         .find("select[name='areas']")
         .empty();
-        
+
       if (areas && areas.length) {
-        $(this.element).find(".di-new-message-button").removeClass("disabled");          
-        
+        $(this.element).find(".di-new-message-button").removeClass("disabled");
+
         $('<option>')
           .text(getLocaleText('plugin.discussion.browseareas.all'))
           .attr('value', 'all')
           .appendTo(areaSelect);
-        
+
         $.each(areas, function (index, area) {
           if (!area.groupId) {
             $('<option>')
               .attr('value', area.id)
               .attr('data-description', area.description)
-              .text(area.name) 
+              .text(area.name)
               .appendTo(areaSelect);
           }
         });
       } else {
-        $(this.element).find(".di-new-message-button").addClass("disabled");          
-        
+        $(this.element).find(".di-new-message-button").addClass("disabled");
+
         $('<option>')
           .text(getLocaleText('plugin.discussion.selectarea.empty'))
           .appendTo(areaSelect);
       }
     },
-    
+
     _loadThreads: function (areaId) {
-      
+
       var option = this.element.find('select[name="areas"] option:selected');
       var description = option.attr('data-description');
       var descriptionContainer =  this.element.find('.di-thread-description-container');
@@ -422,19 +422,19 @@
 
       this.element.find('.di-threads')
         .show()
-        .discussionThreads('loadThreads', areaId); 
-    
+        .discussionThreads('loadThreads', areaId);
+
     },
-    
+
     _loadThread: function (areaId, threadId) {
       this.element.find('.di-thread')
         .discussionThread('loadThread', areaId, threadId)
         .show();
 
       this.element.find('.di-threads')
-        .hide(); 
+        .hide();
     },
-    
+
     _onAreaSelectChange: function (event) {
       event.preventDefault();
       var value = $(event.target).val();
@@ -444,40 +444,40 @@
         this.loadArea(value);
       }
     },
-    
+
     _onNewAreaClick: function (event) {
       this.newAreaDialog();
     },
-    
+
     _onNewMessageClick: function (event) {
       var options = {};
-      
+
       if (this._areaId != 'all') {
         options.areaId = this._areaId;
       }
-      
+
       this.newMessageDialog(options);
     },
-    
+
     _onEditMessageClick: function (event) {
       this.editAreaDialog(this._areaId);
     },
-    
+
     _onDeleteMessageClick: function (event) {
       this.deleteAreaDialog(this._areaId);
     }
-    
+
   });
-  
+
   $.widget("custom.discussionThread", {
-    
+
     options: {
       maxReplyCount: 25
     },
-    
+
     _create : function() {
       this._firstResult = 0;
-      this._replies = []; 
+      this._replies = [];
       this.element.on("click", ".icon-goback", $.proxy(this._onBackClick, this));
       this.element.on("click", ".di-remove-thread-link", $.proxy(this._onRemoveClick, this));
       this.element.on("click", ".di-message-reply-link", $.proxy(this._onMessageReplyClick, this));
@@ -489,30 +489,30 @@
       this.element.on("click", ".di-reply-delete-link", $.proxy(this._onReplyDeleteClick, this));
       this.element.on("click", ".di-page-link-load-more-replies", $.proxy(this._onMoreRepliesClickClick, this));
     },
-    
+
     _createThreadLoad: function (areaId, threadId) {
       return $.proxy(function (callback) {
         this.options.ioController.loadThread(areaId, threadId, callback);
       }, this);
     },
-    
+
     _createThreadRepliesLoad: function (areaId, threadId) {
       return $.proxy(function (callback) {
         this.options.ioController.loadThreadReplies(areaId, threadId, this._firstResult, this.options.maxReplyCount + 1, callback);
       }, this);
     },
-    
+
     loadThread: function (areaId, threadId) {
-      $('.di-thread-description-container').hide();      
+      $('.di-thread-description-container').hide();
       this.element
         .html('')
         .addClass('loading');
-      
+
       this._firstResult = 0;
       this._replies = [];
       this._areaId = areaId;
       this._threadId = threadId;
-      
+
       var tasks = [this._createThreadLoad(areaId, threadId), this._createThreadRepliesLoad(areaId, threadId)];
       async.parallel(tasks, $.proxy(function (err, results) {
         if (err) {
@@ -520,7 +520,7 @@
         } else {
           var thread = _.clone(results[0]);
           var replies = _.clone(results[1]||[]);
-          
+
           this.options.ioController.loadThreadDetails(thread, $.proxy(function (detailsErr, thread) {
             if (detailsErr) {
               $('.notification-queue').notificationQueue('notification', 'error', detailsErr);
@@ -530,7 +530,7 @@
                 hasMore = true;
                 replies.pop();
               }
-              
+
               this._thread = thread;
               this._replies = this._replies.concat(replies);
               this._renderReplies(hasMore);
@@ -539,14 +539,10 @@
         }
       }, this));
     },
-    
+
     _loadMoreReplies: function () {
-      this.element
-        .html('')
-        .addClass('loading');
-    
       this._firstResult += this.options.maxReplyCount;
-        
+
       var tasks = [this._createThreadRepliesLoad(this._areaId, this._threadId)];
       async.parallel(tasks, $.proxy(function (err, results) {
         if (err) {
@@ -558,14 +554,14 @@
             hasMore = true;
             replies.pop();
           }
-          
+
           this._replies = this._replies.concat(replies);
           this._renderReplies(hasMore);
         }
       }, this));
-      
+
     },
-    
+
     _renderReplies: function (hasMore) {
       renderDustTemplate('/discussion/discussion_items_open.dust', {
         thread: this._thread,
@@ -578,7 +574,7 @@
           .removeClass('loading');
       }, this));
     },
-    
+
     _removeThread: function () {
       this.options.ioController.deleteThread(this._areaId, this._threadId, $.proxy(function(err, result) {
         if (err) {
@@ -589,7 +585,7 @@
         }
       }, this));
     },
-    
+
     _confirmThreadRemoval: function (confirmCallback) {
       renderDustTemplate('discussion/discussion-confirm-thread-removal.dust', {}, $.proxy(function(text) {
         var dialog = $(text);
@@ -619,20 +615,20 @@
     _onMessageReplyClick: function (event) {
       var messageElement = $(event.target)
         .closest('.di-message');
-      
+
       var areaId = messageElement.attr('data-area-id');
       var threadId = messageElement.attr('data-id');
-      
+
       this.element.closest('.discussion').discussion('replyMessageDialog', {
         areaId: areaId,
         threadId: threadId
       });
     },
-    
+
     _onMessageQuoteClick: function (event) {
       var messageElement = $(event.target)
         .closest('.di-message');
-      
+
       var areaId = messageElement.attr('data-area-id');
       var threadId = messageElement.attr('data-id');
       var quote = $('<pre>').append($('<blockquote>').html(messageElement.find('.mf-item-content-text').html())).html();
@@ -643,11 +639,11 @@
         content: quote
       });
     },
-    
+
     _onMessageEditClick: function (event) {
       var messageElement = $(event.target)
         .closest('.di-message');
-      
+
       var areaId = messageElement.attr('data-area-id');
       var threadId = messageElement.attr('data-id');
 
@@ -656,13 +652,13 @@
         threadId: threadId
       });
     },
-    
+
     _onReplyEditClick: function (event) {
       var messageElement = $(event.target)
         .closest('.di-message');
       var repliesElement = $(event.target)
         .closest('.di-replies-container');
-      
+
       var areaId = repliesElement.attr('data-area-id');
       var threadId = repliesElement.attr('data-thread-id');
       var replyId = messageElement.attr('data-id');
@@ -673,11 +669,11 @@
         replyId: replyId
       });
     },
-    
+
     _onReplyDeleteClick: function (event) {
       var messageElement = $(event.target).closest('.di-message');
       var repliesElement = $(event.target).closest('.di-replies-container');
-      
+
       var areaId = repliesElement.attr('data-area-id');
       var threadId = repliesElement.attr('data-thread-id');
       var replyId = messageElement.attr('data-id');
@@ -690,35 +686,35 @@
         }
       }, this));
     },
-    
+
     _onReplyAnswerClick: function (event) {
       var messageElement = $(event.target)
         .closest('.di-message');
       var repliesElement = $(event.target)
         .closest('.di-replies-container');
-      
+
       var areaId = repliesElement.attr('data-area-id');
       var threadId = repliesElement.attr('data-thread-id');
       var parentReplyId = $(messageElement).attr("data-parent-id") ? $(messageElement).attr("data-parent-id") : $(messageElement).attr("data-id");
-      
+
       this.element.closest('.discussion').discussion('replyMessageDialog', {
         areaId: areaId,
         threadId: threadId,
         parentReplyId: parentReplyId
       });
     },
-    
+
     _onReplyQuoteClick: function (event) {
        var replyElement = $(event.target)
         .closest('.di-reply');
        var repliesElement = $(event.target)
          .closest('.di-replies-container');
-       
+
       var areaId = repliesElement.attr('data-area-id');
       var threadId = repliesElement.attr('data-thread-id');
       var parentReplyId = $(replyElement).attr("data-parent-id") ? $(replyElement).attr("data-parent-id") : $(replyElement).attr("data-id");
       var quote = $('<pre>').append($('<blockquote>').html(replyElement.find('.mf-item-content-text').html())).html();
-      
+
       this.element.closest('.discussion').discussion('replyMessageDialog', {
         areaId: areaId,
         threadId: threadId,
@@ -726,75 +722,75 @@
         content: quote
       });
     },
-    
+
     _onBackClick: function (event) {
       this.element.closest('.discussion').discussion('reloadArea');
     },
-    
+
     _onRemoveClick: function (event) {
       this._confirmThreadRemoval($.proxy(function () {
         this._removeThread();
       }, this));
     },
-    
+
     _onMoreRepliesClickClick: function (event) {
       this._loadMoreReplies();
     }
-  
+
   });
-  
+
   $.widget("custom.discussionThreads", {
-    
+
     options: {
       maxThreadCount: 25
     },
-    
+
     _create : function() {
       this._firstResults = 0;
       this._threads = [];
-      
+
       this.element.on("click", ".di-page-link-load-more-messages", $.proxy(this._onLoadMoreClick, this));
       this.element.on("click", ".di-message-meta-topic", $.proxy(this._onMessageTopicClick, this));
     },
-    
+
     loadThreads: function (areaId) {
       this._areaId = areaId;
       this._reloadThreads();
     },
-    
+
     _loadMoreThreads: function () {
       this._firstResults += this.options.maxThreadCount;
       this._loadThreads(this._areaId);
     },
-    
+
     _reloadThreads: function () {
       this._firstResults = 0;
       this._threads = [];
       this._loadThreads(this._areaId);
     },
-    
+
     _loadThreads: function (areaId) {
       this.element
         .text('')
         .addClass('loading');
-      
+
       this.options.ioController.loadThreads(areaId, this._firstResults, this.options.maxThreadCount + 1, $.proxy(function (err, response) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
         } else {
           var threads = _.clone(response);
-          
+
           var hasMore = false;
           if (threads.length > this.options.maxThreadCount) {
             hasMore = true;
             threads.pop();
           }
-          
+
           this._threads = this._threads.concat(threads);
-          
-          renderDustTemplate('/discussion/discussion_items.dust', { 
-            threads: this._threads, 
-            hasMore: hasMore 
+
+          renderDustTemplate('/discussion/discussion_items.dust', {
+            threads: this._threads,
+            hasMore: hasMore
           }, $.proxy(function(text) {
             this.element
               .html(text)
@@ -803,53 +799,53 @@
         }
       }, this));
     },
-    
+
     _onLoadMoreClick: function (event) {
       this._loadMoreThreads();
     },
-    
+
     _onMessageTopicClick: function (event) {
       var areaId = $(event.target).closest('.di-message')
         .attr('data-area-id');
       var threadId = $(event.target).closest('.di-message')
         .attr('data-id');
-      
+
       this.element
         .closest('.discussion')
         .discussion('loadThread', areaId, threadId);
     }
   });
-  
+
   $.widget("custom.discussionNewAreaDialog", {
     _create : function() {
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _load: function (callback) {
       var data = {};
       renderDustTemplate('/discussion/discussion_create_area.dust', data, $.proxy(function (text) {
         this.element.html(text);
-        
+
         if (callback) {
           callback();
         }
       }, this));
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
         var description = $('#textDescription').val();
-        
+
         this.options.ioController.createArea(this.element.find('input[name="name"]').val(), description, $.proxy(function(err, result) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.newarea', err));
-          } else {        
+          } else {
             $('.discussion').discussion('reloadAreas');
           }
           this.element.remove();
@@ -862,23 +858,23 @@
       this.element.remove();
     }
   });
-  
+
   $.widget("custom.discussionEditAreaDialog", {
     _create : function() {
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
       this.element.on('change', "select[name='forumAreaId']", $.proxy(this._onAreaChange, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _load: function (callback) {
       this.options.ioController.loadAreas($.proxy(function(err, areas) {
         renderDustTemplate('/discussion/discussion_edit_area.dust', areas, $.proxy(function (text) {
           this.element.html(text);
-          
+
           if (this.options.areaId && this.options.areaId != 'all') {
             var areaSelect = this.element.find("select[name='forumAreaId']");
             areaSelect.val(this.options.areaId)
@@ -886,28 +882,28 @@
             var test = areaSelect.find(':selected').attr('data-description');
             this.element.find('textarea[name="description"]').val(test);
           }
-          
+
           if (callback) {
             callback();
           }
         }, this));
       }, this));
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
         var areaId = this.element.find("select[name='forumAreaId']").val();
         var name = this.element.find('input[name="name"]').val();
         var description = $('#textDescription').val();
-        
+
         this.options.ioController.updateArea(areaId, name, description, $.proxy(function(err, result) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.editarea', err));
           } else {
             $('.discussion').discussion('reloadAreas');
           }
-          
+
           this.element.remove();
         }, this));
       }
@@ -917,38 +913,38 @@
       event.preventDefault();
       this.element.remove();
     },
-    
+
     _onAreaChange: function (event) {
       this.element.find('input[name="name"]').val($(event.target).find(':selected').text());
     }
   });
-  
+
   $.widget("custom.discussionDeleteAreaDialog", {
     _create : function() {
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _load: function (callback) {
       this.options.ioController.loadAreas($.proxy(function(err, areas) {
         renderDustTemplate('/discussion/discussion_delete_area.dust', areas, $.proxy(function (text) {
           this.element.html(text);
-          
+
           if (this.options.areaId && this.options.areaId != 'all') {
             this.element.find("select[name='forumAreaId']")
               .val(this.options.areaId)
           }
-          
+
           if (callback) {
             callback();
           }
         }, this));
       }, this));
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
@@ -959,7 +955,7 @@
           } else {
             $('.discussion').discussion('reloadAreas');
           }
-          
+
           this.element.remove();
         }, this));
       }
@@ -969,14 +965,14 @@
       event.preventDefault();
       this.element.remove();
     },
-    
+
     _onAreaChange: function (event) {
       this.element.find('input[name="name"]').val($(event.target).find(':selected').text());
     }
   });
-  
+
   $.widget("custom.discussionAbstractMessageDialog", {
-    
+
     options: {
       ckeditor: {
         toolbar: [
@@ -995,25 +991,25 @@
         }
       }
     },
-    
+
     _create: function () {
       var extraPlugins = [];
-      
+
       $.each($.extend(this.options.ckeditor.extraPlugins, {}, true), $.proxy(function (plugin, url) {
         CKEDITOR.plugins.addExternal(plugin, url);
         extraPlugins.push(plugin);
       }, this));
-      
+
       this.element.on('dialogReady', $.proxy(this.footerDialogReady, this));
       this.element.on('dialogClose', $.proxy(this.footerDialogClose, this));
-      
+
       this.options.ckeditor.extraPlugins = extraPlugins.join(',');
     },
-    
+
     _destroy: function () {
       this.destroyEditor();
     },
-    
+
     destroyEditor: function (discardDraft) {
       try {
         if (this._messageEditor) {
@@ -1026,34 +1022,34 @@
       } catch (e) {
       }
     },
-    
+
     footerDialogReady: function() {
       $(document.body).css({
         paddingBottom: this.element.height() + 50 + 'px'
       }).addClass('footerDialogOpen');
     },
-      
+
     footerDialogClose: function() {
       $(document.body).removeClass('footerDialogOpen').removeAttr('style');
     }
   });
-  
+
   $.widget("custom.discussionNewMessageDialog", $.custom.discussionAbstractMessageDialog, {
-    
+
     _create : function() {
       this._superApply( arguments );
-      
+
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
 
     _load: function (callback) {
       var tasks = [this._createAreasLoad()];
-      
+
       async.parallel(tasks, $.proxy(function (err, results) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1062,21 +1058,21 @@
               areas: results[0],
               lockStickyPermission: this.options.lockStickyPermission
           };
-          
+
           renderDustTemplate('/discussion/discussion_create_message.dust', parameters, $.proxy(function (text) {
             this.element.html(text);
-            
+
             if (this.options.areaId) {
               this.element.find('*[name="forumAreaId"]').val(this.options.areaId);
             }
-            
+
             this._messageEditor = CKEDITOR.replace(this.element.find('textarea[name="message"]')[0], $.extend(this.options.ckeditor, {
               draftKey: 'discussion-new-message',
               on: {
                 instanceReady: $.proxy(this._onCKEditorReady, this)
               }
             }));
-            
+
             if (callback) {
               callback();
             }
@@ -1084,29 +1080,29 @@
         }
       }, this));
     },
-    
+
     _createAreasLoad: function () {
       return $.proxy(function (callback) {
         this.options.ioController.loadAreas(callback);
       }, this);
     },
-    
+
     _onCKEditorReady: function (event) {
-      this.element.find('input[name="send"]').removeAttr('disabled'); 
+      this.element.find('input[name="send"]').removeAttr('disabled');
       this.element.trigger('dialogReady');
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
         var forumAreaId = this.element.find('*[name="forumAreaId"]').val();
-        
+
         var title = this.element.find('*[name="title"]').val();
         if (!title && !title.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.notitle'));
           return;
         }
-        
+
         var message = this._messageEditor.getData();
         if (!message || !message.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.nomessage'));
@@ -1115,12 +1111,12 @@
 
         var sticky = false;
         var locked = false;
-        
+
         if (this.options.lockStickyPermission) {
           sticky = this.element.find("input[name='sticky']").prop("checked") ? true : false;
           locked = this.element.find("input[name='locked']").prop("checked") ? true : false;
         }
-        
+
         this.options.ioController.createThread(forumAreaId, title, message, sticky, locked, $.proxy(function(err, result) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1141,43 +1137,43 @@
       this.element.remove();
     }
   });
-  
+
   $.widget("custom.discussionReplyMessageDialog", $.custom.discussionAbstractMessageDialog, {
-    
+
     _create : function() {
       this._superApply( arguments );
-      
+
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _destroy: function () {
       try {
         this._messageEditor.destroy();
       } catch (e) {
-        
+
       }
     },
-    
+
     _createThreadLoad: function (areaId, threadId) {
       return $.proxy(function (callback) {
         this.options.ioController.loadThread(areaId, threadId, callback);
       }, this);
     },
-    
+
     _createAreaLoad: function (areaId) {
       return $.proxy(function (callback) {
         this.options.ioController.loadArea(areaId, callback);
       }, this);
     },
-    
+
     _load: function (callback) {
       var tasks = [this._createThreadLoad(this.options.areaId, this.options.threadId), this._createAreaLoad(this.options.areaId)];
-      
+
       async.parallel(tasks, $.proxy(function (err, results) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1186,20 +1182,20 @@
           var reply = $.extend(results[0], {
             areaName: area.name
           });
-          
+
           renderDustTemplate('/discussion/discussion_create_reply.dust', reply, $.proxy(function (text) {
             this.element.html(text);
             if (this.options.content) {
               this.element.find('*[name="message"]').val(this.options.content);
             }
-            
+
             this._messageEditor = CKEDITOR.replace(this.element.find('textarea[name="message"]')[0], $.extend(this.options.ckeditor, {
               draftKey: 'discussion-reply-message-' + this.options.areaId + '-' + this.options.threadId,
               on: {
                 instanceReady: $.proxy(this._onCKEditorReady, this)
               }
             }));
-            
+
             if (callback) {
               callback();
             }
@@ -1207,12 +1203,12 @@
         }
       }, this));
     },
-    
+
     _onCKEditorReady: function (event) {
       this.element.find('input[name="send"]').removeAttr('disabled');
       this.element.trigger('dialogReady');
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
@@ -1221,7 +1217,7 @@
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.nomessage'));
           return;
         }
-        
+
         this.options.ioController.createThreadReply(this.options.areaId, this.options.threadId, this.options.parentReplyId, message, $.proxy(function(err, result) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1242,27 +1238,27 @@
       this.element.remove();
     }
   });
-  
+
   $.widget("custom.discussionEditMessageDialog", $.custom.discussionAbstractMessageDialog, {
-    
+
     _create : function() {
       this._superApply( arguments );
-      
+
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _destroy: function () {
       try {
         this._messageEditor.destroy();
       } catch (e) {
       }
     },
-    
+
     _load: function (callback) {
       this.options.ioController.loadThread(this.options.areaId, this.options.threadId, $.proxy(function (err, thread) {
         if (err) {
@@ -1272,17 +1268,17 @@
               thread: thread,
               lockStickyPermission: this.options.lockStickyPermission
           };
-          
+
           renderDustTemplate('/discussion/discussion_edit_message.dust', parameters, $.proxy(function (text) {
             this.element.html(text);
-            
+
             this._messageEditor = CKEDITOR.replace(this.element.find('textarea[name="message"]')[0], $.extend(this.options.ckeditor, {
               draftKey: 'discussion-edit-message-' + this.options.areaId + '-' + this.options.threadId,
               on: {
                 instanceReady: $.proxy(this._onCKEditorReady, this)
               }
             }));
-            
+
             if (callback) {
               callback();
             }
@@ -1290,40 +1286,40 @@
         }
       }, this));
     },
-    
+
     _onCKEditorReady: function (event) {
       this.element.find('input[name="send"]').removeAttr('disabled');
       this.element.trigger('dialogReady');
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
         var title = this.element.find('*[name="title"]').val();
-        
+
         if (!title && !title.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.notitle'));
           return;
         }
-        
+
         var message = this._messageEditor.getData();
         if (!message || !message.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.nomessage'));
           return;
         }
-        
+
         this.options.ioController.loadThread(this.options.areaId, this.options.threadId, $.proxy(function(err, thread) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', err);
           } else {
             var sticky = thread.sticky;
             var locked = thread.locked;
-            
+
             if (this.options.lockStickyPermission) {
               sticky = this.element.find("input[name='sticky']").prop("checked") ? true : false;
               locked = this.element.find("input[name='locked']").prop("checked") ? true : false;
             }
-          
+
             this.options.ioController.updateThread(this.options.areaId, this.options.threadId, title, message, sticky, locked, $.proxy(function(err, result) {
               if (err) {
                 $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1345,27 +1341,27 @@
       this.element.remove();
     }
   });
-  
+
   $.widget("custom.discussionEditReplyDialog", $.custom.discussionAbstractMessageDialog, {
-    
+
     _create : function() {
       this._superApply( arguments );
-      
+
       this.element.on('click', "input[name='send']", $.proxy(this._onSendClick, this));
       this.element.on('click', "input[name='cancel']", $.proxy(this._onCancelClick, this));
-      
+
       this._load($.proxy(function () {
-        
+
       }, this));
     },
-    
+
     _destroy: function () {
       try {
         this._messageEditor.destroy();
       } catch (e) {
       }
     },
-    
+
     _load: function (callback) {
       this.options.ioController.loadThreadReply(this.options.areaId, this.options.threadId, this.options.replyId, $.proxy(function (err, reply) {
         if (err) {
@@ -1379,7 +1375,7 @@
                 instanceReady: $.proxy(this._onCKEditorReady, this)
               }
             }));
-            
+
             if (callback) {
               callback();
             }
@@ -1387,11 +1383,11 @@
         }
       }, this));
     },
-    
+
     _onCKEditorReady: function (event) {
-      this.element.find('input[name="send"]').removeAttr('disabled'); 
+      this.element.find('input[name="send"]').removeAttr('disabled');
     },
-    
+
     _onSendClick: function (event) {
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
@@ -1400,7 +1396,7 @@
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.discussion.errormessage.nomessage'));
           return;
         }
-        
+
         this.options.ioController.updateThreadReply(this.options.areaId, this.options.threadId, this.options.replyId, message, $.proxy(function(err, result) {
           if (err) {
             $('.notification-queue').notificationQueue('notification', 'error', err);


### PR DESCRIPTION
A very simple fix where I simply allow the html to be overriden with the `.html` as it seems that the scrolling would not be affected when doing so. However it is to consider that the optimal answer is to use diffing techiques or manual updates but it's not quite applicable in the context of dust, this fix however instead does less by not allowing the previous html to be removed.

closes #2176 