### PR TITLE
Made change address link invisible for non-students

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/profile/profile.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/profile/profile.xhtml
@@ -65,9 +65,11 @@
                       <div class="profile-change-password">#{i18n.text['plugin.profile.changePassword.buttonLabel']}</div>
                     </div>
 
-                    <div class="profile-change-address-municipality-container">
-                      <div class="profile-change-address-municipality">#{i18n.text['plugin.profile.changeAddressMunicipality.buttonLabel']}</div>
-                    </div>
+                    <ui:fragment rendered="#{sessionBackingBean.isStudent}">
+                      <div class="profile-change-address-municipality-container">
+                        <div class="profile-change-address-municipality">#{i18n.text['plugin.profile.changeAddressMunicipality.buttonLabel']}</div>
+                      </div>
+                    </ui:fragment>
 
                     <ui:fragment rendered="#{not sessionBackingBean.isStudent}">
                       <form>


### PR DESCRIPTION
As discussed the change address that is shown in the profile is now invisible for non-students and so does not allow change it for such.

Fixes #3171 