### PR TITLE
Better handling of students having ended their studies

### DIFF
--- a/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
+++ b/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
@@ -164,19 +164,19 @@ public class AcceptanceTestsRESTService extends PluginRESTService {
     
     switch (role) {
       case "ENVIRONMENT-STUDENT":
-        localSessionController.login("PYRAMUS", "STUDENT-1");
+        localSessionController.login("PYRAMUS", "STUDENT-1", true);
       break;
       case "ENVIRONMENT-TEACHER":
-        localSessionController.login("PYRAMUS", "STAFF-2");
+        localSessionController.login("PYRAMUS", "STAFF-2", true);
       break;
       case "ENVIRONMENT-MANAGER":
-        localSessionController.login("PYRAMUS", "STAFF-3");
+        localSessionController.login("PYRAMUS", "STAFF-3", true);
       break;
       case "ENVIRONMENT-ADMINISTRATOR":
-        localSessionController.login("PYRAMUS", "STAFF-4");
+        localSessionController.login("PYRAMUS", "STAFF-4", true);
       break;
       case "ENVIRONMENT-TRUSTED_SYSTEM":
-        localSessionController.login("PYRAMUS", "STAFF-5");
+        localSessionController.login("PYRAMUS", "STAFF-5", true);
       break;
       
       case "PSEUDO-EVERYONE":

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorIndexBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorIndexBackingBean.java
@@ -1,11 +1,14 @@
 package fi.otavanopisto.muikku.plugins.communicator;
 
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.ocpsoft.rewrite.annotation.Join;
 import org.ocpsoft.rewrite.annotation.RequestAction;
 
+import fi.otavanopisto.muikku.jsf.NavigationRules;
+import fi.otavanopisto.muikku.session.SessionController;
 import fi.otavanopisto.security.LoggedIn;
 
 @Named
@@ -14,8 +17,14 @@ import fi.otavanopisto.security.LoggedIn;
 @LoggedIn
 public class CommunicatorIndexBackingBean {
 
+  @Inject
+  private SessionController sessionController;
+
   @RequestAction
   public String init() {
+    if (!sessionController.isActiveUser()) {
+      return NavigationRules.ACCESS_DENIED;
+    }
     return null;
   }
     

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/coursepicker/CoursePickerRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/coursepicker/CoursePickerRESTService.java
@@ -486,7 +486,7 @@ public class CoursePickerRESTService extends PluginRESTService {
   }
   
   private boolean getCanSignup(WorkspaceEntity workspaceEntity) {
-    if (sessionController.isLoggedIn()) {
+    if (sessionController.isLoggedIn() && sessionController.isActiveUser()) {
       WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findActiveWorkspaceUserByWorkspaceEntityAndUserIdentifier(workspaceEntity, sessionController.getLoggedUser());
       return workspaceUserEntity == null && sessionController.hasWorkspacePermission(MuikkuPermissions.WORKSPACE_SIGNUP, workspaceEntity);
     }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/DiscussionBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/forum/DiscussionBackingBean.java
@@ -35,7 +35,7 @@ public class DiscussionBackingBean {
 
   @RequestAction
   public String init() {
-    if (!sessionController.hasEnvironmentPermission(ForumResourcePermissionCollection.FORUM_ACCESSENVIRONMENTFORUM)) {
+    if (!sessionController.hasEnvironmentPermission(ForumResourcePermissionCollection.FORUM_ACCESSENVIRONMENTFORUM) || !sessionController.isActiveUser()) {
       return NavigationRules.ACCESS_DENIED;
     }
     

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
@@ -85,7 +85,7 @@
       </div>
     </section>
     
-    <ui:fragment rendered="#{sessionBackingBean.loggedIn}"> 
+    <ui:fragment rendered="#{sessionBackingBean.loggedIn and sessionBackingBean.isActiveUser}"> 
 	    <section class="flex-row">
 	      <div class="workspace-frontpage-teachers lg-flex-cell-first md-flex-cell-first lg-flex-cell-8 md-flex-cell-8 sm-flex-cell-full sm-flex-order-1">
 	        <h1 class="workspace-block-title">#{i18n.text['plugin.workspace.index.teachersTitle']}</h1>

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/auth/AbstractAuthenticationStrategy.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/auth/AbstractAuthenticationStrategy.java
@@ -183,7 +183,7 @@ public abstract class AbstractAuthenticationStrategy implements AuthenticationPr
       SchoolDataSource schoolDataSource = schoolDataController.findSchoolDataSource(user.getSchoolDataSource());
       userEntityController.updateDefaultSchoolDataSource(userEntity, schoolDataSource);
       userEntityController.updateDefaultIdentifier(userEntity, user.getIdentifier());
-      sessionController.login(schoolDataSource.getIdentifier(), user.getIdentifier());
+      sessionController.login(schoolDataSource.getIdentifier(), user.getIdentifier(), user.getStudyEndDate() == null);
       userEntityController.updateLastLogin(userEntity);
       HttpServletRequest req = (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();
       userLoggedInEvent.fire(new LoginEvent(userEntity.getId(), sessionController.getLoggedUser(), this, req.getRemoteAddr()));

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataWorkspaceListener.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataWorkspaceListener.java
@@ -119,6 +119,13 @@ public class DefaultSchoolDataWorkspaceListener {
             }
             workspaceUserEntityController.unarchiveWorkspaceUserEntity(workspaceUserEntity);
           }
+          
+          // For newly discovered workspace students, always set their activity based on their ongoing studies 
+          
+          if (!workspaceUserEntity.getActive().equals(event.getIsActive())) {
+            workspaceUserEntityController.updateActive(workspaceUserEntity, event.getIsActive());
+          }
+
         } else {
           logger.warning("could not add workspace user because userSchoolDataIdentifier #" + event.getUserIdentifier() + '/' + event.getUserDataSource() +  " could not be found");
         }
@@ -172,6 +179,13 @@ public class DefaultSchoolDataWorkspaceListener {
             }
           }
         }
+
+        // If a student has ended their studies but they are still active in the workspace, change them inactive (but not vice versa)
+        
+        if (!event.getIsActive() && workspaceUserEntity.getActive()) {
+          workspaceUserEntityController.updateActive(workspaceUserEntity, event.getIsActive());
+        }
+        
       } else {
         logger.warning("could not update workspace user because workspace entity #" + event.getWorkspaceIdentifier() + '/' + event.getWorkspaceDataSource() +  " could not be found");
       }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/SchoolDataWorkspaceUserDiscoveredEvent.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/SchoolDataWorkspaceUserDiscoveredEvent.java
@@ -3,7 +3,7 @@ package fi.otavanopisto.muikku.schooldata.events;
 public class SchoolDataWorkspaceUserDiscoveredEvent {
 
   public SchoolDataWorkspaceUserDiscoveredEvent(String dataSource, String identifier, String workspaceDataSource, String workspaceIdentifier,
-      String userDataSource, String userIdentifier, String roleDataSource, String roleIdentifier) {
+      String userDataSource, String userIdentifier, String roleDataSource, String roleIdentifier, Boolean isActive) {
     super();
     this.dataSource = dataSource;
     this.identifier = identifier;
@@ -13,6 +13,7 @@ public class SchoolDataWorkspaceUserDiscoveredEvent {
     this.userIdentifier = userIdentifier;
     this.roleDataSource = roleDataSource;
     this.roleIdentifier = roleIdentifier;
+    this.isActive = isActive;
   }
 
   public String getDataSource() {
@@ -54,6 +55,10 @@ public class SchoolDataWorkspaceUserDiscoveredEvent {
   public Long getDiscoveredWorkspaceUserEntityId() {
     return discoveredWorkspaceUserEntityId;
   }
+
+  public Boolean getIsActive() {
+    return isActive;
+  }
   
   private String dataSource;
   private String identifier;
@@ -64,4 +69,5 @@ public class SchoolDataWorkspaceUserDiscoveredEvent {
   private String roleDataSource;
   private String roleIdentifier;
   private Long discoveredWorkspaceUserEntityId;
+  private Boolean isActive;
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/SchoolDataWorkspaceUserUpdatedEvent.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/SchoolDataWorkspaceUserUpdatedEvent.java
@@ -3,7 +3,7 @@ package fi.otavanopisto.muikku.schooldata.events;
 public class SchoolDataWorkspaceUserUpdatedEvent {
 
   public SchoolDataWorkspaceUserUpdatedEvent(String dataSource, String identifier, String workspaceDataSource, String workspaceIdentifier,
-      String userDataSource, String userIdentifier, String roleDataSource, String roleIdentifier) {
+      String userDataSource, String userIdentifier, String roleDataSource, String roleIdentifier, Boolean isActive) {
     super();
     this.dataSource = dataSource;
     this.identifier = identifier;
@@ -13,6 +13,7 @@ public class SchoolDataWorkspaceUserUpdatedEvent {
     this.userIdentifier = userIdentifier;
     this.roleDataSource = roleDataSource;
     this.roleIdentifier = roleIdentifier;
+    this.isActive = isActive;
   }
 
   public String getDataSource() {
@@ -46,6 +47,10 @@ public class SchoolDataWorkspaceUserUpdatedEvent {
   public String getRoleIdentifier() {
     return roleIdentifier;
   }
+
+  public Boolean getIsActive() {
+    return isActive;
+  }
   
   private String dataSource;
   private String identifier;
@@ -55,4 +60,5 @@ public class SchoolDataWorkspaceUserUpdatedEvent {
   private String userIdentifier;
   private String roleDataSource;
   private String roleIdentifier;
+  private Boolean isActive;
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/session/RestSessionControllerImpl.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/session/RestSessionControllerImpl.java
@@ -99,13 +99,20 @@ public class RestSessionControllerImpl extends AbstractSessionController impleme
   }
   
   @Override
-  public void login(String dataSource, String identifier) {
+  public void login(String dataSource, String identifier, boolean isActive) {
     this.activeUserIdentifier = identifier;
     this.activeUserSchoolDataSource = dataSource;
+    this.isActive = isActive;
+  }
+
+  @Override
+  public boolean isActiveUser() {
+    return isActive;
   }
   
   private RestAuthentication authentication;
   private String activeUserIdentifier;
   private String activeUserSchoolDataSource;
+  private boolean isActive;
   private Map<String, AccessToken> accessTokens = Collections.synchronizedMap(new HashMap<String, AccessToken>());
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/session/SessionController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/session/SessionController.java
@@ -49,8 +49,9 @@ public interface SessionController {
    * 
    * @param dataSource user data source
    * @param identifier user identifier
+   * @param isActive is the user active (e.g. not having ended studies)
    */
-  public void login(String dataSource, String identifier);
+  public void login(String dataSource, String identifier, boolean isActive);
   
   boolean hasPermission(String permission, ContextReference contextReference);
   
@@ -102,4 +103,11 @@ public interface SessionController {
   public SchoolDataIdentifier getLoggedUser();
   
   public UserEntity getLoggedUserEntity();
+  
+  /**
+   * Returns whether the logged in user is active, e.g. staff or a student whose studies have not yet ended.
+   * 
+   * @return <code>true</code> if the logged in user is active, otherwise <code>false</code>
+   */
+  public boolean isActiveUser();
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/session/SessionControllerDelegateImpl.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/session/SessionControllerDelegateImpl.java
@@ -106,8 +106,13 @@ public class SessionControllerDelegateImpl implements SessionControllerDelegate 
   }
   
   @Override
-  public void login(String dataSource, String identifier) {
-    implementation.login(dataSource, identifier);
+  public void login(String dataSource, String identifier, boolean isActive) {
+    implementation.login(dataSource, identifier, isActive);
+  }
+  
+  @Override
+  public boolean isActiveUser() {
+    return implementation.isActiveUser();
   }
   
   private SessionController implementation;

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/session/local/LocalSessionControllerImpl.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/session/local/LocalSessionControllerImpl.java
@@ -183,9 +183,15 @@ public class LocalSessionControllerImpl extends AbstractSessionController implem
   }
 
   @Override
-  public void login(String dataSource, String identifier) {
+  public void login(String dataSource, String identifier, boolean isActive) {
     this.activeUserIdentifier = identifier;
     this.activeUserSchoolDataSource = dataSource;
+    this.isActive = isActive;
+  }
+  
+  @Override
+  public boolean isActiveUser() {
+    return isActive;
   }
 
   private Long representedUserId;
@@ -193,6 +199,8 @@ public class LocalSessionControllerImpl extends AbstractSessionController implem
   private String activeUserIdentifier;
   
   private String activeUserSchoolDataSource;
+  
+  private boolean isActive;
   
   private Map<String, AccessToken> accessTokens;
 }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
@@ -657,6 +657,8 @@ public class PyramusUpdater {
     int count = 0;
     Long courseId = identifierMapper.getPyramusCourseId(workspaceEntity.getIdentifier());
 
+    // Synchronize active students of a course
+    
     CourseStudent[] courseStudents = pyramusClient.get().get("/courses/courses/" + courseId + "/students?filterArchived=false&activeStudents=true", CourseStudent[].class);
     if (courseStudents != null) {
       for (CourseStudent courseStudent : courseStudents) {
@@ -673,9 +675,14 @@ public class PyramusUpdater {
             fireCourseStudentDiscovered(courseStudent, true);
             count++;
           }
+          else {
+            fireCourseStudentUpdated(courseStudent, true);
+          }
         }
       }
     }
+
+    // Synchronize inactive students of a course
     
     CourseStudent[] nonActiveCourseStudents = pyramusClient.get().get("/courses/courses/" + courseId + "/students?filterArchived=false&activeStudents=false", CourseStudent[].class);
     if (nonActiveCourseStudents != null) {
@@ -691,6 +698,10 @@ public class PyramusUpdater {
             fireCourseStudentUpdated(nonActiveCourseStudent, false);
             count++;
           }
+        }
+        else {
+          fireCourseStudentDiscovered(nonActiveCourseStudent, false);
+          count++;
         }
       }
     }

--- a/muikku/src/main/java/fi/otavanopisto/muikku/session/SessionBackingBean.java
+++ b/muikku/src/main/java/fi/otavanopisto/muikku/session/SessionBackingBean.java
@@ -94,6 +94,10 @@ public class SessionBackingBean {
   public boolean getIsStudent() {
     return loggedUserRoleArchetype != null && loggedUserRoleArchetype.equals(EnvironmentRoleArchetype.STUDENT); 
   }
+  
+  public boolean getIsActiveUser() {
+    return sessionController.isActiveUser();
+  }
 
   public Long getLoggedUserId() {
     return loggedUserId;

--- a/muikku/src/main/webapp/WEB-INF/templates/flex-main-env.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/flex-main-env.xhtml
@@ -86,14 +86,14 @@
           </a>
         </div>
         <!-- COMMUNICATOR -->
-        <ui:fragment rendered="#{sessionBackingBean.loggedIn}">
+        <ui:fragment rendered="#{sessionBackingBean.loggedIn and sessionBackingBean.isActiveUser}">
           <div class="dock-static-navi-button-communicator #{activeTrail eq 'communicator' ? 'active-trail' : ''}" title="#{i18n.text['plugin.communicator.communicator']}">
             <a jsf:outcome="/jsf/communicator/index.jsf" class="icon-envelope">
               <span style="display:none" class="dock-notification"></span>
             </a>
           </div>
           <!-- DISCUSSION -->
-          <ui:fragment rendered="#{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM')}">
+          <ui:fragment rendered="#{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM') and sessionBackingBean.isActiveUser}">
             <div class="dock-static-navi-button-discussion sm-flex-hide #{activeTrail eq 'discussion' ? 'active-trail' : ''}" title="#{i18n.text['plugin.forum.forum']}">
               <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble">
                 <span style="display:none" class="dock-notification"></span>
@@ -140,9 +140,11 @@
             <div class="icon-navicon">
               <div class="navmore-container">
                 <!-- DISCUSSION -->
-                <div class="dock-static-navi-button-discussion lg-flex-hide md-flex-hide">
-                  <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble"><span>#{i18n.text['plugin.forum.forum']}</span></a>
-                </div>
+                <ui:fragment rendered="{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM') and sessionBackingBean.isActiveUser}">
+                  <div class="dock-static-navi-button-discussion lg-flex-hide md-flex-hide">
+                    <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble"><span>#{i18n.text['plugin.forum.forum']}</span></a>
+                  </div>
+                </ui:fragment>
                 <!-- EVALUATION -->
                 <ui:fragment rendered="#{sessionBackingBean.hasEnvironmentPermission('EVALUATION_VIEW_INDEX')}">
                   <div class="dock-static-navi-button-evaluation lg-flex-hide md-flex-hide">

--- a/muikku/src/main/webapp/WEB-INF/templates/flex-main-workspace.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/flex-main-workspace.xhtml
@@ -30,14 +30,14 @@
           </a>
         </div>
         <!-- COMMUNICATOR -->
-        <ui:fragment rendered="#{sessionBackingBean.loggedIn}">
+        <ui:fragment rendered="#{sessionBackingBean.loggedIn and sessionBackingBean.isActiveUser}">
           <div class="dock-static-navi-button-communicator #{activeTrail eq 'communicator' ? 'active-trail' : ''}" title="#{i18n.text['plugin.communicator.communicator']}">
             <a jsf:outcome="/jsf/communicator/index.jsf" class="icon-envelope">
               <span style="display:none" class="dock-notification"></span>
             </a>
           </div>
           <!-- DISCUSSION -->
-          <ui:fragment rendered="#{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM')}">
+          <ui:fragment rendered="#{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM') and sessionBackingBean.isActiveUser}">
             <div class="dock-static-navi-button-discussion sm-flex-hide #{activeTrail eq 'discussion' ? 'active-trail' : ''}" title="#{i18n.text['plugin.forum.forum']}">
               <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble">
                 <span style="display:none" class="dock-notification"></span>
@@ -104,9 +104,11 @@
             <div class="icon-navicon">
               <div class="navmore-container">
                 <!-- DISCUSSION -->
-                <div class="dock-static-navi-button-discussion lg-flex-hide md-flex-hide">
-                  <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble"><span>#{i18n.text['plugin.forum.forum']}</span></a>
-                </div>
+                <ui:fragment rendered="{sessionBackingBean.hasEnvironmentPermission('FORUM_ACCESSENVIRONMENTFORUM') and sessionBackingBean.isActiveUser}">
+                  <div class="dock-static-navi-button-discussion lg-flex-hide md-flex-hide">
+                    <a jsf:outcome="/jsf/discussion/index.jsf" class="icon-bubble"><span>#{i18n.text['plugin.forum.forum']}</span></a>
+                  </div>
+                </ui:fragment>
                 <!-- EVALUATION -->
                 <ui:fragment rendered="#{sessionBackingBean.hasWorkspacePermission('EVALUATION_VIEW_INDEX')}">
                   <div class="dock-static-navi-button-evaluation lg-flex-hide md-flex-hide">

--- a/muikku/src/main/webapp/index.xhtml
+++ b/muikku/src/main/webapp/index.xhtml
@@ -198,7 +198,7 @@
     </ui:fragment>
     
     <!--  If user is authenticated -->
-    <ui:fragment rendered="#{sessionBackingBean.loggedIn}">
+    <ui:fragment rendered="#{sessionBackingBean.loggedIn and sessionBackingBean.isActiveUser}">
 	    <ui:fragment rendered="#{sessionBackingBean.isStudent}">
 	      <div class="flex-row">
 		      <div class="lg-flex-cell-16 md-flex-cell-16 sm-flex-cell-full md-flex-order-1 sm-flex-order-1">

--- a/muikku/src/main/webapp/index_nonbranded.xhtml
+++ b/muikku/src/main/webapp/index_nonbranded.xhtml
@@ -96,16 +96,16 @@
         </div>
       </ui:fragment>
       
-      <ui:fragment rendered="#{sessionBackingBean.loggedIn}">
-      <ui:fragment rendered="#{sessionBackingBean.isStudent}">
-        <div class="flex-row">
-          <div class="lg-flex-cell-16 md-flex-cell-16 sm-flex-cell-full md-flex-order-1 sm-flex-order-1">
-            <div id="last-workspace">
-            
+      <ui:fragment rendered="#{sessionBackingBean.loggedIn and sessionBackingBean.isActiveUser}">
+        <ui:fragment rendered="#{sessionBackingBean.isStudent}">
+          <div class="flex-row">
+            <div class="lg-flex-cell-16 md-flex-cell-16 sm-flex-cell-full md-flex-order-1 sm-flex-order-1">
+              <div id="last-workspace">
+              
+              </div>
             </div>
           </div>
-        </div>
-      </ui:fragment>
+        </ui:fragment>
       
         <div class="lg-flex-cell12-4 md-flex-cell-8 sm-flex-cell-full lg-flex-cell-first md-flex-order-3 sm-flex-order-3">
           <div class="box box-max-width">


### PR DESCRIPTION
- resolves #3103

Refactored the code for students who have ended their studies. They now only have access to profile, course picker (with no signup), and transcript of records. Workspaces, messages, and announcements have been removed from the environment front page. Teachers and announcements have been removed from workspaces' front pages.

Refactored synchronizing of Pyramus course students so that all of them (except archived ones) also exist in Muikku. Only students who have not yet ended their studies will have their active flag set. This should ensure that everyone's transcript of records show the exact same courses as can be seen in Pyramus.
