### PR TITLE
Removing display none from communicator settings when a message is open

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
@@ -1,24 +1,24 @@
 (function() {
   'use strict';
-  
-  
-  
+
+
+
   var CommunicatorFolderController = function (options) {
     this.options = options;
   };
-  
-  
-  
+
+
+
   $.extend(CommunicatorFolderController.prototype, {
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       throw Error("loadItems not implemented");
     },
-    
+
     loadThread: function (threadId, firstResult, maxResults, callback) {
       throw Error("loadThread not implemented");
     },
-    
+
     removeItems: function (ids, callback) {
       throw Error("removeItem not implemented");
     },
@@ -26,26 +26,26 @@
     readThreadMessageCount: function (communicatorMessageId, callback) {
       throw Error("readThreadMessageCount not implemented");
     },
-    
+
     markAsRead: function (threadId, callback) {
       callback();
     },
-    
+
     markAsUnread: function (threadId, callback) {
       callback();
     },
 
     superApply: function (method) {
-      CommunicatorFolder.prototype[method].call(this, Array.prototype.slice.call(arguments, 1));  
+      CommunicatorFolder.prototype[method].call(this, Array.prototype.slice.call(arguments, 1));
     }
-    
+
   });
-  
+
   var CommunicatorInboxFolderController = function (options) {
     this._super = CommunicatorFolderController.prototype;
-    CommunicatorFolderController.call(this, arguments); 
+    CommunicatorFolderController.call(this, arguments);
   };
-  
+
   $.extend(CommunicatorInboxFolderController.prototype, CommunicatorFolderController.prototype, {
     removeItems: function (ids, callback) {
       var calls = $.map(ids, function (id) {
@@ -55,16 +55,16 @@
             .callback(callback);
         };
       })
-      
+
       async.series(calls, callback);
     },
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       var params = {
         firstResult: firstResult,
         maxResults: maxResults
       };
-      
+
       mApi().communicator.items
         .read(params)
         .callback(mainCallback);
@@ -80,7 +80,7 @@
             : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
           message.senderHasPicture = message.sender.hasImage;
           message.caption = $('<div>').html(message.caption).text();
-          
+
           messageCallback();
         }, this))
         .callback(callback);
@@ -91,18 +91,18 @@
         .callback(callback);
     },
     markAsRead: function (threadId, callback) {
-      mApi().communicator.items.markasread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasread.create(threadId).callback(callback);
     },
     markAsUnread: function (threadId, callback) {
-      mApi().communicator.items.markasunread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasunread.create(threadId).callback(callback);
     }
   });
-  
+
   var CommunicatorUnreadFolderController = function (options) {
     this._super = CommunicatorFolderController.prototype;
-    CommunicatorFolderController.call(this, arguments); 
+    CommunicatorFolderController.call(this, arguments);
   };
-  
+
   $.extend(CommunicatorUnreadFolderController.prototype, CommunicatorFolderController.prototype, {
     removeItems: function (ids, callback) {
       var calls = $.map(ids, function (id) {
@@ -112,17 +112,17 @@
             .callback(callback);
         };
       })
-      
+
       async.series(calls, callback);
     },
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       var params = {
         onlyUnread: true,
         firstResult: firstResult,
         maxResults: maxResults
       };
-      
+
       mApi().communicator.items
         .read(params)
         .callback(mainCallback);
@@ -138,7 +138,7 @@
             : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
           message.senderHasPicture = message.sender.hasImage;
           message.caption = $('<div>').html(message.caption).text();
-          
+
           messageCallback();
         }, this))
         .callback(callback);
@@ -149,19 +149,19 @@
         .callback(callback);
     },
     markAsRead: function (threadId, callback) {
-      mApi().communicator.items.markasread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasread.create(threadId).callback(callback);
     },
     markAsUnread: function (threadId, callback) {
-      mApi().communicator.items.markasunread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasunread.create(threadId).callback(callback);
     }
   });
-  
+
   var CommunicatorLabelFolderController = function (labelId, options) {
     this._super = CommunicatorFolderController.prototype;
     this._labelId = labelId;
-    CommunicatorFolderController.call(this, arguments); 
+    CommunicatorFolderController.call(this, arguments);
   };
-  
+
   $.extend(CommunicatorLabelFolderController.prototype, CommunicatorFolderController.prototype, {
     removeItems: function (ids, callback) {
       var calls = $.map(ids, function (id) {
@@ -171,17 +171,17 @@
             .callback(callback);
         };
       })
-      
+
       async.series(calls, callback);
     },
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       var params = {
         labelId: this._labelId,
         firstResult: firstResult,
         maxResults: maxResults
       };
-      
+
       mApi().communicator.items
         .read(params)
         .callback(mainCallback);
@@ -197,7 +197,7 @@
             : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
           message.senderHasPicture = message.sender.hasImage;
           message.caption = $('<div>').html(message.caption).text();
-          
+
           messageCallback();
         }, this))
         .callback(callback);
@@ -208,18 +208,18 @@
         .callback(callback);
     },
     markAsRead: function (threadId, callback) {
-      mApi().communicator.items.markasread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasread.create(threadId).callback(callback);
     },
     markAsUnread: function (threadId, callback) {
-      mApi().communicator.items.markasunread.create(threadId).callback(callback);    
+      mApi().communicator.items.markasunread.create(threadId).callback(callback);
     }
   });
-  
+
   var CommunicatorSentFolderController = function (options) {
     this._super = CommunicatorFolderController.prototype;
-    CommunicatorFolderController.call(this, arguments); 
+    CommunicatorFolderController.call(this, arguments);
   };
-  
+
   $.extend(CommunicatorSentFolderController.prototype, CommunicatorFolderController.prototype, {
 
     removeItems: function (ids, callback) {
@@ -230,10 +230,10 @@
             .callback(callback);
         };
       })
-      
+
       async.series(calls, callback);
     },
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       mApi().communicator.sentitems
         .read({
@@ -254,32 +254,32 @@
             : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
           message.senderHasPicture = message.sender.hasImage;
           message.caption = $('<div>').html(message.caption).text();
-          
+
           messageCallback();
         }, this))
         .callback(callback);
     },
-    
+
     readThreadMessageCount: function (communicatorMessageId, callback) {
       mApi().communicator.messages.messagecount
         .read(communicatorMessageId)
         .callback(callback);
     },
-    
+
     markAsRead: function (threadId, callback) {
       callback();
     },
     markAsUnread: function (threadId, callback) {
       callback();
     }
-    
+
   });
 
   var CommunicatorTrashFolderController = function (options) {
     this._super = CommunicatorFolderController.prototype;
-    CommunicatorFolderController.call(this, arguments); 
+    CommunicatorFolderController.call(this, arguments);
   };
-  
+
   $.extend(CommunicatorTrashFolderController.prototype, CommunicatorFolderController.prototype, {
     removeItems: function (ids, callback) {
       var calls = $.map(ids, function (id) {
@@ -289,21 +289,21 @@
             .callback(callback);
         };
       })
-      
+
       async.series(calls, callback);
     },
-    
+
     loadItems: function (firstResult, maxResults, mainCallback) {
       var params = {
         firstResult: firstResult,
         maxResults: maxResults
       };
-      
+
       mApi().communicator.trash
         .read(params)
         .callback(mainCallback);
     },
-  
+
     loadThread: function (threadId, firstResult, maxResults, callback) {
       var isStudent = $('.communicator').attr('data-student') == 'true';
       mApi().communicator.trash
@@ -315,30 +315,30 @@
             : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
           message.senderHasPicture = message.sender.hasImage;
           message.caption = $('<div>').html(message.caption).text();
-          
+
           messageCallback();
         }, this))
         .callback(callback);
     },
-    
+
     readThreadMessageCount: function (communicatorMessageId, callback) {
       mApi().communicator.trash.messagecount
         .read(communicatorMessageId)
         .callback(callback);
     },
