### PR TITLE
Communicator setting view does not work when reading a message

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
@@ -875,7 +875,8 @@
           $('.notification-queue').notificationQueue('notification', 'error', getLocaleText('plugin.communicator.errormessage.signatures.loading'));          
         }else{          
           renderDustTemplate('communicator/communicator_settings.dust', {signatures : signatures}, $.proxy(function(text) {
-            $(".cm-messages-container").html(text);
+            $(".cm-thread-container").hide();
+            $(".cm-messages-container").html(text).show();
             $('.mf-controls-container').messageTools( 'toolset', 'settings');   
             this._updateHash('settings', null);
           }, this));


### PR DESCRIPTION
Yes that was literally the problem, took a while to found out but since there are two elements one to contain the messages and other to content the settings the message screen superseded the other when the messages was open, so I just make it to show and hide respectably.

Eclipse is making weird changes without even asking me it seems from the formatting.

Fixes #312