### PR TITLE
Added and used archived property to modify announcements

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncementController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncementController.java
@@ -68,12 +68,13 @@ public class AnnouncementController {
     return announcementWorkspaceDAO.create(announcement, workspaceEntity.getId(), Boolean.FALSE);
   }
 
-  public Announcement updateAnnouncement(Announcement announcement, String caption, String content, Date startDate, Date endDate, boolean publiclyVisible) {
+  public Announcement updateAnnouncement(Announcement announcement, String caption, String content, Date startDate, Date endDate, boolean publiclyVisible, boolean archived) {
     announcementDAO.updateCaption(announcement, caption);
     announcementDAO.updateContent(announcement, content);
     announcementDAO.updateStartDate(announcement, startDate);
     announcementDAO.updateEndDate(announcement, endDate);
     announcementDAO.updatePubliclyVisible(announcement, publiclyVisible);
+    announcementDAO.updateArchived(announcement, archived);
     return announcement;
   }
   

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/rest/AnnouncerRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/rest/AnnouncerRESTService.java
@@ -204,7 +204,9 @@ public class AnnouncerRESTService extends PluginRESTService {
         restModel.getContent(),
         restModel.getStartDate(),
         restModel.getEndDate(),
-        restModel.getPubliclyVisible());
+        restModel.getPubliclyVisible(),
+        restModel.isArchived()
+    );
 
     announcementController.clearAnnouncementTargetGroups(newAnnouncement);
     for (Long userGroupEntityId : userGroupEntityIds) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/announcer.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/announcer.js
@@ -443,7 +443,7 @@
           var announcementId = this.options.announcement.id;
 
           mApi().announcer.announcements
-            .update(announcementId, payload)
+            .update(announcementId, Object.assign(payload, {'archived': false}))
             .callback($.proxy(function (err, result) {
               this._discardDraft();
               


### PR DESCRIPTION
This fixes #3011 as well as provides a futureproof endpoint for more functionality. This is a rather simple fix and makes sure that editing archived announcements will makes the pop up back to the active list or past for its defect.