-    
+
     markAsRead: function (threadId, callback) {
-      mApi().communicator.trash.markasread.create(threadId).callback(callback);    
+      mApi().communicator.trash.markasread.create(threadId).callback(callback);
     },
     markAsUnread: function (threadId, callback) {
-      mApi().communicator.trash.markasunread.create(threadId).callback(callback);    
+      mApi().communicator.trash.markasunread.create(threadId).callback(callback);
     }
   });
-  
+
   var CommunicatorSettingsController = function () {
    // not much to control, but maybe when there are more settings than signatures?
   };
-  
+
   $.widget("custom.communicatorMessages", {
     _create : function() {
       this._firstItem = 0;
@@ -348,25 +348,25 @@
       $('.mf-controls-container').on('click', '.cm-delete-thread', $.proxy(this._onDeleteClick, this));
       $('.mf-controls-container').on('click', '.icon-message-unread', $.proxy(this._onMarkUnreadClick, this));
       $('.mf-controls-container').on('click', '.icon-message-read', $.proxy(this._onMarkReadClick, this));
-      $('.mf-controls-container').on('click', '.cm-add-label-menu', $.proxy(this._onAddLabelMenuClick, this));         
+      $('.mf-controls-container').on('click', '.cm-add-label-menu', $.proxy(this._onAddLabelMenuClick, this));
       $('.mf-controls-container').on('click', '#newLabelSubmit', $.proxy(this._onCreateLabelClick, this));
-      
+
       this.element.on('change', 'input[name="messageSelect"]', $.proxy(this._onThreadSelectionChange, this));
       this.element.on('click', '.cm-page-link-load-more:not(.disabled)', $.proxy(this._onMoreClick, this));
       this.element.on('click', '.cm-message-header-container', $.proxy(this._onMessageHeaderClick, this));
       $(document).on("Communicator:newmessagereceived", $.proxy(this._onNewMessageReceived, this));
       $(document).on('click', $.proxy(this._onDocumentClicked, this));
     },
-    
+
     loadFolder: function (id) {
       this._folderId = id;
       this._reload();
     },
-    
+
     folderId: function () {
       return this._folderId;
     },
-    
+
     _getSelectedThreads: function () {
       return $.map(this.element.find('input[name="messageSelect"]:checked'), function (input) {
         var message = $(input).closest('.cm-message');
@@ -378,40 +378,40 @@
         };
       });
     },
-    
+
     _loadMore: function (callback) {
       this._firstItem += this.options.maxMessageCount;
       this._load(callback);
     },
-    
+
     _reload: function (callback) {
       this._firstItem = 0;
       this._items = [];
       this._load(callback);
     },
-    
+
     _load: function (callback) {
       this.element
         .html('')
         .addClass('loading');
-      
-      var folderController = this.element.closest('.communicator') 
+
+      var folderController = this.element.closest('.communicator')
         .communicator('folderController', this._folderId);
-      
+
       folderController.loadItems(this._firstItem, this.options.maxMessageCount + 1, $.proxy(function (err, items) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
         } else {
           var communicator = $(".communicator").communicator("instance");
           var hasMore = false;
-          
+
           $.each(items, function (ind, item) {
             if (item.labels) {
               for (var i = 0, l = item.labels.length; i < l; i++) {
                 item.labels[i]["hexColor"] = communicator.colorIntToHex(item.labels[i].labelColor);
               }
             }
-            
+
             if (item.recipients) {
               $.each(item.recipients, function (ind, recipient) {
                 if (recipient.userId && recipient.userId == MUIKKU_LOGGED_USER_ID) {
@@ -420,19 +420,19 @@
               });
             }
           });
-          
+
           if (items.length > this.options.maxMessageCount) {
             hasMore = true;
             items.pop();
-          } 
-          
+          }
+
           this._items = this._items.concat(items);
           var data = $.map(this._items, $.proxy(function (item) {
             return $.extend(item, {
               folderId: this._folderId
             });
           }, this));
-          
+
           renderDustTemplate('communicator/communicator_items.dust', {
             items: data, sent: this._folderId == 'sent',
             isStudent: $('.communicator').attr('data-student') == 'true' ? 1 : ''
@@ -440,20 +440,20 @@
             this.element
               .html(text)
               .removeClass('loading');
-            
+
             if (hasMore) {
               this.element.find('.cm-page-link-load-more').removeClass('disabled');
             } else {
               this.element.find('.cm-page-link-load-more').addClass('disabled');
             }
-            
+
             if (callback) {
               callback();
             }
           }, this));
         }
       }, this));
