### PR TITLE
Proper sending and canceling of evaluation requests

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestController.java
@@ -119,7 +119,15 @@ public class AssessmentRequestController {
     }
     else if (latestRequest != null && (latestAssessment == null || latestAssessment.getDate().before(latestRequest.getDate()))) {
       // Has request and no assessment, or the assessment is older
-      return WorkspaceAssessmentState.PENDING;
+      if (latestAssessment == null) {
+        return WorkspaceAssessmentState.PENDING;
+      }
+      else if (latestAssessment.getPassing()) {
+        return WorkspaceAssessmentState.PENDING_PASS;
+      }
+      else {
+        return WorkspaceAssessmentState.PENDING_FAIL;
+      }
     }
     else {
       // Has neither assessment nor request

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestState.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestState.java
@@ -1,8 +1,0 @@
-package fi.otavanopisto.muikku.plugins.assessmentrequest;
-
-public enum AssessmentRequestState {
-  PENDING,
-  CANCELED,
-  PASS,
-  FAIL
-}

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/WorkspaceAssessmentState.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/WorkspaceAssessmentState.java
@@ -1,11 +1,12 @@
 package fi.otavanopisto.muikku.plugins.assessmentrequest;
 
 public enum WorkspaceAssessmentState {
-  UNASSESSED("unassessed"),
-  PENDING("pending"),
-  CANCELED("canceled"),
-  PASS("pass"),
-  FAIL("fail");
+  UNASSESSED("unassessed"),                // no request, no grade
+  PENDING("pending"),                      // active request, no grade
+  PENDING_PASS("pending_pass"),            // active request, earlier passing grade
+  PENDING_FAIL("pending_fail"),            // active request, earlier failing grade
+  PASS("pass"),                            // no request, passing grade
+  FAIL("fail");                            // no request, failing grade
   
   private WorkspaceAssessmentState(String stateName) {
     this.stateName = stateName;
@@ -13,21 +14,6 @@ public enum WorkspaceAssessmentState {
   
   public String getStateName() {
     return stateName;
-  }
-  
-  public static WorkspaceAssessmentState fromAssessmentRequestState(AssessmentRequestState state) {
-    switch (state) {
-    case PENDING:
-      return PENDING;
-    case CANCELED:
-      return CANCELED;
-    case PASS:
-      return PASS;
-    case FAIL:
-      return FAIL;
-    default:
-      throw new NullPointerException("Assessment request state must not be null");
-    }
   }
   
   private String stateName;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/dust/guider/guider_profile_workspaces.dust
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/dust/guider/guider_profile_workspaces.dust
@@ -24,8 +24,9 @@
           <label>{#localize key="plugin.guider.assessmentStateLabel"/}</label>
           <span>
             {@select key=activity.assessmentState}
-              {@eq value="CANCELED"}{#localize key="plugin.guider.assessmentState.CANCELED"/}{/eq}
               {@eq value="PENDING"}{#localize key="plugin.guider.assessmentState.PENDING"/}{/eq}
+              {@eq value="PENDING_PASS"}{#localize key="plugin.guider.assessmentState.PENDING"/}{/eq}
+              {@eq value="PENDING_FAIL"}{#localize key="plugin.guider.assessmentState.PENDING"/}{/eq}
               {@eq value="PASS"}{#localize key="plugin.guider.assessmentState.PASS"/}{/eq}
               {@eq value="FAIL"}{#localize key="plugin.guider.assessmentState.FAIL"/}{/eq}
               {@none}{#localize key="plugin.guider.assessmentState.UNASSESSED"/}{/none}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/widgets/dock-workspaces-assessment.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/widgets/dock-workspaces-assessment.xhtml
@@ -5,36 +5,25 @@
   <div class="widget wi-workspace-dock-navi-button-evaluation" data-state="#{workspaceBackingBean.assessmentState}">
   
     <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'unassessed'}">
-      <a class="icon-assessment-#{workspaceBackingBean.assessmentState} w-tooltip" 
-           title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
+      <a class="icon-assessment-unassessed w-tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
         <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
       </a>   
     </ui:fragment>
     
-    <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending'}">
-      <a class="icon-assessment-#{workspaceBackingBean.assessmentState} w-tooltip" 
-           title="#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}">
+    <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending' or workspaceBackingBean.assessmentState eq 'pending_pass' or workspaceBackingBean.assessmentState eq 'pending_fail'}">
+      <a class="icon-assessment-pending w-tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}">
         <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}</span>
       </a>   
     </ui:fragment>
     
-    <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'canceled'}">
-      <a class="icon-assessment-#{workspaceBackingBean.assessmentState} w-tooltip" 
-           title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
-        <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
-      </a>   
-    </ui:fragment>
-    
     <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pass'}">
-      <a class="icon-assessment-#{workspaceBackingBean.assessmentState} w-tooltip" 
-           title="#{i18n.text['plugin.workspace.dock.evaluation.viewEvaluationButtonTooltip']}">
-        <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
+      <a class="icon-assessment-pass w-tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
+        <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}</span>
       </a>   
     </ui:fragment>
     
     <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'fail'}">
-      <a class="icon-assessment-#{workspaceBackingBean.assessmentState} w-tooltip" 
-           title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
+      <a class="icon-assessment-fail w-tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
         <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}</span>
       </a>   
     </ui:fragment>

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/guider/GuiderJsPluginMessages_en.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/guider/GuiderJsPluginMessages_en.properties
@@ -78,7 +78,6 @@ plugin.guider.assessmentStateTitle = Assessment
 plugin.guider.assessmentStateLabel = Assessment
 plugin.guider.assessmentState.UNASSESSED = Assessment request not sent
 plugin.guider.assessmentState.PENDING = Assessment request has been sent
-plugin.guider.assessmentState.CANCELED = Assessment request has been cancelled
 plugin.guider.assessmentState.PASS = Assessed with a passing grade
 plugin.guider.assessmentState.FAIL = Assessed with a non-passing grade
 

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/guider/GuiderJsPluginMessages_fi.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/guider/GuiderJsPluginMessages_fi.properties
@@ -79,6 +79,5 @@ plugin.guider.assessmentStateTitle = Arvioinnin tila
 plugin.guider.assessmentStateLabel = Arvioinnin tila
 plugin.guider.assessmentState.UNASSESSED = Arviointipyyntöä ei lähetetty
 plugin.guider.assessmentState.PENDING = Arviointipyyntö lähetetty
-plugin.guider.assessmentState.CANCELED = Arviointipyyntö peruutettu
 plugin.guider.assessmentState.PASS = Arvioitu - hyväksytty
 plugin.guider.assessmentState.FAIL = Arvioitu - hylätty

--- a/muikku/src/main/webapp/WEB-INF/templates/flex-main-workspace.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/flex-main-workspace.xhtml
@@ -149,32 +149,22 @@
             <div id="workspaceEvaluationDock">
               <div class="workspace-dock-navi-button-evaluation" data-state="#{workspaceBackingBean.assessmentState}">
                 <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'unassessed'}">
-                  <a class="icon-assessment-#{workspaceBackingBean.assessmentState} tooltip" 
-                       title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
+                  <a class="icon-assessment-unassessed tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
                     <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
                   </a>   
                 </ui:fragment>
-                <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending'}">
-                  <a class="icon-assessment-#{workspaceBackingBean.assessmentState} tooltip" 
-                       title="#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}">
+                <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending' or workspaceBackingBean.assessmentState eq 'pending_pass' or workspaceBackingBean.assessmentState eq 'pending_fail'}">
+                  <a class="icon-assessment-pending tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}">
                     <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}</span>
                   </a>   
                 </ui:fragment>
-                <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'canceled'}">
-                  <a class="icon-assessment-#{workspaceBackingBean.assessmentState} tooltip" 
-                       title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
-                    <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
-                  </a>   
-                </ui:fragment>
                 <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pass'}">
-                  <a class="icon-assessment-#{workspaceBackingBean.assessmentState} tooltip" 
-                       title="#{i18n.text['plugin.workspace.dock.evaluation.viewEvaluationButtonTooltip']}">
-                    <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
+                  <a class="icon-assessment-pass tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
+                    <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}</span>
                   </a>   
                 </ui:fragment>
                 <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'fail'}">
-                  <a class="icon-assessment-#{workspaceBackingBean.assessmentState} tooltip" 
-                       title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
+                  <a class="icon-assessment-fail tooltip" title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
                     <span class="workspace-navi-tt-container-evaluation">#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}</span>
                   </a>   
                 </ui:fragment>
@@ -320,22 +310,16 @@
                       <span class="workspace-evaluation-item-label">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
                     </a>   
                   </ui:fragment>
-                  <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending'}">
+                  <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pending' or workspaceBackingBean.assessmentState eq 'pending_pass' or workspaceBackingBean.assessmentState eq 'pending_fail'}">
                     <a class="icon-assessment-#{workspaceBackingBean.assessmentState}" 
                          title="#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}">
                       <span class="workspace-evaluation-item-label">#{i18n.text['plugin.workspace.dock.evaluation.cancelEvaluationButtonTooltip']}</span>
                     </a>   
                   </ui:fragment>
-                  <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'canceled'}">
-                    <a class="icon-assessment-#{workspaceBackingBean.assessmentState}" 
-                         title="#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}">
-                      <span class="workspace-evaluation-item-label">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
-                    </a>   
-                  </ui:fragment>
                   <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'pass'}">
                     <a class="icon-assessment-#{workspaceBackingBean.assessmentState}" 
