### PR TITLE
Further fine-tuning of workspace student activity

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/rest/AssessmentRequestRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/rest/AssessmentRequestRESTService.java
@@ -79,14 +79,14 @@ public class AssessmentRequestRESTService extends PluginRESTService {
       return Response.status(Status.UNAUTHORIZED).build();
     }
     
-    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
     try {
       WorkspaceAssessmentRequest assessmentRequest = assessmentRequestController.createWorkspaceAssessmentRequest(workspaceUserEntity, newAssessmentRequest.getRequestText());
       communicatorAssessmentRequestController.sendAssessmentRequestMessage(assessmentRequest);
       return Response.ok(restModel(assessmentRequest)).build();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       logger.log(Level.SEVERE, "Couldn't create workspace assessment request.", e);
-      
       return Response.status(Status.INTERNAL_SERVER_ERROR).build();
     } 
   }
@@ -151,7 +151,7 @@ public class AssessmentRequestRESTService extends PluginRESTService {
       return Response.status(Status.NOT_FOUND).entity("Workspace entity not found").build();
     }
     
-    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());    
+    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());    
     
     if(workspaceUserEntity == null){
       return Response.status(Status.NOT_FOUND).entity("Workspace user entity not found").build();

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/coursepicker/CoursePickerRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/coursepicker/CoursePickerRESTService.java
@@ -387,20 +387,13 @@ public class CoursePickerRESTService extends PluginRESTService {
       return Response.status(Status.UNAUTHORIZED).build();
     }
     
-    User user = userController.findUserByDataSourceAndIdentifier(sessionController.getLoggedUserSchoolDataSource(),
-        sessionController.getLoggedUserIdentifier());
+    User user = userController.findUserByDataSourceAndIdentifier(sessionController.getLoggedUserSchoolDataSource(), sessionController.getLoggedUserIdentifier());
 
     Long workspaceStudentRoleId = getWorkspaceStudentRoleId();
     
     WorkspaceRoleEntity workspaceRole = roleController.findWorkspaceRoleEntityById(workspaceStudentRoleId);
-    if (workspaceUserEntityController.findWorkspaceUserEntityByWorkspaceAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser()) != null) {
-      return Response.status(Status.BAD_REQUEST).build();
-    }
-
     Workspace workspace = workspaceController.findWorkspace(workspaceEntity);
-    
     Role role = roleController.findRoleByDataSourceAndRoleEntity(user.getSchoolDataSource(), workspaceRole);
-    
     
     SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(workspace.getIdentifier(), workspace.getSchoolDataSource());
     SchoolDataIdentifier userIdentifier = new SchoolDataIdentifier(user.getIdentifier(), user.getSchoolDataSource());