-    },  
+    },
     _onNewMessageReceived: function () {
       if (this._folderId == "inbox") {
         this._reload();
@@ -463,7 +463,7 @@
     _onDocumentClicked: function (event) {
       var labelMenu = $(event.target).closest('.cm-label-menu');
       var labelButton = $(event.target).closest('.cm-add-label-container');
-      
+
       if (labelMenu.length || labelButton.length) {
         return;
       } else {
@@ -471,28 +471,28 @@
         labelMenu.toggle(false);
       }
     },
-    
+
     _onMoreClick: function (event) {
       this._loadMore($.proxy(function () {
         $('.cm-page-link-load-more')[0].scrollIntoView();
       }, this));
     },
-    
+
     _onDeleteClick: function (event) {
       if ($(event.target).closest(".mf-tool-container").hasClass("disabled"))
         return;
-      
+
       var selectedThreads = this._getSelectedThreads();
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('deleteThreads', selectedThreads);
     },
-    
+
     _onMarkUnreadClick: function (event) {
       if ($(event.target).closest(".mf-tool-container").hasClass("disabled"))
         return;
-      
+
       var selectedThreads = this._getSelectedThreads();
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('markUnreadThreads', selectedThreads, $.proxy(function () {
           $.each(selectedThreads, function (idx, thread) {
             thread.element.addClass("unread");
@@ -500,18 +500,18 @@
           $('.cm-messages-container').communicatorMessages('updateThreadSelection');
         }, this));
     },
-    
+
     _onMarkReadClick: function (event) {
       if ($(event.target).closest(".mf-tool-container").hasClass("disabled"))
         return;
-      
+
       var selectedThreads = this._getSelectedThreads();
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('markReadThreads', selectedThreads, $.proxy(function () {
           $.each(selectedThreads, function (idx, thread) {
             thread.element.removeClass("unread");
           });
-          
+
           $('.cm-messages-container').communicatorMessages('updateThreadSelection');
         }, this));
     },
@@ -519,51 +519,51 @@
     _onMessageHeaderClick: function (event) {
       var threadId = $(event.target).closest('.cm-message')
         .attr('data-thread-id');
-      
-      this.element.closest('.communicator') 
+
+      this.element.closest('.communicator')
         .communicator('loadThread', threadId);
     },
 
     _onThreadSelectionChange: function (event) {
       this.updateThreadSelection();
     },
-    
+
     updateThreadSelection: function () {
       var selectedThreads = this._getSelectedThreads();
       var communicatorElement = this.element.closest(".communicator");
       var hasUnread = false;
       var markMessages = communicatorElement.find(".cm-mark-thread");
-      
+
       for(var i = 0; i < selectedThreads.length; i++) {
         if (selectedThreads[i].unread == true) {
-          hasUnread = true;          
-        }        
+          hasUnread = true;
+        }
       }
-      
+
       if (selectedThreads.length === 0) {
         communicatorElement.find(".cm-delete-thread").closest(".mf-tool-container").addClass("disabled");
         markMessages.closest(".mf-tool-container").addClass("disabled");
         markMessages.attr("title", getLocaleText("plugin.communicator.tool.title.unread"));
         markMessages.removeClass("icon-message-read");
-        markMessages.addClass("icon-message-unread"); 
+        markMessages.addClass("icon-message-unread");
       } else {
         communicatorElement.find(".cm-delete-thread").closest(".mf-tool-container").removeClass("disabled");
         communicatorElement.find(".cm-mark-thread").closest(".mf-tool-container").removeClass("disabled");
-        
+
         if(hasUnread == true) {
           markMessages.attr("title", getLocaleText("plugin.communicator.tool.title.read"));
           markMessages.removeClass("icon-message-unread");
           markMessages.addClass("icon-message-read");
         } else {
-          markMessages.attr("title", getLocaleText("plugin.communicator.tool.title.unread"));          
+          markMessages.attr("title", getLocaleText("plugin.communicator.tool.title.unread"));
           markMessages.removeClass("icon-message-read");
-          markMessages.addClass("icon-message-unread");          
+          markMessages.addClass("icon-message-unread");
         }
       }
     },
-    
+
     _onAddLabelMenuClick: function (event) {
-      var labelObjs = $('.cm-categories').find('.mf-label');      
+      var labelObjs = $('.cm-categories').find('.mf-label');
       var labels = [];
       var messagesLabels = [];
       var labelOccurrances = {};
@@ -574,46 +574,46 @@
         var labelId = $(label).attr('data-label-id')
         if( messagesLabels.indexOf(labelId) == -1){
           messagesLabels.push(labelId);
-          labelOccurrances[labelId] = 1; 
-        }else{  
+          labelOccurrances[labelId] = 1;
+        }else{
           labelOccurrances[labelId]++;
         }
       });
-      
+
       $.each(labelObjs, function(key, value){
         var label = {};
         var lName = $(value).attr('data-folder-name');
         var lStyle = $(value).find('.cm-label-name').attr('style');
         var lId = $(value).attr('data-label-id');
-        var lSelected = messagesLabels.indexOf(lId) == -1 ? false : true; 
+        var lSelected = messagesLabels.indexOf(lId) == -1 ? false : true;
         var lAllSelected =  labelOccurrances[lId] == checkedMessages.length ? true : false;
         labels.push({name: lName, id: lId, selected: lSelected, inAll: lAllSelected, style: lStyle });
-        
+
       });
 
       renderDustTemplate('communicator/communicator_label_link.dust', labels, $.proxy(function (text) {
         $(".mf-tool-label-container").html(text);
-        
+
         $('#communicatorNewlabelField').on('input', $.proxy(this._onLabelFilterInputChange, this));
       }, this));
-      
+
       $(event.target).closest('.mf-tool-container').find('.cm-label-menu').toggle();
     },
-    
+
     _onLabelFilterInputChange: function (event) {
       if (this._typingTimer) {
         clearTimeout(this._typingTimer);
       }
-      
+
       this._typingTimer = setTimeout($.proxy(function() {
         this._onLabelFilterInputChangeTimeout(event);
       }, this), 500);
     },
-    
+
     _onLabelFilterInputChangeTimeout: function (event) {
       var filter = $(event.target).val().toLowerCase();
       $('.mf-label-link').show();
-    
+
       if (filter) {
         $('.mf-label-link span').each(function (idx, element) {
           var spanner = $(element);
@@ -624,21 +624,21 @@
       }
     },
 
-    _onAddLabelToMessagesClick: function (event) {  
+    _onAddLabelToMessagesClick: function (event) {
       var clickedLabel = $(event.target).closest('.mf-label-link');
       var lId = $(clickedLabel).attr('data-label-id');
       var isSelectedInAll = $(event.target).closest('.mf-label-link').hasClass('selected-in-all') ? true : false;
       var addLabelChanges = [];
       var removeLabelChanges = [];
       var checkedMessageThreads = $('.cm-messages-pages').find('input[name="messageSelect"]:checked');
-       
+
       $.each(checkedMessageThreads, function(key, value) {
         var inputElement = $(value);
         var labelElement = inputElement.closest('.cm-message').find('.cm-message-label[data-label-id=' + lId + ']');
 
         var messageId = inputElement.attr('value');
-        var messageLabelId = labelElement.attr('data-message-label-id');        
-        
+        var messageLabelId = labelElement.attr('data-message-label-id');
+
         if (labelElement.length) {
           if(isSelectedInAll == true){
             mApi().communicator.messages.labels.del(messageId, messageLabelId).callback($.proxy(function (err, results) {
@@ -648,7 +648,7 @@
                 var communicator = $(".communicator").communicator("instance");
                 var messageThreadElement = $('.cm-message[data-thread-id="' + messageId + '"]');
                 var labelElement = messageThreadElement.find('.cm-message-label[data-label-id=' + lId + ']');
-                              
+
                 labelElement.remove();
               }
             }, this));
@@ -660,9 +660,9 @@
             } else {
               var communicator = $(".communicator").communicator("instance");
               var messageThreadElement = $('.cm-message[data-thread-id="' + label.messageThreadId + '"]');
-              
+
               label["hexColor"] = communicator.colorIntToHex(label.labelColor);
-              
+
               renderDustTemplate('communicator/communicator_item_label.dust', label, $.proxy(function (text) {
                 messageThreadElement.find('.cm-message-header-content-secondary').append($(text));
               }, this));
@@ -670,25 +670,25 @@
           }, this));
         }
       });
-      
+
       if(isSelectedInAll === true){
         $(clickedLabel).removeClass('selected-in-all');
       }else{
-        $(clickedLabel).removeClass('selected').addClass('selected-in-all');    
+        $(clickedLabel).removeClass('selected').addClass('selected-in-all');
       }
 
-      
+
     },
-    
+
     _onCreateLabelClick: function (event) {
-      var labelObjs = $('.cm-categories').find('.mf-label');      
-      
+      var labelObjs = $('.cm-categories').find('.mf-label');
+
       var labels = [];
-      
+
       $.each(labelObjs, function(key, value){
         var name= $(value).attr('data-folder-name');
         labels.push(name);
-      });      
+      });
       var communicator = $('.communicator').communicator("instance");
       var name =  $('#communicatorNewlabelField').val();
       var color = Math.round(Math.random() * 16777215);
@@ -702,10 +702,10 @@
       } else {
         $('.notification-queue').notificationQueue('notification', 'error', getLocaleText("plugin.communicator.label.create.error.empty"));
       }
-    }    
-    
+    }
+
   });
