### PR TITLE
Fixing archiving of announcements bug

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/rest/AnnouncerRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/rest/AnnouncerRESTService.java
@@ -320,6 +320,7 @@ public class AnnouncerRESTService extends PluginRESTService {
     restModel.setEndDate(announcement.getEndDate());
     restModel.setId(announcement.getId());
     restModel.setPubliclyVisible(announcement.getPubliclyVisible());
+    restModel.setArchived(announcement.getArchived());
 
     List<Long> userGroupEntityIds = new ArrayList<>();
     for (AnnouncementUserGroup announcementUserGroup : announcementUserGroups) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/dust/announcer/announcer_item.dust
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/dust/announcer/announcer_item.dust
@@ -1,6 +1,10 @@
 <div class="lg-flex-cell12-4 md-flex-cell-8 sm-flex-cell-full mf-item an-announcement {@gt key=workspaceEntityIds.length value=0}workspace{/gt} {temporalStatus}" data-announcement-id="{id}">
   <div class="mf-item-header-container an-announcement-header-container default">
-    <div class="mf-item-select an-announcement-select"><input type="checkbox" class="an-select" value="{id}" /></div>
+    <div class="mf-item-select an-announcement-select">
+      {^archived}
+        <input type="checkbox" class="an-select" value="{id}"/>
+      {/archived}
+    </div>
     <div class="mf-item-header-label {@gt key=workspaceEntityIds.length value=0}workspace{/gt} an-announcement-dates"><span>{startDate|formatDate}</span> - <span>{endDate|formatDate}</span></div>
   </div>
   <div class="mf-item-details an-announcement-details">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/dust/announcer/announcer_items.dust
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/dust/announcer/announcer_items.dust
@@ -1,13 +1,15 @@
-{?.}
-  <div class="mf-items-toolbar flex-row an-announcements-toolbar"> 
-     <div class="mf-items-tool an-announcements-tool archive mf-item-tool icon-delete"></div>
-     <div class="clear"></div>
-  </div>
-{/.}
+{?items}
+  {^options.onlyArchived}
+    <div class="mf-items-toolbar flex-row an-announcements-toolbar"> 
+      <div class="mf-items-tool an-announcements-tool archive mf-item-tool icon-delete"></div>
+      <div class="clear"></div>
+    </div>
+  {/options.onlyArchived}
+{/items}
 <div class="an-announcements flex-row">
-  {#.}
+  {#items}
     {>"announcer/announcer_item.dust"/}
   {:else}
     {>"announcer/announcer_empty.dust"/}
-  {/.} 
+  {/items}
 </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/announcer.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/announcer.js
@@ -581,7 +581,12 @@
           if (err) {
             $(".notification-queue").notificationQueue('notification', 'error', err);
           } else {
-            renderDustTemplate('announcer/announcer_items.dust',result,$.proxy(function (text) {
+            var data = {
+                items: result,
+                options: options
+            };
+            
+            renderDustTemplate('announcer/announcer_items.dust', data, $.proxy(function (text) {
               $('.an-announcements-view-container').html(text);
             }, this));
           }


### PR DESCRIPTION
Fixes #3010 this was fixed as discussed with @pkukkon by removing the delete button, in the archived view as well as removing the checkboxs in the items that are archived.

A backend side bug was fixed where the property archived was not being set at all.