@@ -484,22 +477,22 @@ public class CoursePickerRESTService extends PluginRESTService {
 
   private boolean getIsAlreadyOnWorkspace(WorkspaceEntity workspaceEntity) {
     if (sessionController.isLoggedIn()) {
-      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
-
-      return workspaceUserEntity != null && workspaceUserEntity.getActive();
-    } else
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+      return workspaceUserEntity != null;
+    }
+    else {
       return false;
+    }
   }
   
   private boolean getCanSignup(WorkspaceEntity workspaceEntity) {
     if (sessionController.isLoggedIn()) {
-      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
-
-      return
-          workspaceUserEntity == null &&
-          sessionController.hasWorkspacePermission(MuikkuPermissions.WORKSPACE_SIGNUP, workspaceEntity);
-    } else
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+      return workspaceUserEntity == null && sessionController.hasWorkspacePermission(MuikkuPermissions.WORKSPACE_SIGNUP, workspaceEntity);
+    }
+    else {
       return false;
+    }
   }
   
   private Long getWorkspaceStudentRoleId() {

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/ForumPermissionResolver.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/ForumPermissionResolver.java
@@ -74,7 +74,7 @@ public class ForumPermissionResolver extends AbstractPermissionResolver implemen
       
       WorkspaceEntity workspaceEntity = workspaceController.findWorkspaceEntityById(workspaceForum.getWorkspace());
       
-      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
       if (workspaceUserEntity != null) {
         userRole = workspaceUserEntity.getWorkspaceUserRole();
         if (resourceUserRolePermissionDAO.hasResourcePermissionAccess(

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/ForumPermissionResolver.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/ForumPermissionResolver.java
@@ -1,7 +1,5 @@
 package fi.otavanopisto.muikku.plugins.forum;
 
-import java.util.List;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -76,14 +74,9 @@ public class ForumPermissionResolver extends AbstractPermissionResolver implemen
       
       WorkspaceEntity workspaceEntity = workspaceController.findWorkspaceEntityById(workspaceForum.getWorkspace());
       
-      List<WorkspaceUserEntity> workspaceUsers = workspaceUserEntityController.listWorkspaceUserEntitiesByWorkspaceAndUser(workspaceEntity, userEntity);
-      // TODO: This is definitely not the way to do this 
-      
-      if (workspaceUsers.size() > 0) {
-        WorkspaceUserEntity workspaceUser = workspaceUsers.get(0);
-        
-        userRole = workspaceUser.getWorkspaceUserRole();
-        
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
+      if (workspaceUserEntity != null) {
+        userRole = workspaceUserEntity.getWorkspaceUserRole();
         if (resourceUserRolePermissionDAO.hasResourcePermissionAccess(
             resourceRightsController.findResourceRightsById(forumArea.getRights()), userRole, perm) ||
             hasEveryonePermission(permission, forumArea) ||

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/AbstractWorkspaceBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/AbstractWorkspaceBackingBean.java
@@ -53,7 +53,7 @@ public abstract class AbstractWorkspaceBackingBean {
           return navigationController.requireLogin();
         }
         
-        WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+        WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
         if (workspaceUserEntity == null) {
           if (!sessionController.hasWorkspacePermission(MuikkuPermissions.ACCESS_MEMBERS_ONLY_WORKSPACE, workspaceEntity)) {
             return NavigationRules.ACCESS_DENIED;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/WorkspaceBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/WorkspaceBackingBean.java
@@ -80,27 +80,25 @@ public class WorkspaceBackingBean {
 
   public void setWorkspaceUrlName(String workspaceUrlName) {
     
-    WorkspaceUserEntity workspaceUserEntity = null;
     WorkspaceEntity workspaceEntity = resolveWorkspaceEntity(workspaceUrlName);
     if (workspaceEntity != null) {
       this.workspaceEntityId = workspaceEntity.getId();
       this.workspaceUrlName = workspaceEntity.getUrlName();
-      if (sessionController.isLoggedIn()) {
-        workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
-      }
     }
-    boolean activeWorkspaceUser = workspaceUserEntity != null && Boolean.TRUE.equals(workspaceUserEntity.getActive());
     
     homeVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "home");
     guidesVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "guides");
     materialsVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "materials");
-    discussionsVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(ForumResourcePermissionCollection.FORUM_ACCESSWORKSPACEFORUMS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "discussions");
-    usersVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MEMBERS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "users");
-    journalVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.ACCESS_WORKSPACE_JOURNAL, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "journal");
+    discussionsVisible = sessionController.hasWorkspacePermission(ForumResourcePermissionCollection.FORUM_ACCESSWORKSPACEFORUMS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "discussions");
+    usersVisible = sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MEMBERS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "users");
+    journalVisible = sessionController.hasWorkspacePermission(MuikkuPermissions.ACCESS_WORKSPACE_JOURNAL, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "journal");
     // Assessment state
-    if (activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.REQUEST_WORKSPACE_ASSESSMENT, workspaceEntity)) {
-      WorkspaceAssessmentState workspaceAssessmentState = assessmentRequestController.getWorkspaceAssessmentState(workspaceUserEntity);
-      this.assessmentState = workspaceAssessmentState == null ? null : workspaceAssessmentState.getStateName();
+    if (sessionController.isLoggedIn() && sessionController.hasWorkspacePermission(MuikkuPermissions.REQUEST_WORKSPACE_ASSESSMENT, workspaceEntity)) {
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+      if (workspaceUserEntity != null) {
+        WorkspaceAssessmentState workspaceAssessmentState = assessmentRequestController.getWorkspaceAssessmentState(workspaceUserEntity);
+        this.assessmentState = workspaceAssessmentState == null ? null : workspaceAssessmentState.getStateName();
+      }
     }
     else {
       this.assessmentState = null;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/WorkspaceBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/WorkspaceBackingBean.java
@@ -79,24 +79,28 @@ public class WorkspaceBackingBean {
   }
 
   public void setWorkspaceUrlName(String workspaceUrlName) {
+    
+    WorkspaceUserEntity workspaceUserEntity = null;
     WorkspaceEntity workspaceEntity = resolveWorkspaceEntity(workspaceUrlName);
     if (workspaceEntity != null) {
       this.workspaceEntityId = workspaceEntity.getId();
       this.workspaceUrlName = workspaceEntity.getUrlName();
+      if (sessionController.isLoggedIn()) {
+        workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
+      }
     }
+    boolean activeWorkspaceUser = workspaceUserEntity != null && Boolean.TRUE.equals(workspaceUserEntity.getActive());
+    
     homeVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "home");
     guidesVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "guides");
     materialsVisible = workspaceToolSettingsController.getToolVisible(workspaceEntity, "materials");
-    discussionsVisible = sessionController.hasWorkspacePermission(ForumResourcePermissionCollection.FORUM_ACCESSWORKSPACEFORUMS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "discussions");
-    usersVisible = sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MEMBERS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "users");
-    journalVisible = sessionController.hasWorkspacePermission(MuikkuPermissions.ACCESS_WORKSPACE_JOURNAL, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "journal");
+    discussionsVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(ForumResourcePermissionCollection.FORUM_ACCESSWORKSPACEFORUMS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "discussions");
+    usersVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MEMBERS, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "users");
+    journalVisible = activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.ACCESS_WORKSPACE_JOURNAL, workspaceEntity) && workspaceToolSettingsController.getToolVisible(workspaceEntity, "journal");
     // Assessment state
-    if (sessionController.isLoggedIn() && sessionController.hasWorkspacePermission(MuikkuPermissions.REQUEST_WORKSPACE_ASSESSMENT, workspaceEntity)) {
-      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
-      if (workspaceUserEntity != null) {
-        WorkspaceAssessmentState workspaceAssessmentState = assessmentRequestController.getWorkspaceAssessmentState(workspaceUserEntity);
-        this.assessmentState = workspaceAssessmentState == null ? null : workspaceAssessmentState.getStateName();
-      }
+    if (activeWorkspaceUser && sessionController.hasWorkspacePermission(MuikkuPermissions.REQUEST_WORKSPACE_ASSESSMENT, workspaceEntity)) {
+      WorkspaceAssessmentState workspaceAssessmentState = assessmentRequestController.getWorkspaceAssessmentState(workspaceUserEntity);
+      this.assessmentState = workspaceAssessmentState == null ? null : workspaceAssessmentState.getStateName();
     }
     else {
       this.assessmentState = null;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -1096,7 +1096,7 @@ public class WorkspaceRESTService extends PluginRESTService {
         
         // #3111: Workspace staff members should be limited to teachers only. A better implementation would support specified workspace roles
         
-        WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
+        WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
         if (workspaceUserEntity == null || workspaceUserEntity.getWorkspaceUserRole().getArchetype() != WorkspaceRoleArchetype.TEACHER) {
           continue;
         }
@@ -2255,7 +2255,7 @@ public class WorkspaceRESTService extends PluginRESTService {
             (Collection<SchoolDataIdentifier>) null,
             Boolean.FALSE,
             Boolean.FALSE,
-            false,
+            true,
             0,
             maxResults != null ? maxResults : Integer.MAX_VALUE);
         

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -899,7 +899,7 @@ public class WorkspaceRESTService extends PluginRESTService {
           continue;
         }
 
-        if (active && !wue.getActive()) {
+        if (active != null && !active.equals(wue.getActive())) {
           continue;
         }
 
@@ -934,7 +934,7 @@ public class WorkspaceRESTService extends PluginRESTService {
       SchoolDataIdentifier workspaceUserIdentifier = workspaceUser.getIdentifier();
       WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityMap.get(workspaceUserIdentifier.toId());
       
-      if ((active == null) || (active.equals(workspaceUserEntity.getActive()))) {
+      if (active == null || active.equals(workspaceUserEntity.getActive())) {
         if (requestedAssessment != null) {
           boolean hasAssessmentRequest = workspaceUserEntity != null && !assessmentRequestController.listByWorkspaceUser(workspaceUserEntity).isEmpty();
           if (requestedAssessment != hasAssessmentRequest) {

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/security/impl/DefaultPermissionResolver.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/security/impl/DefaultPermissionResolver.java
@@ -76,7 +76,7 @@ public class DefaultPermissionResolver extends AbstractPermissionResolver implem
   
   private boolean hasWorkspaceAccess(WorkspaceEntity workspaceEntity, UserEntity userEntity, Permission permission) {
     // Workspace access as an individual
-    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
+    WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
     if (workspaceUserEntity != null) {
       if (permissionController.hasPermission(workspaceUserEntity.getWorkspaceUserRole(), permission)) {
         // TODO Override rules for workspace users

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
@@ -51,7 +51,7 @@ public class WorkspaceUserEntityController {
     UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierController.
         findUserSchoolDataIdentifierByDataSourceAndIdentifier(userIdentifier.getDataSource(), userIdentifier.getIdentifier());
     if (userSchoolDataIdentifier != null) {
-      return findWorkspaceUserEntityByWorkspaceAndUserSchoolDataIdentifier(workspaceEntity, userSchoolDataIdentifier);
+      return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.FALSE);
     }
     else {
       logger.severe(String.format("Could not find UserSchoolDataIdentifier by %s", userIdentifier));
@@ -71,8 +71,8 @@ public class WorkspaceUserEntityController {
     }
   }
 
-  public WorkspaceUserEntity findWorkspaceUserEntityByWorkspaceAndUserSchoolDataIdentifier(WorkspaceEntity workspaceEntity, UserSchoolDataIdentifier userSchoolDataIdentifier) {
-    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.FALSE);
+  public WorkspaceUserEntity findActiveWorkspaceUserEntityByWorkspaceAndUserSchoolDataIdentifier(WorkspaceEntity workspaceEntity, UserSchoolDataIdentifier userSchoolDataIdentifier) {
+    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndActiveAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.TRUE, Boolean.FALSE);
   }
 
   public WorkspaceUserEntity findWorkspaceUserEntityByWorkspaceAndUserSchoolDataIdentifierIncludeArchived(WorkspaceEntity workspaceEntity, UserSchoolDataIdentifier userSchoolDataIdentifier) {
@@ -175,31 +175,22 @@ public class WorkspaceUserEntityController {
     return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.FALSE);
   }
 
-  public WorkspaceUserEntity findWorkspaceUserByWorkspaceEntityAndUserIdentifierIncludeArchived(WorkspaceEntity workspaceEntity, SchoolDataIdentifier userIdentifier) {
+  public WorkspaceUserEntity findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(WorkspaceEntity workspaceEntity, SchoolDataIdentifier userIdentifier) {
     UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByDataSourceAndIdentifier(userIdentifier.getDataSource(), userIdentifier.getIdentifier());
     if (userSchoolDataIdentifier == null) {
       return null;
     }
-    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifier(workspaceEntity, userSchoolDataIdentifier);
+    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndActiveAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.TRUE, Boolean.FALSE);
   }
 
-  public WorkspaceUserEntity findWorkspaceUserByWorkspaceEntityAndUserEntity(WorkspaceEntity workspaceEntity, UserEntity userEntity) {
+  public WorkspaceUserEntity findActiveWorkspaceUserByWorkspaceEntityAndUserEntity(WorkspaceEntity workspaceEntity, UserEntity userEntity) {
     UserSchoolDataIdentifier userSchoolDataIdentifier = toUserSchoolDataIdentifier(userEntity);
     if (userSchoolDataIdentifier == null) {
       return null;
     }
-    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.FALSE);
+    return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndActiveAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.TRUE, Boolean.FALSE);
   }
   
-  public WorkspaceRoleEntity findWorkspaceUserRoleByWorkspaceEntityAndUserEntity(WorkspaceEntity workspaceEntity, UserEntity userEntity) {
-    WorkspaceUserEntity workspaceUserEntity = findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
-    if (workspaceUserEntity != null) {
-      return workspaceUserEntity.getWorkspaceUserRole();
-    }
-    
-    return null;
-  }
-
   public List<WorkspaceEntity> listActiveWorkspaceEntitiesByUserEntity(UserEntity userEntity) {
     SchoolDataIdentifier schoolDataIdentifier = toSchoolDataIdentifier(userEntity);
     List<WorkspaceEntity> result = new ArrayList<>();

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
@@ -134,17 +134,15 @@ public class WorkspaceUserEntityController {
   }
   
   public List<WorkspaceUserEntity> listActiveWorkspaceUserEntitiesByUserEntity(UserEntity userEntity) {
-    return workspaceUserEntityDAO.listByUserEntityAndActiveAndArchived(userEntity, Boolean.TRUE, Boolean.FALSE);
+    UserSchoolDataIdentifier userSchoolDataIdentifier = toUserSchoolDataIdentifier(userEntity);
+    return workspaceUserEntityDAO.listByUserSchoolDataIdentifierAndActiveAndArchived(userSchoolDataIdentifier, Boolean.TRUE, Boolean.FALSE);
   }
 
   public List<WorkspaceUserEntity> listWorkspaceUserEntitiesByUserEntity(UserEntity userEntity) {
-    return workspaceUserEntityDAO.listByUserEntityAndArchived(userEntity, Boolean.FALSE);
+    UserSchoolDataIdentifier userSchoolDataIdentifier = toUserSchoolDataIdentifier(userEntity);
+    return workspaceUserEntityDAO.listByUserSchoolDataIdentifierAndArchived(userSchoolDataIdentifier, Boolean.FALSE);
   }
 
-  public List<WorkspaceUserEntity> listWorkspaceUserEntitiesByWorkspaceAndUser(WorkspaceEntity workspaceEntity, UserEntity userEntity) {
-    return workspaceUserEntityDAO.listByWorkspaceEntityAndUserEntityAndArchived(workspaceEntity, userEntity, Boolean.FALSE);
-  }
-  
   public WorkspaceUserEntity archiveWorkspaceUserEntity(WorkspaceUserEntity workspaceUserEntity) {
     return workspaceUserEntityDAO.updateArchived(workspaceUserEntity, Boolean.TRUE);
   }
@@ -186,11 +184,10 @@ public class WorkspaceUserEntityController {
   }
 
   public WorkspaceUserEntity findWorkspaceUserByWorkspaceEntityAndUserEntity(WorkspaceEntity workspaceEntity, UserEntity userEntity) {
-    UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByDataSourceAndIdentifier(userEntity.getDefaultSchoolDataSource(), userEntity.getDefaultIdentifier());
+    UserSchoolDataIdentifier userSchoolDataIdentifier = toUserSchoolDataIdentifier(userEntity);
     if (userSchoolDataIdentifier == null) {
       return null;
     }
-    
     return workspaceUserEntityDAO.findByWorkspaceEntityAndUserSchoolDataIdentifierAndArchived(workspaceEntity, userSchoolDataIdentifier, Boolean.FALSE);
   }
   
@@ -204,24 +201,22 @@ public class WorkspaceUserEntityController {
   }
 
   public List<WorkspaceEntity> listActiveWorkspaceEntitiesByUserEntity(UserEntity userEntity) {
+    SchoolDataIdentifier schoolDataIdentifier = toSchoolDataIdentifier(userEntity);
     List<WorkspaceEntity> result = new ArrayList<>();
-    
-    List<WorkspaceUserEntity> workspaceUserEntities = listActiveWorkspaceUserEntitiesByUserEntity(userEntity);
+    List<WorkspaceUserEntity> workspaceUserEntities = listActiveWorkspaceUserEntitiesByUserIdentifier(schoolDataIdentifier);
     for (WorkspaceUserEntity workspaceUserEntity : workspaceUserEntities) {
       result.add(workspaceUserEntity.getWorkspaceEntity());
     }
-    
     return result;
   }
 
   public List<WorkspaceEntity> listWorkspaceEntitiesByUserEntity(UserEntity userEntity) {
+    SchoolDataIdentifier schoolDataIdentifier = toSchoolDataIdentifier(userEntity);
     List<WorkspaceEntity> result = new ArrayList<>();
-    
-    List<WorkspaceUserEntity> workspaceUserEntities = listWorkspaceUserEntitiesByUserEntity(userEntity);
+    List<WorkspaceUserEntity> workspaceUserEntities = listWorkspaceUserEntitiesByUserIdentifier(schoolDataIdentifier);
     for (WorkspaceUserEntity workspaceUserEntity : workspaceUserEntities) {
       result.add(workspaceUserEntity.getWorkspaceEntity());
     }
-    
     return result;
   }
   
@@ -248,6 +243,17 @@ public class WorkspaceUserEntityController {
   
   public void deleteWorkspaceUserEntity(WorkspaceUserEntity workspaceUserEntity) {
     workspaceUserEntityDAO.delete(workspaceUserEntity);
-  }  
+  }
+  
+  private SchoolDataIdentifier toSchoolDataIdentifier(UserEntity userEntity) {
+    return new SchoolDataIdentifier(userEntity.getDefaultIdentifier(), userEntity.getDefaultSchoolDataSource().getIdentifier());
+  }
+
+  private UserSchoolDataIdentifier toUserSchoolDataIdentifier(UserEntity userEntity) {
+    UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByDataSourceAndIdentifier(
+        userEntity.getDefaultSchoolDataSource(),
+        userEntity.getDefaultIdentifier());
+    return userSchoolDataIdentifier == null ? null : userSchoolDataIdentifier;
+  }
 
 }

--- a/muikku-evaluation-plugin/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationRESTService.java
+++ b/muikku-evaluation-plugin/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationRESTService.java
@@ -126,7 +126,7 @@ public class EvaluationRESTService extends PluginRESTService {
         .build();
     }
     
-    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
+    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
     if (workspaceStudentEntity == null) {
       return Response.status(Status.NOT_FOUND)
         .entity(String.format("Could not find workspace student entity %s from workspace entity %d", studentIdentifier, workspaceEntityId))
@@ -263,7 +263,7 @@ public class EvaluationRESTService extends PluginRESTService {
     
     SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(workspaceEntity.getIdentifier(), workspaceEntity.getDataSource().getIdentifier());
 
-    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
+    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
     if (workspaceStudentEntity == null) {
       return Response.status(Status.NOT_FOUND)
         .entity(String.format("Could not find workspace student entity %s from workspace entity %d", studentIdentifier, workspaceEntityId))
@@ -373,7 +373,7 @@ public class EvaluationRESTService extends PluginRESTService {
     
     SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(workspaceEntity.getIdentifier(), workspaceEntity.getDataSource().getIdentifier());
     
-    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
+    WorkspaceUserEntity workspaceStudentEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, studentIdentifier);
     if (workspaceStudentEntity == null) {
       return Response.status(Status.NOT_FOUND)
         .entity(String.format("Could not find workspace student entity %s from workspace entity %d", studentIdentifier, workspaceEntityId))

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/dao/workspace/WorkspaceUserEntityDAO.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/dao/workspace/WorkspaceUserEntityDAO.java
@@ -3,22 +3,19 @@ package fi.otavanopisto.muikku.dao.workspace;
 import java.util.List;
 
 import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Root;
 
-import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier_;
-import fi.otavanopisto.muikku.model.workspace.WorkspaceRoleEntity_;
-import fi.otavanopisto.muikku.model.workspace.WorkspaceUserEntity_;
 import fi.otavanopisto.muikku.dao.CoreDAO;
-import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceRoleArchetype;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceRoleEntity;
+import fi.otavanopisto.muikku.model.workspace.WorkspaceRoleEntity_;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceUserEntity;
+import fi.otavanopisto.muikku.model.workspace.WorkspaceUserEntity_;
 
 public class WorkspaceUserEntityDAO extends CoreDAO<WorkspaceUserEntity> {
 
@@ -91,45 +88,6 @@ public class WorkspaceUserEntityDAO extends CoreDAO<WorkspaceUserEntity> {
     );
     
     return getSingleResult(entityManager.createQuery(criteria));
-  }
-
-  public List<WorkspaceUserEntity> listByUserEntityAndActiveAndArchived(UserEntity userEntity, Boolean active, Boolean archived) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    Join<WorkspaceUserEntity, UserSchoolDataIdentifier> userIdentifierJoin = root.join(WorkspaceUserEntity_.userSchoolDataIdentifier);
-    
-    criteria.select(root);
-    criteria.where(
-      criteriaBuilder.and(
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.active), active),
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
-        criteriaBuilder.equal(userIdentifierJoin.get(UserSchoolDataIdentifier_.userEntity), userEntity)
-      )
-    );
-    
-    return entityManager.createQuery(criteria).getResultList();
-  }
-
-  public List<WorkspaceUserEntity> listByUserEntityAndArchived(UserEntity userEntity, Boolean archived) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    Join<WorkspaceUserEntity, UserSchoolDataIdentifier> userIdentifierJoin = root.join(WorkspaceUserEntity_.userSchoolDataIdentifier);
-    
-    criteria.select(root);
-    criteria.where(
-      criteriaBuilder.and(
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
-        criteriaBuilder.equal(userIdentifierJoin.get(UserSchoolDataIdentifier_.userEntity), userEntity)
-      )
-    );
-    
-    return entityManager.createQuery(criteria).getResultList();
   }
 
   public List<WorkspaceUserEntity> listByWorkspaceEntity(WorkspaceEntity workspaceEntity) {
@@ -225,75 +183,6 @@ public class WorkspaceUserEntityDAO extends CoreDAO<WorkspaceUserEntity> {
     return entityManager.createQuery(criteria).getResultList();
   }
   
-  public List<WorkspaceUserEntity> listByWorkspaceEntityAndRolesAndArchived(WorkspaceEntity workspaceEntity, List<WorkspaceRoleEntity> workspaceUserRoles, Boolean archived, Integer firstResult, Integer maxResults) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    
-    criteria.select(root);
-    criteria.where(
-        criteriaBuilder.and(
-            criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
-            criteriaBuilder.equal(root.get(WorkspaceUserEntity_.workspaceEntity), workspaceEntity),
-            root.get(WorkspaceUserEntity_.workspaceUserRole).in(workspaceUserRoles)
-        )
-    );
-    
-    TypedQuery<WorkspaceUserEntity> query = entityManager.createQuery(criteria);
-    if (firstResult != null) {
-      query.setFirstResult(firstResult);
-    }
-    
-    if (maxResults != null) {
-      query.setMaxResults(maxResults);
-    }
-    
-    return query.getResultList();
-  }
-  
-  public List<WorkspaceUserEntity> listByWorkspaceEntityAndUserEntityAndActiveAndArchived(WorkspaceEntity workspaceEntity, UserEntity userEntity, Boolean active, Boolean archived) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    Join<WorkspaceUserEntity, UserSchoolDataIdentifier> userIdentifierJoin = root.join(WorkspaceUserEntity_.userSchoolDataIdentifier);
-    
-    criteria.select(root);
-    criteria.where(
-      criteriaBuilder.and(
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.active), active),
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.workspaceEntity), workspaceEntity),
-        criteriaBuilder.equal(userIdentifierJoin.get(UserSchoolDataIdentifier_.userEntity), userEntity)
-      )
-    );
-    
-    return entityManager.createQuery(criteria).getResultList();
-  }
-
-  public List<WorkspaceUserEntity> listByWorkspaceEntityAndUserEntityAndArchived(WorkspaceEntity workspaceEntity, UserEntity userEntity, Boolean archived) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    Join<WorkspaceUserEntity, UserSchoolDataIdentifier> userIdentifierJoin = root.join(WorkspaceUserEntity_.userSchoolDataIdentifier);
-    
-    criteria.select(root);
-    criteria.where(
-      criteriaBuilder.and(
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
-        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.workspaceEntity), workspaceEntity),
-        criteriaBuilder.equal(userIdentifierJoin.get(UserSchoolDataIdentifier_.userEntity), userEntity)
-      )
-    );
-    
-    return entityManager.createQuery(criteria).getResultList();
-  }
-
   public List<WorkspaceUserEntity> listByUserSchoolDataIdentifierAndActiveAndArchived(UserSchoolDataIdentifier userSchoolDataIdentifier, Boolean active, Boolean archived) {
     EntityManager entityManager = getEntityManager(); 
     
@@ -407,21 +296,6 @@ public class WorkspaceUserEntityDAO extends CoreDAO<WorkspaceUserEntity> {
         criteriaBuilder.equal(root.get(WorkspaceUserEntity_.identifier), identifier),
         criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived)
       )
-    );
-    
-    return getSingleResult(entityManager.createQuery(criteria));
-  }
-
-  public WorkspaceUserEntity findByIdentifierIncludeArchived(String identifier) {
-    EntityManager entityManager = getEntityManager(); 
-    
-    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
-    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
-    
-    criteria.select(root);
-    criteria.where(
-      criteriaBuilder.equal(root.get(WorkspaceUserEntity_.identifier), identifier)
     );
     
     return getSingleResult(entityManager.createQuery(criteria));

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/dao/workspace/WorkspaceUserEntityDAO.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/dao/workspace/WorkspaceUserEntityDAO.java
@@ -90,6 +90,27 @@ public class WorkspaceUserEntityDAO extends CoreDAO<WorkspaceUserEntity> {
     return getSingleResult(entityManager.createQuery(criteria));
   }
 
+
+  public WorkspaceUserEntity findByWorkspaceEntityAndUserSchoolDataIdentifierAndActiveAndArchived(WorkspaceEntity workspaceEntity, UserSchoolDataIdentifier userSchoolDataIdentifier, Boolean active, Boolean archived) {
+    EntityManager entityManager = getEntityManager(); 
+    
+    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<WorkspaceUserEntity> criteria = criteriaBuilder.createQuery(WorkspaceUserEntity.class);
+    Root<WorkspaceUserEntity> root = criteria.from(WorkspaceUserEntity.class);
+    
+    criteria.select(root);
+    criteria.where(
+      criteriaBuilder.and(
+        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.active), active),
+        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.archived), archived),
+        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.userSchoolDataIdentifier), userSchoolDataIdentifier),
+        criteriaBuilder.equal(root.get(WorkspaceUserEntity_.workspaceEntity), workspaceEntity)
+      ) 
+    );
+    
+    return getSingleResult(entityManager.createQuery(criteria));
+  }
+
   public List<WorkspaceUserEntity> listByWorkspaceEntity(WorkspaceEntity workspaceEntity) {
     EntityManager entityManager = getEntityManager(); 
     

--- a/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
+++ b/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
@@ -1347,7 +1347,7 @@ public class UserRESTService extends AbstractRESTService {
           // #3111: Workspace staff members should be limited to teachers only. A better implementation would support specified workspace roles
           
           if (workspaceEntity != null) {
-            WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
+            WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserEntity(workspaceEntity, userEntity);
             if (workspaceUserEntity == null || workspaceUserEntity.getWorkspaceUserRole().getArchetype() != WorkspaceRoleArchetype.TEACHER) {
               continue;
             }


### PR DESCRIPTION
- fixes #3190

Changed all WorkspaceUserEntityController methods that accept a UserEntity to use the default identifier of that user. For example, asking for all workspaces of a user only returns those that are part of their currently active study program.

When a study program of a student is marked as ended in Pyramus, they are automatically removed from active workspaces of that study program only. Earlier implementation would have removed them from every active workspace of their every study program.

Changed workspace permission handling to treat inactive workspace users like they were archived (i.e. permanently deleted). Thus, if a student is removed from a workspace, Muikku will act like they were never even part of it. Naturally they can still sign up for the workspace again, which reactivates the previously inactivated entity.

Renamed most workspace user getters to better indicate that they deal with active workspace users only.