-  
+
   $.widget("custom.messageTools", {
     options : {
       value : 'none'
@@ -713,11 +713,11 @@
     _create : function(){
       this.toolset(this.options.value);
     },
-    toolset: function(value) {   
+    toolset: function(value) {
       var toolTemplate = null;
       if ( value === undefined ) {
         return this.options.value;
-      }      
+      }
       this.options.value = value;
       switch (this.options.value) {
         case 'message':
@@ -731,28 +731,28 @@
         case 'settings':
           toolTemplate = 'communicator/communicator_tools_settings.dust';
           this._loadTools(toolTemplate);
-          break;          
-      }      
+          break;
+      }
     },
-    
+
     _loadTools: function(toolSet) {
       renderDustTemplate(toolSet, {}, $.proxy(function (text) {
         this.element.html(text);
       }, this));
     }
-  }); 
-  
+  });
+
 
   $.widget("custom.communicator", {
     options: {
       defaultFolderId: 'inbox'
     },
     _create : function() {
-      
-    $('.mf-view-settings-function-container').on('click', '.cm-settings-icon', $.proxy(this._onSettingsClick, this));    
 
-      
-   
+    $('.mf-view-settings-function-container').on('click', '.cm-settings-icon', $.proxy(this._onSettingsClick, this));
+
+
+
       this.loadLabels($.proxy(
         function (err, labels) {
           this._folderControllers = {
@@ -762,7 +762,7 @@
             'trash': new CommunicatorTrashFolderController(),
             'settings': new CommunicatorSettingsController(),
           };
-          
+
           if (err) {
           } else {
             var addLabelControlsCalls = $.map(labels, $.proxy(function(label) {
@@ -770,15 +770,15 @@
                 this.addLabelControl(label, callback);
               }, this)
             }, this));
-  
+
             async.series(addLabelControlsCalls, $.proxy(function() {
               this._sortLabels();
             }, this));
           }
-          
+
           var folderId;
           var threadId;
-           
+
           if (window.location.hash.length > 1) {
             var hashParts = window.location.hash.substring(1).split('/');
             if (hashParts.length > 0) {
@@ -791,95 +791,96 @@
           }
 
           folderId = this._folderControllers[folderId] ? folderId : this.options.defaultFolderId;
-          
-          this.element.on('click', '.mf-label-edit', $.proxy(this._onLabelEditClick, this));    
-                 
+
+          this.element.on('click', '.mf-label-edit', $.proxy(this._onLabelEditClick, this));
+
           this.element.find('.cm-messages-container').communicatorMessages({
             maxMessageCount: this.options.maxMessageCount,
             folderId: folderId
           });
           $('.mf-controls-container').messageTools();
-          this.element.on('click', '.mf-label-functions', $.proxy(this._onLabelMenuOpenClick, this));    
-          this.element.on('click', '.mf-label-function-edit', $.proxy(this._onLabelEditClick, this));  
-          this.element.on('click', '.mf-label-function-delete', $.proxy(this._onLabelDeleteClick, this));               
-          this.element.find('.cm-thread-container').communicatorThread();       
+          this.element.on('click', '.mf-label-functions', $.proxy(this._onLabelMenuOpenClick, this));
+          this.element.on('click', '.mf-label-function-edit', $.proxy(this._onLabelEditClick, this));
+          this.element.on('click', '.mf-label-function-delete', $.proxy(this._onLabelDeleteClick, this));
+          this.element.find('.cm-thread-container').communicatorThread();
           this.element.on('click', '.cm-setting-create-signature-link', $.proxy(this._onNewSignatureLinkClick, this));
-          this.element.on('click', '.cm-setting-edit-signature-link', $.proxy(this._onEditSignatureLinkClick, this));          
+          this.element.on('click', '.cm-setting-edit-signature-link', $.proxy(this._onEditSignatureLinkClick, this));
           this.element.on('click', '.cm-setting-remove-signature-link', $.proxy(this._removeSignature, this));
           this.element.on('click', '.cm-new-message-button', $.proxy(this._onNewMessageButtonClick, this));
-          
+
           this.element.on('click', '.cm-folder', $.proxy(this._onCommunicatorFolderClick, this));
-          
+
           if (threadId) {
-            this.loadThread(threadId);  
+            this.loadThread(threadId);
           } else {
-            this.loadFolder(folderId);       
+            this.loadFolder(folderId);
           }
         }
       , this));
-      
+
     },
-    _onSettingsClick: function() { 
-      this.loadSignatures($.proxy(function(err, signatures) {        
+    _onSettingsClick: function() {
+      this.loadSignatures($.proxy(function(err, signatures) {
         if(err){
-          $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.signatures.loading'));          
-        }else{          
+          $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.signatures.loading'));
+        }else{
           renderDustTemplate('communicator/communicator_settings.dust', {signatures : signatures}, $.proxy(function(text) {
-            $(".cm-messages-container").html(text);
-            $('.mf-controls-container').messageTools( 'toolset', 'settings');   
+            $(".cm-thread-container").hide();
+            $(".cm-messages-container").html(text).show();
+            $('.mf-controls-container').messageTools( 'toolset', 'settings');
             this._updateHash('settings', null);
           }, this));
         }
-      }, this)); 
+      }, this));
     },
 
     loadFolder: function (id) {
-      
+
       if(id == 'settings'){
         this._onSettingsClick();
-        this._updateHash(id, null);        
+        this._updateHash(id, null);
       }else{
-      
+
         this._updateHash(id, null);
         this._updateSelected(id);
-        
+
         this.element.find('.cm-thread-container').hide();
-        $('.mf-controls-container').messageTools( 'toolset', 'thread');       
+        $('.mf-controls-container').messageTools( 'toolset', 'thread');
         this.element.find('.cm-messages-container')
           .communicatorMessages('loadFolder', id)
           .show();
       }
     },
-    
+
     reloadFolder: function () {
       var folderId = this.element.find('.cm-messages-container')
         .communicatorMessages('folderId');
-    
+
       this.loadFolder(folderId);
     },
-    
+
     loadThread: function (threadId) {
       var folderId = this.element.find('.cm-messages-container')
         .communicatorMessages('folderId');
-      
+
       this._updateHash(folderId, threadId);
       this._updateSelected(folderId);
-      
+
       this.element.find('.cm-messages-container').hide();
-      $('.mf-controls-container').messageTools( 'toolset', 'message');     
+      $('.mf-controls-container').messageTools( 'toolset', 'message');
       this.element.find('.cm-thread-container')
         .empty()
         .communicatorThread('loadThread', folderId, threadId)
         .show();
     },
-    
+
     deleteThread: function (folderId, threadId) {
       this.deleteThreads([{
         folderId: folderId,
         id: threadId
       }]);
     },
-    
+
     deleteThreads: function (threads) {
       this._removeThreads(threads, $.proxy(function () {
         this.reloadFolder();
@@ -893,7 +894,7 @@
           this._folderControllers[thread.folderId].markAsUnread(thread.id, callback);
         }, this);
       }, this));
-      
+
       async.series(calls, $.proxy(function (err, results) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -913,7 +914,7 @@
           this._folderControllers[thread.folderId].markAsRead(thread.id, callback);
         }, this);
       }, this));
-      
+
       async.series(calls, $.proxy(function (err, results) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -925,15 +926,15 @@
           }
         }
       }, this));
-    },    
-    
+    },
+
     createLabel: function (name, hexColor) {
       var colorInt = this.hexToColorInt(hexColor);
       var label = {
         name: name,
         color: colorInt
       };
-      
+
       mApi().communicator.userLabels.create(label).callback($.proxy(function (err, label) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -944,7 +945,7 @@
         }
       }, this));
     },
-    
+
     updateLabel: function (id, name, hexColor) {
       var colorInt = this.hexToColorInt(hexColor);
       var label = {
@@ -952,7 +953,7 @@
         name: name,
         color: colorInt
       };
-      
+
       mApi().communicator.userLabels.update(id, label).callback($.proxy(function (err, label) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -974,13 +975,13 @@
         }
       }, this));
     },
-    
+
     loadLabels: function (callback) {
       mApi().communicator.userLabels.read().callback($.proxy(function (err, results) {
         callback(err, results);
       }, this));
     },
-    
+
     _sortLabels: function () {
       var labelContainer = this.element.find('.cm-categories ul');
       var labelItems = labelContainer.children('.mf-label');
@@ -999,7 +1000,7 @@
         callback(err, results);
       }, this));
     },
-    
+
     createSignature: function (name, signature, callback) {
       mApi().communicator.signatures.create({ name: name, signature: signature }).callback($.proxy(function (err, results) {
         callback(err, results);
@@ -1017,7 +1018,7 @@
         callback(err, results);
       }, this));
     },
-    
+
     _removeSignature: function  (event) {
       var id = $(event.target).closest('.cm-signature').attr('data-id');
       this._confirmSignatureRemoval(id, $.proxy(function (){
@@ -1025,9 +1026,9 @@
           this._onSettingsClick();
         }, this));
       }, this));
-      
-    }, 
-    
+
+    },
+
     _confirmSignatureRemoval: function (id, confirmCallback) {
       renderDustTemplate('communicator/communicator_confirm_signature_removal.dust', {}, $.proxy(function(text) {
         var dialog = $(text);
@@ -1052,31 +1053,31 @@
           } ]
         });
       }, this));
