### PR TITLE
Added html for the an-categories class

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace_announcer.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace_announcer.xhtml
@@ -44,10 +44,26 @@
             </div>
           </div>        
           <div class="mf-content-area flex-row">
-            <div class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
+            <div class="lg-flex-cell-4 md-flex-cell-4 sm-flex-cell-full sm-flex-order-1 mf-categories an-categories">
+              <ul>
+                <li class="mf-category an-category icon-new-section" data-folder-id="active">
+                  <a href="#">#{i18n.text['plugin.announcer.cat.active']}</a>
+                </li>
+                <li class="mf-category an-category icon-new-section" data-folder-id="past">
+                  <a href="#">#{i18n.text['plugin.announcer.cat.past']}</a>
+                </li>
+                <li class="mf-category an-category icon-new-section" data-folder-id="mine">
+                  <a href="#">#{i18n.text['plugin.announcer.cat.mine']}</a>
+                </li>
+                <li class="mf-category an-category icon-new-section" data-folder-id="archived">
+                  <a href="#">#{i18n.text['plugin.announcer.cat.archived']}</a>
+                </li>
+              </ul>
+            </div>        
+            <div class="lg-flex-cell-12 md-flex-cell-12 sm-flex-cell-16 sm-flex-order-2 no-margin-top no-margin-bottom">
               <div class="flex-row">
-                <div class="an-announcements-view-container lg-flex-cell-full md-flex-cell-full sm-flex-cell-full"></div>
-              </div>                     
+                <div class="lg-flex-cell-16 md-flex-cell-16 sm-flex-cell-full an-announcements-view-container"></div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #3142 it was a pretty easy fix as only some html was added into the mix, the widget basically handles it all; it just represents a copy of the content that is in the normal announcer outside the workspace announcer.