-                         title="#{i18n.text['plugin.workspace.dock.evaluation.viewEvaluationButtonTooltip']}">
-                      <span class="workspace-evaluation-item-label">#{i18n.text['plugin.workspace.dock.evaluation.requestEvaluationButtonTooltip']}</span>
+                         title="#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}">
+                      <span class="workspace-evaluation-item-label">#{i18n.text['plugin.workspace.dock.evaluation.resendRequestEvaluationButtonTooltip']}</span>
                     </a>   
                   </ui:fragment>
                   <ui:fragment rendered="#{workspaceBackingBean.assessmentState eq 'fail'}">

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/_workspaces.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/_workspaces.scss
@@ -179,7 +179,9 @@ body[class^='workspace'] {
       
     }
     
-    &[data-state='pending'] { /* Evaluation Request Pending */
+    &[data-state='pending'],
+    &[data-state='pending_pass'],
+    &[data-state='pending_fail'] { /* Evaluation Request Pending */
       background:#0099ff; 
       transition: background 0.2s ease-in-out;
 
@@ -216,35 +218,7 @@ body[class^='workspace'] {
       }
       
     }
-    
-    &[data-state='cancel'] { /* Evaluation Request Cancelled */
-      background:#f6a930; /* Same as Default at this point */
-      
-      a:hover {
-        background:#e5961b;
-        
-        span[class*='workspace-navi-tt-container-'] {
-          background:#e5961b;
-        }
-        
-      }
-      
-    }
-    
-    &[data-state='canceled'] { /* Evaluation Request Cancelled */
-      background:#55bbff; /* Same as Default at this point */
-      
-      a:hover {
-        background:#509ccf;
-        
-        span[class*='workspace-navi-tt-container-'] {
-          background:#509ccf;
-        }
-        
-      }
-      
-    }
-    
+
     &[data-state='pass'] { /* Evaluation of Workspace - Pass */
       background:#1ec30c;
       

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace_navigation_wide.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace_navigation_wide.scss
@@ -39,7 +39,9 @@
   }
   
   // Evaluation Request Pending
-  &[data-state='pending'] { 
+  &[data-state='pending'],
+  &[data-state='pending_pass'],
+  &[data-state='pending_fail'] { 
     background: #0099ff; 
     transition: background 0.2s ease-in-out;
 
@@ -74,36 +76,6 @@
 
       }
 
-    }
-    
-  }
-  
-  // Evaluation Request Cancelled
-  &[data-state='cancel'] { 
-    background: #f6a930;
-    
-    a:hover {
-      background: #e5961b;
-      
-      span[class*='workspace-navi-tt-container-'] {
-        background: #e5961b;
-      }
-      
-    }
-    
-  }
-  
-  // Evaluation Request Cancelled
-  &[data-state='canceled'] { 
-    background: #55bbff;
-    
-    a:hover {
-      background: #509ccf;
-      
-      span[class*='workspace-navi-tt-container-'] {
-        background: #509ccf;
-      }
-      
     }
     
   }


### PR DESCRIPTION
- fixes #3224

Method to cancel an evaluation request was there but never called. I added the missing pieces.

While at it, I also removed the "evaluation request canceled" state, because it had no real value and wasn't ever fully implemented either. If an evaluation request is canceled, the resulting workspace state is once again either unassessed or graded.

Furthermore, I also added two new states to indicate a pending evaluation request when the workspace has been graded before. This way, canceling an evaluation request will correctly revert to the previous state of unassessed, passed, or failed.

I also removed the obsolete AssessmentRequestState class, which has been replaced by WorkspaceAssessmentRequestState at some point.