-    },    
+    },
     _onLabelMenuOpenClick : function(event){
       var menus = $(event.target).closest("ul").find('.mf-label-functions-menu');
       var clickedMenu = $(event.target).closest("li").find('.mf-label-functions-menu');
       var menuPosition = $(event.target).closest("li").width() - 10;
-      var menuState = clickedMenu.css('display') ;     
+      var menuState = clickedMenu.css('display') ;
       clickedMenu.css('left', menuPosition);
-      
+
       menus.hide();
 
       if(menuState == 'none'){
-        clickedMenu.show();       
+        clickedMenu.show();
       }else{
-        clickedMenu.hide();   
-        
+        clickedMenu.hide();
+
       }
-    }, 
-    
+    },
+
     _onLabelEditClick : function(event) {
       var communicator = $('.communicator').communicator("instance");
       var folderId = $(event.target).closest("li").attr("data-folder-id");
-      var menus = $(event.target).closest("ul").find('.mf-label-functions-menu');      
+      var menus = $(event.target).closest("ul").find('.mf-label-functions-menu');
       var folderController = this._folderControllers[folderId];
       var labelId = folderController._labelId;
-  
+
       mApi().communicator.userLabels.read(labelId).callback($.proxy(function (err, results) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', err);
@@ -1084,67 +1085,67 @@
           var label = results;
           label.hexColor =  communicator.colorIntToHex(label.color);
           renderDustTemplate('communicator/communicator_label_edit.dust', label, $.proxy(function(text) {
-            this._dialog = $(text);      
+            this._dialog = $(text);
             $(this._dialog).dialog(
               {
-                'title' : getLocaleText("plugin.communicator.label.edit.caption"),              
+                'title' : getLocaleText("plugin.communicator.label.edit.caption"),
                 buttons : [ {
-  
+
                    'text' :  getLocaleText("plugin.communicator.label.edit.button.send"),
                    'class' : 'save-button',
                    'click' : function() {
-                       
+
                        var id = $(this).find("input[type='text']").attr('data-id');
                        var name = $(this).find("input[type='text']").val();
                        var color = $(this).find("input[type='color']").val();
-                       var communicator = $(".communicator").communicator("instance");            
+                       var communicator = $(".communicator").communicator("instance");
                        communicator.updateLabel(id, name, color);
                        $(this).dialog().remove();
                        menus.hide();
-                       
+
                     // TODO: REFRESH LABELS
                    }
-                
-                 }, 
-               
+
+                 },
+
                  {
                    'text' :  getLocaleText("plugin.communicator.label.edit.button.cancel"),
                    'class' : 'cancel-button',
-                   'click' : function(){               
+                   'click' : function(){
                      $(this).dialog().remove();
                      menus.hide();
                  }
                }
                ]
-              } 
+              }
             );
           }));
         }
       }, this));
- 
+
     },
     _onLabelDeleteClick : function(event){
       var folderId = $(event.target).closest("li").attr("data-folder-id");
       var folderName = $(event.target).closest("li").attr("data-folder-name");
-      var menus = $(event.target).closest("ul").find('.mf-label-functions-menu');      
+      var menus = $(event.target).closest("ul").find('.mf-label-functions-menu');
       var folderController = this._folderControllers[folderId];
-      var labelId = folderController._labelId;      
+      var labelId = folderController._labelId;
       var label = [];
-      
+
       label.id = labelId;
       label.name = folderName;
-      
+
       renderDustTemplate('communicator/communicator_label_delete.dust', label, $.proxy(function(text) {
-        this._dialog = $(text);      
+        this._dialog = $(text);
         $(this._dialog).dialog(
-            
+
           {
-            'title' : getLocaleText("plugin.communicator.label.remove.caption"),                          
+            'title' : getLocaleText("plugin.communicator.label.remove.caption"),
             buttons : [ {
                'text' : getLocaleText("plugin.communicator.label.remove.button.send"),
                'class' : 'save-button',
                'click' :  function() {
-                 
+
                  var id = $(this).find("div").attr('data-id');
                  var communicator = $(".communicator").communicator("instance");
                  communicator.deleteLabel(id);
@@ -1152,39 +1153,39 @@
                  menus.hide();
               // TODO: REFRESH LABELS
              }
-             }, 
-           
+             },
+
              {
                'text' : getLocaleText("plugin.communicator.label.edit.button.cancel"),
                'class' : 'cancel-button',
-               'click' : function(){               
+               'click' : function(){
                  $(this).dialog('close');
-               
+
              }
-           }           
+           }
            ]
-          } 
+          }
         );
-      
-      }));      
+
+      }));
     },
     addLabelControl: function (label, callback) {
       this._folderControllers[ "label-" + label.id ] = new CommunicatorLabelFolderController(label.id);
-      
+
       // Label has id, name, color
-      
+
       label.hexColor = this.colorIntToHex(label.color);
 
       renderDustTemplate('communicator/communicator_label.dust', label, $.proxy(function (text) {
         this.element.find(".cm-categories ul").append(text);
-        
+
         if (callback) {
           callback();
         }
       }, this));
-      
+
     },
-    
+
     colorIntToHex: function (color) {
       var b = (color & 255).toString(16);
       var g = ((color >> 8) & 255).toString(16);
@@ -1193,73 +1194,73 @@
       var rStr = r.length == 1 ? "0" + r : r;
       var gStr = g.length == 1 ? "0" + g : g;
       var bStr = b.length == 1 ? "0" + b : b;
-      
+
       return "#" + rStr + gStr + bStr;
     },
-    
+
     hexToColorInt: function (hexColor) {
       var r = 255;
       var g = 255;
       var b = 255;
-    
+
       if (hexColor) {
         if (hexColor.length == 7)
           hexColor = hexColor.slice(1);
-        
+
         r = parseInt(hexColor.slice(0, 2), 16);
         g = parseInt(hexColor.slice(2, 4), 16);
         b = parseInt(hexColor.slice(4, 6), 16);
       }
-        
+
       return (r << 16) + (g << 8) + b;
     },
-    
+
     folderController: function (folderId) {
       return this._folderControllers[folderId];
     },
-        
+
     newMessageDialog: function (options) {
       var dialog = $('<div>')
         .communicatorCreateMessageDialog($.extend(options||{}, {
           groupMessagingPermission: this.options.groupMessagingPermission
         }));
-      
+
       dialog.on('dialogReady', function(e) {
         $(document.body).css({
           paddingBottom: dialog.height() + 50 + 'px'
         }).addClass('footerDialogOpen');
       });
-      
+
       dialog.on('dialogClose', function(e) {
         $(document.body).removeClass('footerDialogOpen').removeAttr('style');
       });
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
-    
+
     signatureDialog: function (options) {
       var dialog = $('<div>')
         .communicatorCreateEditSignatureDialog(options);
-      
+
       dialog.on('dialogReady', function(e) {
         $(document.body).css({
           paddingBottom: dialog.height() + 50 + 'px'
         }).addClass('footerDialogOpen');
       });
-      
+
       dialog.on('dialogClose', function(e) {
         $(document.body).removeClass('footerDialogOpen').removeAttr('style');
       });
-      
+
       $('#socialNavigation')
         .empty()
         .append(dialog);
     },
 
 
-    
+
     _updateHash: function (folderId, threadId) {
       if (folderId) {
         if (threadId) {
@@ -1271,65 +1272,65 @@
         window.location.hash = '';
       }
     },
-    
+
     _updateSelected: function (id) {
       this.element.find('.cm-folder')
         .removeClass('selected');
       this.element.find('.cm-folder[data-folder-id="' + id + '"]')
         .addClass('selected');
     },
-    
+
     _removeThreads: function (threads, mainCallback) {
       var folderMap = {};
-      
+
       $.each(threads, function (index, thread) {
         if (!folderMap[thread.folderId]) {
           folderMap[thread.folderId] = [];
         }
-        
+
         folderMap[thread.folderId].push(thread.id);
       });
-      
+
       var calls = $.map(folderMap, $.proxy(function (ids, folderId) {
         return $.proxy(function (callback) {
           this._folderControllers[folderId].removeItems(ids, callback);
         }, this);
       }, this));
-      
+
       async.series(calls, mainCallback);
     },
-    
+
     _onNewMessageButtonClick: function (event) {
       this.newMessageDialog();
     },
-    
+
     _onEditSignatureLinkClick: function (event) {
       var signatureElem = $(event.target).closest('.cm-signature');
       var signature = {};
-      
+
       signature.id = signatureElem.attr('data-id');
       signature.name = signatureElem.attr('data-name');
       signature.content = signatureElem.attr('data-signature');
-      
+
       this.signatureDialog({signature: signature});
-    },    
-    
+    },
+
     _onNewSignatureLinkClick: function (event) {
       this.signatureDialog();
     },
-    
-    
+
+
     _onCommunicatorFolderClick: function (event) {
       var folderId = $(event.target).closest('.cm-folder')
         .attr('data-folder-id');
-      
+
       this.loadFolder(folderId);
     }
-    
+
   });
