### PR TITLE
Ftr 3179 communicator slowness

### DIFF
--- a/updates/1.076/170601-communicator_index.xml
+++ b/updates/1.076/170601-communicator_index.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<update xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ofw.fi/xml/2011/java-xmldb-updater/UpdaterSchema.xsd">
+
+  <sql>create index ind_cmrecipient_id_tra_arc on CommunicatorMessageRecipient (recipient_id, trashedByReceiver, archivedByReceiver);</sql>
+
+</update>


### PR DESCRIPTION
Closes #3179 

This index helps with listing the threads in the users' inbox. Trash box is still a problem as it can't be covered by an index due to more complex table joins and JPA restrictions on unions. Separate issue on that.