### PR TITLE
Fixed course discussions button not working

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/discussion.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/discussion.js
@@ -48,7 +48,9 @@
     },
 
     loadThreadRepliesDetails: function(replies, callback) {
-      var replyCreatedMap = {};
+      this.replyCreatedMap = this.replyCreatedMap || {};
+      var replyCreatedMap = this.replyCreatedMap;
+      
       $.each(replies, function (index, reply) {
         replyCreatedMap[reply.id] = reply;
       });
@@ -81,11 +83,12 @@
             var globalEdit = $('.discussion').discussion('mayEditMessages', reply.forumAreaId);
             var creatorFullName = generateFullName(user);
             var replyParentCreatorFullName = null;
+            let replyParentTime = null;
 
             //I must search for the creator rather than indexing it in an object
             //because the calls are parallell and are tangled, this is to refactor...
             //everything should be done with promises
-            if (reply.parentReplyId){
+            if (reply.parentReplyId && replyCreatedMap[reply.parentReplyId]){
               var replyCreatorId = replyCreatedMap[reply.parentReplyId].creator;
 
               //Array find not supported in IE :(
@@ -94,6 +97,8 @@
                   replyParentCreatorFullName = generateFullName(usr);
                 }
               });
+              
+              replyParentTime = formatDate(moment(replyCreatedMap[reply.parentReplyId].created).toDate()) + ' ' + formatTime(moment(replyCreatedMap[reply.parentReplyId].created).toDate());
             }
 
             return {
@@ -106,7 +111,7 @@
               userEntityId: user.id,
               nameLetter: creatorFullName.substring(0,1),
               isReply: reply.parentReplyId ? true : false,
-              replyParentTime: reply.parentReplyId ? formatDate(moment(replyCreatedMap[reply.parentReplyId].created).toDate()) + ' ' + formatTime(moment(replyCreatedMap[reply.parentReplyId].created).toDate()) : null,
+              replyParentTime: replyParentTime,
               replyParentCreatorFullName: replyParentCreatorFullName
             };
           }, this)));


### PR DESCRIPTION
This issue was actually all over the discussions but only appeared under a very specific circumstance that was that the parent reply was just cutting the children replies because the request didn't load more. eg.

```
[1]
[2]
  [3]
[4]
[5]
---------
  [6]
```

Because they were loaded in a separated manner, the 6 answer wouldn't relate to the 5th and so it wouldn't be able to create itself, causing it to crash.

Fixed by adding an accumulative variable that would remember the previous values as well as adding a failsafe mechanism for even when the parent thread does not exist.

Fixes #3173 