-  
+
   $.widget("custom.communicatorCreateEditSignatureDialog", {
-    
+
     options: {
       signature: null,
       ckeditor: {
@@ -1344,9 +1345,9 @@
         ],
       }
     },
-      
+
     _create : function() {
-      
+
       this._load($.proxy(function () {
         this._contentsEditor = CKEDITOR.replace(this.element.find('textarea[name="content"]')[0], $.extend(this.options.ckeditor, {
           on: {
@@ -1355,15 +1356,15 @@
         }));
 
         if(this.options.signature){
-          this._contentsEditor.setData(this.options.signature.content);          
-        }                
-        
+          this._contentsEditor.setData(this.options.signature.content);
+        }
+
       }, this));
-        
+
       this.element.on('click', 'input[name="send"]', $.proxy(this._onSendClick, this));
       this.element.on('click', 'input[name="cancel"]', $.proxy(this._onCancelClick, this));
     },
-    
+
     _load: function (callback) {
       var content = null;
 
@@ -1373,8 +1374,8 @@
           callback();
         }
       }, this));
-      
-    },    
+
+    },
     _destroy: function () {
       try {
         this._contentsEditor.destroy();
@@ -1382,17 +1383,17 @@
         alert(e);
       }
     },
-    
+
     _onSendClick: function (event) {
       this.element.addClass('loading');
       var communicator = $(".communicator").communicator("instance");
 
-      
+
       var form = $(event.target).closest('form')[0];
       if (form.checkValidity()) {
         var buttonElement = $(event.target);
         buttonElement.attr('disabled','disabled');
-        
+
         var content = this._contentsEditor.getData();
 
         if (!content  ||  !content.trim()) {
@@ -1400,7 +1401,7 @@
           buttonElement.removeAttr('disabled');
           return false;
         }
-        
+
         if (this.options.signature) {
           communicator.updateSignature(this.options.signature.id, this.options.signature.name, content, $.proxy(function () {
             this.element.removeClass('loading');
@@ -1412,9 +1413,9 @@
           communicator.createSignature(caption, content, $.proxy(function () {
             communicator._onSettingsClick();
             this._closeDialog(event);
-          }, this));                    
+          }, this));
         }
-      }      
+      }
     },
 
     _closeDialog: function (event) {
@@ -1422,21 +1423,21 @@
       this.element.trigger('dialogClose');
       this.element.remove();
     },
-    
+
     _onCancelClick: function (event) {
       this._closeDialog(event);
     },
-    
+
     _onCKEditorReady: function (e) {
       this.element.find('input[name="send"]').removeAttr('disabled');
       this.element.trigger('dialogReady');
     }
-  });  
+  });
 
-  
-  
+
+
   $.widget("custom.communicatorCreateMessageDialog", {
-    
+
     options: {
       groupMessagingPermission: false,
       ckeditor: {
@@ -1465,20 +1466,20 @@
     },
 
 
-      
+
     _create : function() {
       var extraPlugins = [];
       $.each($.extend(this.options.ckeditor.extraPlugins, {}, true), $.proxy(function (plugin, url) {
         CKEDITOR.plugins.addExternal(plugin, url);
         extraPlugins.push(plugin);
       }, this));
-      
+
       this.options.ckeditor.extraPlugins = extraPlugins.join(',');
-      
+
       this.element.on('click', 'input[name="send"]', $.proxy(this._onSendClick, this));
       this.element.on('click', 'input[name="cancel"]', $.proxy(this._onCancelClick, this));
       this.element.on('click', '.cm-message-recipient', $.proxy(this._onRecipientClick, this));
-      
+
       this._load($.proxy(function () {
         this._contentsEditor = CKEDITOR.replace(this.element.find('textarea[name="content"]')[0], $.extend(this.options.ckeditor, {
           draftKey: 'communicator-new-message',
@@ -1493,7 +1494,7 @@
               wheelSpeed:3,
               swipePropagation:false
             });
-          },  
+          },
           source: $.proxy(function (request, response) {
             this._searchRecipients(request.term, function (err, results) {
               if (err) {
@@ -1511,31 +1512,31 @@
             }
             return false;
           }, this),
-          
+
           appendTo: '#msgRecipientsContainer'
         });
-        
+
         autocomplete.data("ui-autocomplete")._renderItem = function (ul, item) {
           var li = $("<li>")
             .text(item.label)
             .appendTo(ul);
-          
+
           if (item.existing) {
             li.attr("data-existing", "true");
           }
-        
+
           return li;
         };
       }, this));
     },
-    
+
     _destroy: function () {
       try {
         this._contentsEditor.destroy();
       } catch (e) {
       }
     },
-    
+
     _createRecipientLoad: function (messageId) {
       return $.proxy(function (callback) {
         var isStudent = $('.communicator').attr('data-student') == 'true';
@@ -1547,7 +1548,7 @@
                 reply.senderFullName = isStudent
                   ? (user.nickName ? user.nickName : user.firstName) + ' ' + user.lastName
                   : (user.nickName ? user.firstName + ' "' + user.nickName + '"' : user.firstName) + ' ' + user.lastName
-                reply.senderHasPicture = user.hasImage;                
+                reply.senderHasPicture = user.hasImage;
                 replyCallback();
 
               });
@@ -1563,20 +1564,20 @@
           .callback(callback);
       }, this);
     },
-    
+
 
     _load: function (callback) {
       var communicator = $(".communicator").communicator("instance");
       var replyMessageId = this.options.replyMessageId;
       this._signature = undefined;
-      var hasSignature = false; 
-      
+      var hasSignature = false;
+
       communicator.loadSignatures( $.proxy(function (err, signatures){
         if(signatures.length > 0){
-          this._signature = "<br/> <i class='mf-signature'>" + signatures[0].signature + "</i>";            
+          this._signature = "<br/> <i class='mf-signature'>" + signatures[0].signature + "</i>";
           hasSignature = true;
-        }        
-        
+        }
+
         if (replyMessageId) {
           mApi().communicator.communicatormessages.read(replyMessageId).callback($.proxy(function (err, message) {
             if (err) {
@@ -1587,44 +1588,44 @@
                 replyMessage: message,
                 hasSignature: hasSignature
               };
-              
+
               renderDustTemplate('communicator/communicator_create_message.dust', data, $.proxy(function (text) {
                 this.element.html(text);
-                
+
                 if (this.options.mode == "replyall") {
                   // Add all the recipients
                   $.each(message.recipients,  $.proxy(function (index, recipient) {
                     var recipientFullName = isStudent
                       ? (recipient.nickName ? recipient.nickName : recipient.firstName) + ' ' + recipient.lastName
                       : (recipient.nickName ? recipient.firstName + ' "' + recipient.nickName + '"' : recipient.firstName) + ' ' + recipient.lastName;
-                    
+
                     if ((recipient.userId != message.senderId) && (recipient.userId != MUIKKU_LOGGED_USER_ID)) {
                       this._addRecipient('USER', recipient.userId, recipientFullName);
                     }
                   }, this));
-                  
+
                   // Add all the usergroups if the user is allowed to message groups
                   if (this.options.groupMessagingPermission == true) {
                     $.each(message.userGroupRecipients,  $.proxy(function (index, recipient) {
                       this._addRecipient('GROUP', recipient.id, recipient.name);
                     }, this));
                   }
-                  
+
                   // Add all the workspace groups if the user is allowed to message groups
                   if (this.options.groupMessagingPermission == true) {
                     $.each(message.workspaceRecipients,  $.proxy(function (index, recipient) {
                       this._addRecipient('WORKSPACE', recipient.workspaceEntityId, recipient.workspaceName);
                     }, this));
                   }
-                  
+
                   this.options.replyToGroupMessage = ((message.userGroupRecipients.length | 0) + (message.workspaceRecipients.length | 0)) > 0;
                 }
-                
+
                 var senderFullName = isStudent
                   ? (message.sender.nickName ? message.sender.nickName : message.sender.firstName) + ' ' + message.sender.lastName
                   : (message.sender.nickName ? message.sender.firstName + ' "' + message.sender.nickName + '"' : message.sender.firstName) + ' ' + message.sender.lastName
-                this._addRecipient('USER', message.sender.id, senderFullName);                       
-                
+                this._addRecipient('USER', message.sender.id, senderFullName);
+
                 if (callback) {
                   callback();
                 }
@@ -1642,16 +1643,16 @@
             }
           }, this));
         }
-      }, this));    
+      }, this));
     },
-    
+
     _addRecipient: function (type, id, label) {
       var parameters = {
         id: id,
         name: label,
         type: type
       };
-      
+
       switch (type) {
         case 'USER':
           renderDustTemplate('communicator/communicator_messagerecipient.dust', parameters, $.proxy(function (text) {
@@ -1670,28 +1671,28 @@
         break;
       }
     },
-    
+
     _getRecipientIds: function () {
       return $.map(this.element.find('input[name="recipientIds"]'), function (input) {
         return parseInt($(input).val());
       });
     },
-    
+
     _getRecipientGroupIds: function () {
       return $.map(this.element.find('input[name="recipientGroupIds"]'), function (input) {
         return parseInt($(input).val());
       });
     },
-    
+
     _getExistingWorkspaceIds: function () {
       return $.map(this.element.find('input[name="recipientStudentsWorkspaceIds"],input[name="recipientTeachersWorkspaceIds"]'), function (input) {
         return parseInt($(input).val());
       });
     },
-    
+
     _createWorkspaceSearch: function (term) {
       var existingWorkspaceIds = this._getExistingWorkspaceIds();
-      
+
       return $.proxy(function (callback) {
         // coursepicker??
         mApi().coursepicker.workspaces
@@ -1716,10 +1717,10 @@
           }, this));
       }, this);
     },
-    
+
     _createGroupSearch: function (term) {
       var existingGroupIds = this._getRecipientGroupIds();
-      
+
       return $.proxy(function (callback) {
         mApi().usergroup.groups
           .read({ 'searchString' : term })
@@ -1740,7 +1741,7 @@
           });
       }, this);
     },
-    
+
     _createUserSearch: function (term) {
       var isStudent = $('.communicator').attr('data-student') == 'true';
       var existingUserIds = this._getRecipientIds();
@@ -1757,12 +1758,12 @@
                   label = (result.nickName ? result.nickName : result.firstName) + ' ' + result.lastName;
                 }
                 else {
-                  label = (result.nickName ? result.firstName + ' "' + result.nickName + '" ' : result.firstName) + ' ' + result.lastName; 
+                  label = (result.nickName ? result.firstName + ' "' + result.nickName + '" ' : result.firstName) + ' ' + result.lastName;
                 }
                 if (result.email) {
                   label = label + " (" + result.email + ")"
                 }
-                
+
                 return {
                   category: getLocaleText("plugin.communicator.users"),
                   label : label,
@@ -1776,30 +1777,30 @@
           });
       }, this);
     },
-    
+
     _searchRecipients: function (term, callback) {
       var tasks = [this._createUserSearch(term), this._createWorkspaceSearch(term)];
 
       if (this.options.groupMessagingPermission) {
         tasks.push(this._createGroupSearch(term));
       }
-      
+
       async.parallel(tasks, function (err, results) {
         if (err) {
           callback(err);
         } else {
-          callback(null, _.flatMap(results)); 
+          callback(null, _.flatMap(results));
         }
       });
     },
-    
+
     _discardDraft: function () {
       try {
         this._contentsEditor.discardDraft();
       } catch (e) {
       }
     },
-    
+
     _onSendClick: function (event) {
       this.element.addClass('loading');
 
@@ -1807,50 +1808,50 @@
       if (form.checkValidity()) {
         var buttonElement = $(event.target);
         buttonElement.attr('disabled','disabled');
-        
+
         var caption = this.element.find('input[name="caption"]').val();
         var content = this._contentsEditor.getData();
         var signatureLen = this.element.find('input[name="signature"]:checked').length;
 
-        
- 
-        
+
+
+
         if (!caption || !caption.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.validation.notitle'));
           buttonElement.removeAttr('disabled');
           return false;
         }
-        
+
         if (!content || !content.trim()) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.validation.nomessage'));
-          buttonElement.removeAttr('disabled');          
+          buttonElement.removeAttr('disabled');
           return false;
         }
-        
+
         if(signatureLen > 0){
-          content = content + this._signature;          
+          content = content + this._signature;
         }
-        
+
         var payload = {
-          caption: caption,  
+          caption: caption,
           content: content,
-          categoryName: "message" 
+          categoryName: "message"
         };
-        
+
         $.each(['recipientIds', 'recipientGroupIds', 'recipientStudentsWorkspaceIds', 'recipientTeachersWorkspaceIds'], $.proxy(function (index, name) {
           var values = $.map(this.element.find('input[name="' + name + '"]'), function (input) {
             return $(input).val();
           });
-          
+
           payload[name] = values;
         }, this));
-            
+
         if (!payload.recipientIds.length && !payload.recipientGroupIds.length && !payload.recipientStudentsWorkspaceIds.length && !payload.recipientTeachersWorkspaceIds.length) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.validation.norecipients'));
           buttonElement.removeAttr('disabled');
           return false;
         }
-        
+
         var replyThreadId = this.options.replyThreadId;
         if (replyThreadId) {
           // Replying to a message that was group message but isn't anymore will be directed to new thread
@@ -1858,18 +1859,18 @@
             var len1 = payload.recipientGroupIds.length | 0;
             var len2 = payload.recipientStudentsWorkspaceIds.length | 0;
             var len3 = payload.recipientTeachersWorkspaceIds.length | 0;
-            
+
             if (len1 + len2 + len3 == 0)
               replyThreadId = undefined;
           }
         }
-        
+
         if (replyThreadId) {
           mApi().communicator.messages
           .create(this.options.replyThreadId, payload)
           .callback($.proxy(function (err, result) {
             this._discardDraft();
-            
+
             if (err) {
               $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.infomessage.newMessage.error'));
               buttonElement.removeAttr('disabled');
@@ -1884,7 +1885,7 @@
             .create(payload)
             .callback($.proxy(function (err, result) {
               this._discardDraft();
-              
+
               if (err) {
                 $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.infomessage.newMessage.error'));
                 buttonElement.removeAttr('disabled');
@@ -1897,39 +1898,39 @@
         }
       }
     },
-    
+
     _onCancelClick: function (event) {
       event.preventDefault();
       this.element.trigger('dialogClose');
       this.element.remove();
     },
-    
+
     _onRecipientClick: function (event) {
       $(event.target).closest('.cm-message-recipient')
         .remove();
     },
-    
+
     _onCKEditorReady: function (e) {
       this.element.find('input[name="send"]').removeAttr('disabled');
       this.element.trigger('dialogReady');
     }
   });
-  
+
   $.widget("custom.communicatorThread", {
     _create : function() {
       var controls = $('.mf-controls-container');
       this._threadId = null;
       controls.on('click', '.icon-goback', $.proxy(this._onBackClick, this));
       controls.on('click', '.cm-delete-message', $.proxy(this._onDeleteClick, this));
-      controls.on('click', '.mf-label-message-link', $.proxy(this._onAddLabelToMessageClick, this));    
-      controls.on('click', '.cm-add-label-message-menu', $.proxy(this._onAddLabelMenuClick, this));     
+      controls.on('click', '.mf-label-message-link', $.proxy(this._onAddLabelToMessageClick, this));
+      controls.on('click', '.cm-add-label-message-menu', $.proxy(this._onAddLabelMenuClick, this));
       controls.on('click', '.cm-mark-unread-message', $.proxy(this._onMarkUnreadClick, this));
       controls.on('click', '.cm-go-previous', $.proxy(this._onNavigateNewerThreadClick, this));
       controls.on('click', '.cm-go-next', $.proxy(this._onNavigateOlderThreadClick, this));
-      this.element.on('click', '.cm-message-reply-link', $.proxy(this._onReplyClick, this));    
-      this.element.on('click', '.cm-message-reply-all-link', $.proxy(this._onReplyAllClick, this));    
+      this.element.on('click', '.cm-message-reply-link', $.proxy(this._onReplyClick, this));
+      this.element.on('click', '.cm-message-reply-all-link', $.proxy(this._onReplyAllClick, this));
     },
-    
+
     setOlderThreadId : function (olderThreadId) {
       this._olderThreadId = olderThreadId;
       if (this._olderThreadId)
@@ -1937,7 +1938,7 @@
       else
         $(".cm-go-next").closest(".mf-tool-container").addClass("disabled");
     },
-    
+
     setNewerThreadId : function (newerThreadId) {
       this._newerThreadId = newerThreadId;
       if (this._newerThreadId)
@@ -1945,28 +1946,28 @@
       else
         $(".cm-go-previous").closest(".mf-tool-container").addClass("disabled");
     },
-    
+
     _onNavigateNewerThreadClick: function (event) {
       if (!$(event.target).closest(".mf-tool-container").hasClass("disabled")) {
         if (this._newerThreadId)
           this.loadThread(this._folderId, this._newerThreadId)
       }
     },
-    
+
     _onNavigateOlderThreadClick: function (event) {
       if (!$(event.target).closest(".mf-tool-container").hasClass("disabled")) {
         if (this._olderThreadId)
           this.loadThread(this._folderId, this._olderThreadId)
       }
     },
-    
+
     loadThread: function (folderId, threadId) {
       this._threadId = threadId;
       this._folderId = folderId;
-      
+
       var communicator = $(".communicator").communicator("instance");
       var folderController = communicator.folderController(folderId);
-      
+
       folderController.loadThread(threadId, 0, 0, $.proxy(function (err, thread) {
         if (err) {
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.showmessage.thread.error'));
@@ -1982,40 +1983,40 @@
               hexColor: communicator.colorIntToHex(label.labelColor)
             });
           });
-          
-          
+
+
           this.setOlderThreadId(thread.olderThreadId);
           this.setNewerThreadId(thread.newerThreadId);
-          
+
           renderDustTemplate('communicator/communicator_items_open.dust', {
             messages: messages,
             labels: labels,
             isStudent: $('.communicator').attr('data-student') == 'true' ? 1 : ''
           }, $.proxy(function(text) {
             this.element.html(text);
-            
+
             var folderController = communicator.folderController(folderId);
             folderController.markAsRead(threadId, function () {
               mApi().communicator.cacheClear();
               $(document).trigger("Communicator:messageread");
-            });    
+            });
           }, this));
-        }         
+        }
       }, this));
     },
-    
+
     _onBackClick: function () {
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('reloadFolder');
     },
-    
+
     _onDeleteClick: function () {
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('deleteThread', this._folderId, this._threadId);
     },
     _onAddLabelMenuClick: function (event) {
-      
-      var labelObjs = $('.cm-categories').find('.mf-label');      
+
+      var labelObjs = $('.cm-categories').find('.mf-label');
       var labels = [];
       var messageLabels = [];
       var labelOccurrances = {};
@@ -2025,37 +2026,37 @@
         var labelId = $(label).attr('data-label-id');
         if( messageLabels.indexOf(labelId) == -1){
           messageLabels.push(labelId);
-          labelOccurrances[labelId] = 1; 
-        }else{  
+          labelOccurrances[labelId] = 1;
+        }else{
           labelOccurrances[labelId]++;
         }
       });
-      
+
       $.each(labelObjs, function(key, value){
         var lName = $(value).attr('data-folder-name');
         var lStyle = $(value).find('.cm-label-name').attr('style');
         var lId = $(value).attr('data-label-id');
-        var lSelected = messageLabels.indexOf(lId) == -1 ? false : true; 
+        var lSelected = messageLabels.indexOf(lId) == -1 ? false : true;
         labels.push({name: lName, id: lId, selected: lSelected, style: lStyle, thread : true });
-        
+
       });
 
       renderDustTemplate('communicator/communicator_label_link.dust', labels, $.proxy(function (text) {
-        $(".mf-tool-label-container").html(text);        
+        $(".mf-tool-label-container").html(text);
         $('#communicatorNewlabelField').on('input', $.proxy( $(".cm-messages-container").communicatorMessages._onLabelFilterInputChange, this));
       }, this));
-      
+
       $(event.target).closest('.mf-tool-container').find('.cm-label-menu').toggle();
     },
-    _onAddLabelToMessageClick: function (event) {  
+    _onAddLabelToMessageClick: function (event) {
       var clickedLabel = $(event.target).closest('.mf-label-message-link');
       var lId = $(clickedLabel).attr('data-label-id');
       var messageThread = $('.cm-thread-container').find('.cm-message:first-child');
       var messageThreads = $('.cm-thread-container').find('.cm-message');
       var labelElement = messageThread.find('.cm-message-label[data-label-id=' + lId + ']');
       var messageThreadId = messageThread.attr('data-thread-id');
-      var messageLabelId = labelElement.attr('data-message-label-id');        
-        
+      var messageLabelId = labelElement.attr('data-message-label-id');
+
         if (labelElement.length) {
           mApi().communicator.messages.labels.del(messageThreadId, messageLabelId).callback($.proxy(function (err, results) {
             if (err) {
@@ -2075,14 +2076,14 @@
               var communicator = $(".communicator").communicator("instance");
               label["hexColor"] = communicator.colorIntToHex(label.labelColor);
               renderDustTemplate('communicator/communicator_item_label.dust', label, $.proxy(function (text) {
-                $(clickedLabel).addClass('selected');    
+                $(clickedLabel).addClass('selected');
                 messageThreads.find('.cm-message-header').append($(text));
               }, this));
             }
           }, this));
         }
-     },    
-    
+     },
+
     _onMarkUnreadClick: function (event) {
       var threads = [
           {
@@ -2090,20 +2091,20 @@
             id: this._threadId
           }
       ];
-      this.element.closest('.communicator') 
+      this.element.closest('.communicator')
         .communicator('markUnreadThreads', threads);
     },
-    
+
     _onReplyClick: function (event) {
       var messageId = $(event.target)
         .closest('.cm-message')
         .attr('data-id');
-      
-      this.element.closest('.communicator') 
+
+      this.element.closest('.communicator')
         .communicator('newMessageDialog', {
           mode: "reply",
-          replyThreadId: this._threadId, 
-          replyMessageId: messageId 
+          replyThreadId: this._threadId,
+          replyMessageId: messageId
         }
       );
     },
@@ -2111,17 +2112,17 @@
       var messageId = $(event.target)
         .closest('.cm-message')
         .attr('data-id');
-      
-      this.element.closest('.communicator') 
+
+      this.element.closest('.communicator')
         .communicator('newMessageDialog', {
           mode: "replyall",
-          replyThreadId: this._threadId, 
+          replyThreadId: this._threadId,
           replyMessageId: messageId
         }
       );
     }
   });
-  
+
   $(document).ready(function() {
     webshim.polyfill('forms');
     $('.communicator').communicator({


### PR DESCRIPTION
Yes that was literally the problem, took a while to found out but since there are two elements one to contain the messages and other to content the settings the message screen superseded the other when the messages was open, so I just make it to show and hide respectably.

Eclipse is making weird changes without even asking me it seems from the formatting.

Fixes #312