### PR TITLE
Select field explanations + fix for broken field border colors

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/fieldmeta/MultiSelectFieldMeta.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/fieldmeta/MultiSelectFieldMeta.java
@@ -10,10 +10,11 @@ public class MultiSelectFieldMeta extends FieldMeta {
 
   }
 
-  public MultiSelectFieldMeta(String name, String listType, List<MultiSelectFieldOptionMeta> options) {
+  public MultiSelectFieldMeta(String name, String listType, List<MultiSelectFieldOptionMeta> options, String explanation) {
     super(name);
     this.listType = listType;
-    this.setOptions(options);
+    this.options = options;
+    this.explanation = explanation;
   }
 
   public List<MultiSelectFieldOptionMeta> getOptions() {
@@ -38,6 +39,15 @@ public class MultiSelectFieldMeta extends FieldMeta {
     this.listType = listType;
   }
 
+  public String getExplanation() {
+    return explanation;
+  }
+
+  public void setExplanation(String explanation) {
+    this.explanation = explanation;
+  }
+
   private List<MultiSelectFieldOptionMeta> options;
   private String listType; // checkbox-vertical | checkbox-horizontal
+  private String explanation;
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/fieldmeta/SelectFieldMeta.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/fieldmeta/SelectFieldMeta.java
@@ -6,23 +6,15 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 
 public class SelectFieldMeta extends FieldMeta {
   
-  // TODO Assess the need for size
-  
   public SelectFieldMeta() {
     
   }
 
-//  public SelectFieldMeta(String name, String listType, Integer size, List<SelectFieldOptionMeta> selectFieldOptionMetas) {
-//    super(name);
-//    this.setOptions(selectFieldOptionMetas);
-//    this.setListType(listType);
-//    this.setSize(size);
-//  }
-
-  public SelectFieldMeta(String name, String listType, List<SelectFieldOptionMeta> selectFieldOptionMetas) {
+  public SelectFieldMeta(String name, String listType, List<SelectFieldOptionMeta> selectFieldOptionMetas, String explanation) {
     super(name);
-    this.setOptions(selectFieldOptionMetas);
-    this.setListType(listType);
+    this.selectFieldOptionMetas = selectFieldOptionMetas;
+    this.listType = listType;
+    this.explanation = explanation;
   }
   
   public List<SelectFieldOptionMeta> getOptions() {
@@ -46,16 +38,17 @@ public class SelectFieldMeta extends FieldMeta {
   public void setListType(String listType) {
     this.listType = listType;
   }
-
-//  public Integer getSize() {
-//    return size;
-//  }
-//  
-//  public void setSize(Integer size) {
-//    this.size = size;
-//  }
   
+  public String getExplanation() {
+    return explanation;
+  }
+
+  public void setExplanation(String explanation) {
+    this.explanation = explanation;
+  }
+
   private List<SelectFieldOptionMeta> selectFieldOptionMetas;
   private String listType; // dropdown | list | radio-horizontal | radio-vertical
-//  private Integer size;
+  private String explanation;
+
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/dust/workspace/materials-management-new.dust
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/dust/workspace/materials-management-new.dust
@@ -1,4 +1,4 @@
-<section class="workspace-materials-view-page material-management-view workspace-materials-management-new lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
+<section class="material-page material-management-view workspace-materials-management-new lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
   <a href="javascript:void(null)" data-material-type="html" class="workspace-materials-management-new-page-link icon-new-page">{#localize key="plugin.workspace.materialsManagement.newDocument"/}</a>
   {?clipboardItem}<span class="clipboard-material-container"><a href="javascript:void(null)" class="workspace-materials-management-paste-page-link icon-content_paste">{#localize key="plugin.workspace.materialsManagement.pasteDocument"/}</a><a href="javascript:void(null)" class="workspace-materials-management-clear-clipboard-link icon-delete"></a></span>{/clipboardItem}
   <a href="javascript:void(null)" data-material-type="html" class="workspace-materials-management-new-section-link icon-new-section">{#localize key="plugin.workspace.materialsManagement.newSection"/}</a>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/frontpage-management.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/frontpage-management.xhtml
@@ -60,7 +60,7 @@
             data-material-type="#{node.type}"
             data-path="#{node.path}"
             data-material-title="#{node.title}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
     
           <ui:repeat var="articleNode" value="#{node.children}">
             <ui:fragment rendered="#{articleNode.type eq 'folder'}">
@@ -72,7 +72,7 @@
                 data-path="#{articleNode.path}"
                 data-material-title="#{articleNode.title}"
                 data-assignment-type="#{articleNode.assignmentType}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
             </ui:fragment>
     
             <ui:fragment rendered="#{articleNode.type ne 'folder'}">
@@ -87,7 +87,7 @@
                 data-material-current-revision="#{articleNode.currentRevision}"
                 data-material-published-revision="#{articleNode.publishedRevision}"
                 data-assignment-type="#{articleNode.assignmentType}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
             </ui:fragment>
           </ui:repeat>
         </ui:fragment>
@@ -104,7 +104,7 @@
             data-material-current-revision="#{node.currentRevision}"
             data-material-published-revision="#{node.publishedRevision}"
             data-assignment-type="#{node.assignmentType}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
         </ui:fragment>
       </ui:repeat>
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/help.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/help.xhtml
@@ -31,7 +31,7 @@
           data-material-title="#{contentNode.title}"
           data-material-content="#{contentNode.html}"
           data-path="#{contentNode.path}"
-          class="workspace-materials-view-page material-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full no-margin-top" />
+          class="materials-page material-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full no-margin-top" />
       </ui:repeat>
       <input class="workspaceEntityId" type="hidden" value="#{workspaceHelpPageBackingBean.workspaceEntityId}" />
       <input class="materialsBaseUrl" type="hidden" value="#{workspaceHelpPageBackingBean.materialsBaseUrl}"/>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/helppage-management.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/helppage-management.xhtml
@@ -60,7 +60,7 @@
             data-material-type="#{node.type}"
             data-path="#{node.path}"
             data-material-title="#{node.title}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
   
           <ui:repeat var="articleNode" value="#{node.children}">
             <ui:fragment rendered="#{articleNode.type eq 'folder'}">
@@ -72,7 +72,7 @@
                 data-path="#{articleNode.path}"
                 data-material-title="#{articleNode.title}"
                 data-assignment-type="#{articleNode.assignmentType}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
             </ui:fragment>
   
             <ui:fragment rendered="#{articleNode.type ne 'folder'}">
@@ -87,7 +87,7 @@
                 data-material-current-revision="#{articleNode.currentRevision}"
                 data-material-published-revision="#{articleNode.publishedRevision}"
                 data-assignment-type="#{articleNode.assignmentType}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
             </ui:fragment>
   
           </ui:repeat>
@@ -105,7 +105,7 @@
             data-material-current-revision="#{node.currentRevision}"
             data-material-published-revision="#{node.publishedRevision}"
             data-assignment-type="#{node.assignmentType}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
         </ui:fragment>
       </ui:repeat>
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-management.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-management.xhtml
@@ -125,7 +125,7 @@
             data-material-title="#{node.title}"
             data-path="#{node.path}"
             data-view-restrict="#{node.viewRestrict}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{node.hidden ? 'item-hidden' : ''}"></section>
   
           <div class="workspace-materials-management-add lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
             <span class="workspace-materials-management-line-separator"></span><a  class="workspaces-materials-management-add icon-add" href="javascript:void(null)"><span>#{i18n.text['plugin.workspace.materialsManagement.add']}</span></a>
@@ -144,7 +144,7 @@
                 data-material-title="#{articleNode.title}"
                 data-path="#{articleNode.path}"
                 data-view-restrict="#{articleNode.viewRestrict}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view folder #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}"></h2>
             </ui:fragment>
   
             <ui:fragment rendered="#{articleNode.type ne 'folder'}">
@@ -161,7 +161,7 @@
                 data-assignment-type="#{articleNode.assignmentType}"
                 data-correct-answers="#{articleNode.correctAnswers eq null ? 'ALWAYS' : articleNode.correctAnswers}"
                 data-view-restrict="#{articleNode.viewRestrict}"
-                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
+                class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{articleNode.hidden ? 'item-hidden' : ''} #{node.hidden ? 'parent-hidden' : ''}" />
             </ui:fragment>
   
             <div class="workspace-materials-management-add lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
@@ -186,7 +186,7 @@
             data-assignment-type="#{node.assignmentType}"
             data-correct-answers="#{articleNode.correctAnswers eq null ? 'ALWAYS' : articleNode.correctAnswers}"
             data-view-restrict="#{articleNode.viewRestrict}"
-            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full workspace-materials-view-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
+            class="lg-flex-cell-full md-flex-cell-full sm-flex-cell-full material-page material-management-view #{node.hidden ? 'item-hidden' : ''}" />
           <div class="workspace-materials-management-add lg-flex-cell-full md-flex-cell-full sm-flex-cell-full">
             <span class="workspace-materials-management-line-separator"></span><a class="workspaces-materials-management-add icon-add" href="javascript:void(null)"><span>#{i18n.text['plugin.workspace.materialsManagement.add']}</span></a>
           </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
@@ -114,7 +114,7 @@
           </div>  
           <ui:repeat var="node" value="#{workspaceMaterialsReadingBackingBean.contentNodes}">
             <ui:fragment rendered="#{node.type eq 'folder'}">
-              <section id="page-#{node.workspaceMaterialId}" class="workspace-materials-view-page-section material-reading-view" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-path="#{node.path}" data-view-restricted="#{node.viewRestricted}">
+              <section id="page-#{node.workspaceMaterialId}" class="material-page material-reading-view" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-path="#{node.path}" data-view-restricted="#{node.viewRestricted}">
                 <h2>#{node.title}</h2>
                 <ui:fragment rendered="#{node.viewRestricted eq true}">
                   <p class="content-view-restricted-message">#{i18n.text['plugin.workspace.sectionViewRestricted']}</p>
@@ -136,7 +136,7 @@
                       </ui:fragment>
                     </ui:fragment>
                     <ui:fragment rendered="#{articleNode.type ne 'folder'}">
-                      <article id="page-#{articleNode.workspaceMaterialId}" data-correct-answers="#{articleNode.correctAnswers}" data-assignment-type="#{articleNode.assignmentType}" data-workspace-material-id="#{articleNode.workspaceMaterialId}" data-material-id="#{articleNode.materialId}" data-material-type="#{articleNode.type}" data-material-title="#{articleNode.title}" data-material-content="#{articleNode.html}" data-path="#{articleNode.path}" data-license="#{articleNode.license}" data-producers="#{articleNode.producers}" data-view-restricted="#{articleNode.viewRestricted}" class="workspace-materials-view-page material-reading-view"/>
+                      <article id="page-#{articleNode.workspaceMaterialId}" data-correct-answers="#{articleNode.correctAnswers}" data-assignment-type="#{articleNode.assignmentType}" data-workspace-material-id="#{articleNode.workspaceMaterialId}" data-material-id="#{articleNode.materialId}" data-material-type="#{articleNode.type}" data-material-title="#{articleNode.title}" data-material-content="#{articleNode.html}" data-path="#{articleNode.path}" data-license="#{articleNode.license}" data-producers="#{articleNode.producers}" data-view-restricted="#{articleNode.viewRestricted}" class="material-page material-reading-view"/>
                     </ui:fragment>
                   </ui:repeat>
                 </ui:fragment>
@@ -144,7 +144,7 @@
             </ui:fragment>  
             
             <ui:fragment rendered="#{node.type ne 'folder'}">
-              <article id="page-#{node.workspaceMaterialId}" data-correct-answers="#{node.correctAnswers}" data-assignment-type="#{node.assignmentType}" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-material-content="#{node.html}" data-path="#{node.path}" data-license="#{node.license}" data-producers="#{node.producers}" data-view-restricted="#{node.viewRestricted}" class="workspace-materials-view-page material-reading-view"/>
+              <article id="page-#{node.workspaceMaterialId}" data-correct-answers="#{node.correctAnswers}" data-assignment-type="#{node.assignmentType}" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-material-content="#{node.html}" data-path="#{node.path}" data-license="#{node.license}" data-producers="#{node.producers}" data-view-restricted="#{node.viewRestricted}" class="material-page material-reading-view"/>
             </ui:fragment>  
           </ui:repeat>
         </article>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
@@ -114,7 +114,7 @@
           </div>  
           <ui:repeat var="node" value="#{workspaceMaterialsReadingBackingBean.contentNodes}">
             <ui:fragment rendered="#{node.type eq 'folder'}">
-              <section id="page-#{node.workspaceMaterialId}" class="material-page material-reading-view" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-path="#{node.path}" data-view-restricted="#{node.viewRestricted}">
+              <section id="page-#{node.workspaceMaterialId}" class="workspace-materials-view-page-section material-reading-view" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-path="#{node.path}" data-view-restricted="#{node.viewRestricted}">
                 <h2>#{node.title}</h2>
                 <ui:fragment rendered="#{node.viewRestricted eq true}">
                   <p class="content-view-restricted-message">#{i18n.text['plugin.workspace.sectionViewRestricted']}</p>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials.xhtml
@@ -82,7 +82,7 @@
                     </ui:fragment>
                   </ui:fragment>
                   <ui:fragment rendered="#{articleNode.type ne 'folder'}">
-                    <article id="page-#{articleNode.workspaceMaterialId}" data-correct-answers="#{articleNode.correctAnswers}" data-assignment-type="#{articleNode.assignmentType}" data-workspace-material-id="#{articleNode.workspaceMaterialId}" data-material-id="#{articleNode.materialId}" data-material-type="#{articleNode.type}" data-material-title="#{articleNode.title}" data-material-content="#{articleNode.html}" data-path="#{articleNode.path}" data-license="#{articleNode.license}" data-view-restricted="#{articleNode.viewRestricted}" data-producers="#{articleNode.producers}" class="workspace-materials-view-page material-view"/>
+                    <article id="page-#{articleNode.workspaceMaterialId}" data-correct-answers="#{articleNode.correctAnswers}" data-assignment-type="#{articleNode.assignmentType}" data-workspace-material-id="#{articleNode.workspaceMaterialId}" data-material-id="#{articleNode.materialId}" data-material-type="#{articleNode.type}" data-material-title="#{articleNode.title}" data-material-content="#{articleNode.html}" data-path="#{articleNode.path}" data-license="#{articleNode.license}" data-view-restricted="#{articleNode.viewRestricted}" data-producers="#{articleNode.producers}" class="material-page material-view"/>
                   </ui:fragment>
                 </ui:repeat>
               </ui:fragment>
@@ -90,7 +90,7 @@
           </ui:fragment>  
           
           <ui:fragment rendered="#{node.type ne 'folder'}">
-            <article id="page-#{node.workspaceMaterialId}" data-correct-answers="#{node.correctAnswers}" data-assignment-type="#{node.assignmentType}" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-material-content="#{node.html}" data-path="#{node.path}" data-license="#{node.license}" data-view-restricted="#{node.viewRestricted}" data-producers="#{node.producers}" class="workspace-materials-view-page material-view"/>
+            <article id="page-#{node.workspaceMaterialId}" data-correct-answers="#{node.correctAnswers}" data-assignment-type="#{node.assignmentType}" data-workspace-material-id="#{node.workspaceMaterialId}" data-material-id="#{node.materialId}" data-material-type="#{node.type}" data-material-title="#{node.title}" data-material-content="#{node.html}" data-path="#{node.path}" data-license="#{node.license}" data-view-restricted="#{node.viewRestricted}" data-producers="#{node.producers}" class="material-page material-view"/>
           </ui:fragment>  
         </ui:repeat>
       </article>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace-material-scripts.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace-material-scripts.xhtml
@@ -26,6 +26,7 @@
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-sorter-component.js"/>
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-image-details.js"/>
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-word-definition.js"/>
+    <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-explanation-widget.js"/>
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/article-details.js"/>
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-field.js"/> 
     <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/muikku-material-loader.js"/> 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/workspace.xhtml
@@ -108,7 +108,7 @@
           data-material-type="#{contentNode.type}"
           data-path="#{contentNode.path}"
           data-material-content="#{contentNode.html}"
-          class="workspace-materials-view-page material-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full"/>
+          class="material-page material-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full"/>
       </ui:repeat>
       <input class="workspaceEntityId" type="hidden" value="#{workspaceIndexBackingBean.workspaceEntityId}" />
       <input class="materialsBaseUrl" type="hidden" value="#{workspaceIndexBackingBean.materialsBaseUrl}" />

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/lang/en.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/lang/en.js
@@ -13,5 +13,6 @@ CKEDITOR.plugins.setLang('muikku-selection', 'en', {
   propertiesDialogOptions: 'Options',
   propertiesDialogAddOptionLink: 'Add New Option',
   propertiesDialogCorrectTooltip: 'Correct Answer',
-  propertiesDialogDeleteOptionLink: 'Remove Option'
+  propertiesDialogDeleteOptionLink: 'Remove Option',
+  propertiesDialogExplanation: 'Explanation'
 });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/lang/fi.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/lang/fi.js
@@ -13,5 +13,6 @@ CKEDITOR.plugins.setLang('muikku-selection', 'fi', {
   propertiesDialogOptions: 'Valinnat',
   propertiesDialogAddOptionLink: 'Lisää uusi valinta',
   propertiesDialogCorrectTooltip: 'Oikea vastaus',
-  propertiesDialogDeleteOptionLink: 'Poista valinta'
+  propertiesDialogDeleteOptionLink: 'Poista valinta',
+  propertiesDialogExplanation: 'Selitys'
 });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/plugin.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-selection/plugin.js
@@ -260,6 +260,14 @@
                   }
                 }
               }
+            },
+            {
+              id: 'explanation',
+              type: 'textarea',
+              label: editor.lang['muikku-selection'].propertiesDialogExplanation,
+              setup: function(json) {
+                this.setValue(json.explanation);
+              }
             }
           ]
         }
@@ -272,12 +280,16 @@
         
         var fieldType = this.getContentElement('tab-basic', 'fieldType').getValue();
         var isMultiselectField = fieldType == 'checkbox-horizontal' || fieldType == 'checkbox-vertical';
+        var explanation = this.getContentElement('tab-basic', 'explanation').getValue();
 
         // JSON representation
         
         var contentJson = editor.getMuikkuFieldDefinition(editor.getSelection().getStartElement());
         if (!contentJson.name) {
           contentJson.name = editor.createRandomMuikkuFieldName();
+        }
+        if (explanation) {
+          contentJson.explanation = explanation;
         }
         contentJson.listType = fieldType;
         contentJson.options = [];

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
@@ -11,17 +11,29 @@
       this._icon = $('<span>').addClass('explanation-button icon-explanation');
       this._content = $('<span>').addClass('explanation-content').text(this.options.text).hide();
       this.element.append(this._icon);
-      this.element.append(this._content);
-      this._icon.on('touch', $.proxy(function() {
+      this._content.appendTo(document.body);
+      this._icon.on('touch', $.proxy(function(event) {
         if (this._content.is(':visible')) {
           this._content.hide();
         }
         else {
-          this._content.show();
+          var iconPos = $(event.target).offset();
+          this._content
+            .css({
+              'left': Math.max(0, Math.min(iconPos.left, $(window).width() - this._content.outerWidth())) + 'px',
+              'top': (iconPos.top - this._content.outerHeight()) + 'px'
+            })
+            .show();
         }
       }, this));
-      this._icon.on('mouseenter', $.proxy(function() {
-        this._content.show();
+      this._icon.on('mouseenter', $.proxy(function(event) {
+        var iconPos = $(event.target).offset();
+        this._content
+          .css({
+            'left': Math.max(0, Math.min(iconPos.left, $(window).width() - this._content.outerWidth())) + 'px',
+            'top': (iconPos.top - this._content.outerHeight()) + 'px'
+          })
+          .show();
       }, this));
       this._icon.on('mouseleave', $.proxy(function() {
         this._content.hide();
@@ -29,6 +41,7 @@
     },
     
     _destroy: function () {
+      this._content.remove();
       this._icon.off();
     }
   });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
@@ -1,0 +1,37 @@
+(function() {
+  'use strict';
+  
+  $.widget("custom.explanation", {
+    
+    options: {
+      text: ''
+    },
+    
+    _create : function() {
+      this._icon = $('<span>').addClass('explanation-icon').text('X');
+      this._content = $('<span>').addClass('explanation-content').text(this.options.text).hide();
+      this.element.append(this._icon);
+      this.element.append(this._content);
+      this._icon.on('touch', $.proxy(function() {
+        if (this._content.is(':visible')) {
+          this._content.hide();
+        }
+        else {
+          this._content.show();
+        }
+      }, this));
+      this._icon.on('mouseenter', $.proxy(function() {
+        this._content.show();
+      }, this));
+      this._icon.on('mouseleave', $.proxy(function() {
+        this._content.hide();
+      }, this));
+    },
+    
+    _destroy: function () {
+      this._icon.off();
+    }
+  });
+  
+
+}).call(this);

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-explanation-widget.js
@@ -8,7 +8,7 @@
     },
     
     _create : function() {
-      this._icon = $('<span>').addClass('explanation-icon').text('X');
+      this._icon = $('<span>').addClass('explanation-button icon-explanation');
       this._content = $('<span>').addClass('explanation-content').text(this.options.text).hide();
       this.element.append(this._icon);
       this.element.append(this._content);

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
@@ -690,6 +690,9 @@
           $(this.element).removeAttr('disabled');
         } 
       },
+      getFieldElements: function() {
+        return [$(this.element)];
+      },
       readonly: false,
       saveTimeout: 300,
       saveFailedTimeout: 5000,
@@ -769,6 +772,9 @@
         this.options.setReadonly.call(this, readonly);
       }
     },
+    getFieldElements: function() {
+      return this.options.getFieldElements.call(this);
+    },
     _checkStatusMessage: function () {
       var saveStateLabel = this.element.prev('.muikku-field-save-state-label');
       if (saveStateLabel.length <= 0) {
@@ -785,9 +791,9 @@
       if (!this.readonly()) {
         this._checkStatusMessage();
         
-        $(this.element)
-          .removeClass('muikku-field-unsaved')
-          .addClass('muikku-field-saving');
+        $.each(this.getFieldElements(), function(index, element) {
+          $(element).removeClass('muikku-field-unsaved').addClass('muikku-field-saving');
+        });
         
         var page = $(this.element).closest('.material-page');
         var workspaceEntityId = page.muikkuMaterialPage('workspaceEntityId'); 
@@ -820,9 +826,9 @@
       $(document).connectionLostNotifier("notifyConnectionLost");
     },
     _propagateChange: function () {
-      $(this.element)
-        .removeClass('muikku-field-saved muikku-field-saving')
-        .addClass('muikku-field-unsaved'); 
+      $.each(this.getFieldElements(), function(index, element) {
+        $(element).removeClass('muikku-field-saved muikku-field-saving').addClass('muikku-field-unsaved');
+      });
       
       if (this._saveTimeoutId) {
         clearTimeout(this._saveTimeoutId);
@@ -864,9 +870,9 @@
       if ((message.embedId == this.embedId()) && (message.materialId == this.materialId()) && (message.fieldName == this.fieldName())) {
 
         if (message.originTicket == $(document).muikkuWebSocket("ticket")) {
-          $(this.element)
-            .removeClass('muikku-field-unsaved muikku-field-saving')
-            .addClass('muikku-field-saved');
+          $.each(this.getFieldElements(), function(index, element) {
+            $(element).removeClass('muikku-field-unsaved muikku-field-saving').addClass('muikku-field-saved');
+          });
           
           $(this.element)
             .prev('.muikku-field-save-state-label')
@@ -879,9 +885,9 @@
             });
 
         } else {
-          $(this.element)
-            .removeClass('muikku-field-unsaved muikku-field-saving')
-            .addClass('muikku-field-saved');
+          $.each(this.getFieldElements(), function(index, element) {
+            $(element).removeClass('muikku-field-unsaved muikku-field-saving').addClass('muikku-field-saved');
+          });
           
           $(this.element)
           .prev('.muikku-field-save-state-label')

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
@@ -1,45 +1,6 @@
 (function() {
   'use strict';
   
-  
-  function recolorCheckboxFields(elem) {
-    $(elem).find(".muikku-field-correct-answer-override").removeClass("muikku-field-correct-answer-override");
-    
-    if ($(elem).next(".muikku-field-examples").length === 0) {
-      return;
-    }
-    
-    var labels = $(elem).find("label[for]");
-    var answers = [];
-    for (var i=0; i<labels.length; i++) {
-      var label = labels[i];
-
-      var id = $(label).attr('for');
-      var answer = $(label).html();
-      answers.push({id: id, answer: answer});
-    } 
-    
-    var correctAnswers = [];
-    $(elem).next(".muikku-field-examples").find(".muikku-field-example").each(function() {
-      correctAnswers.push($(this).html());
-    });
-    
-    for (var i=0; i < answers.length; i++) {
-      var answer = answers[i];
-      var inputElem = document.getElementById(answer.id);
-      if (inputElem.type === "checkbox") {
-        if ((inputElem.checked && correctAnswers.indexOf(answer.answer) >= 0) ||
-            (!inputElem.checked && correctAnswers.indexOf(answer.answer) === -1)) {
-          $(inputElem).addClass("muikku-field-correct-answer-override");
-        }
-      } else if (inputElem.type === "radio") {
-        if (correctAnswers.indexOf(answer.answer) >= 0) {
-          $(inputElem).addClass("muikku-field-correct-answer-override");
-        }
-      }
-    }
-  }
-
   $(document).on('workspace:field-answer-error', function (event, data) {
     try {
       var message = $.parseJSON(data);
@@ -554,7 +515,6 @@
       this.element.find('.muikku-field-semi-correct-answer').removeClass('muikku-field-semi-correct-answer');
 
       $(fields).each(function (index, field) {
-        $(field).find(".muikku-field-correct-answer-override").removeClass("muikku-field-correct-answer-override");
         if ($(field).muikkuField('canCheckAnswer')) {
           if ($(field).muikkuField('checksOwnAnswer')) {
             var answerCounts = $(field).muikkuField('checkAnswer', (correctAnswersDisplay == 'ALWAYS' || (correctAnswersDisplay == 'ON_REQUEST' && requestAnswers)));
@@ -590,10 +550,9 @@
                   );
                 });
                 $(field).after(exampleDetails);
-                
-                recolorCheckboxFields(field);
               }
-            } else if (correctAnswersDisplay == 'ON_REQUEST' && !requestAnswers){
+            }
+            else if (correctAnswersDisplay == 'ON_REQUEST' && !requestAnswers){
               $(field).muikkuField('hideCorrectAnswers');
             }
           }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
@@ -789,7 +789,7 @@
           .removeClass('muikku-field-unsaved')
           .addClass('muikku-field-saving');
         
-        var page = $(this.element).closest('.workspace-materials-view-page');
+        var page = $(this.element).closest('.material-page');
         var workspaceEntityId = page.muikkuMaterialPage('workspaceEntityId'); 
         var workspaceMaterialId =  page.muikkuMaterialPage('workspaceMaterialId'); 
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -1070,12 +1070,7 @@
                     }
                   }
                   if (this.options.meta.explanation) {
-                    var explanationWrapper = $('<span>').addClass('explanation-wrapper');
-                    var explanationIcon = $('<span>').addClass('explanation-icon');
-                    var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
-                    exampleDetails.append(explanationWrapper);
-                    explanationWrapper.append(explanationIcon);
-                    explanationWrapper.append(explanationContent);
+                    exampleDetails.append($('<span>').addClass('explanation-wrapper').explanation({text: this.options.meta.explanation}));
                   }
                   $(this.element).after(exampleDetails);
                 }
@@ -1220,12 +1215,7 @@
                   }
                 }
                 if (this.options.meta.explanation) {
-                  var explanationWrapper = $('<span>').addClass('explanation-wrapper');
-                  var explanationIcon = $('<span>').addClass('explanation-icon');
-                  var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
-                  exampleDetails.append(explanationWrapper);
-                  explanationWrapper.append(explanationIcon);
-                  explanationWrapper.append(explanationContent);
+                  exampleDetails.append($('<span>').addClass('explanation-wrapper').explanation({text: this.options.meta.explanation}));
                 }
                 $(this.element).after(exampleDetails);
               }
@@ -1400,12 +1390,7 @@
               }
             }
             if (this.options.meta.explanation) {
-              var explanationWrapper = $('<span>').addClass('explanation-wrapper');
-              var explanationIcon = $('<span>').addClass('explanation-icon');
-              var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
-              exampleDetails.append(explanationWrapper);
-              explanationWrapper.append(explanationIcon);
-              explanationWrapper.append(explanationContent);
+              exampleDetails.append($('<span>').addClass('explanation-wrapper').explanation({text: this.options.meta.explanation}));
             }
             $(this.element).after(exampleDetails);
           }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -1005,9 +1005,9 @@
               meta: meta,
               readonly: data.readOnlyFields||false,
               hasDisplayableAnswers: function() {
-                return this.canCheckAnswer(); 
-              },
-              canCheckAnswer: function() {
+                if (this.options.meta.explanation) {
+                  return true;
+                }
                 for (var i = 0, l = meta.options.length; i < l; i++) {
                   if (meta.options[i].correct == true) {
                     return true;
@@ -1015,21 +1015,69 @@
                 }
                 return false;
               },
-              isCorrectAnswer: function() {
-                var answer = this.answer();
-                for (var i = 0, l = meta.options.length; i < l; i++) {
-                  if (meta.options[i].correct == true && meta.options[i].name == answer) {
-                    return true;
-                  }
-                }
-                return false; 
+              canCheckAnswer: function() {
+                return this.hasDisplayableAnswers();
               },
-              getCorrectAnswers: function() {
-                var result = [];
+              checksOwnAnswer: function() {
+                return true;
+              },
+              checkAnswer: function(showCorrectAnswers) {
+                $(this.element).find('.muikku-field-examples').remove();
+                $(this.element).removeClass('muikku-field-correct-answer muikku-field-incorrect-answer');
+                var result = {
+                  'correctAnswers': 0,
+                  'wrongAnswers': 0
+                }
+                // Selected by user
+                var selectedValues = [this.answer()];
+                // Choices that would be correct
+                var correctValues = [];
                 for (var i = 0, l = meta.options.length; i < l; i++) {
                   if (meta.options[i].correct == true) {
-                    result.push(meta.options[i].text);
+                    correctValues.push(meta.options[i].name);
                   }
+                }
+                // If there are correct answers, calculate and recolor
+                if (correctValues.length > 0) {
+                  var answer = this.answer();
+                  if (correctValues.indexOf(answer) >= 0) {
+                    result.correctAnswers++;
+                    if (showCorrectAnswers) {
+                      $(this.element).addClass('muikku-field-correct-answer');
+                    }
+                  }
+                  else {
+                    result.wrongAnswers++;
+                    if (showCorrectAnswers) {
+                      $(this.element).addClass('muikku-field-incorrect-answer');
+                    }
+                  }
+                }
+                if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+                  var exampleDetails = $('<span>').addClass('muikku-field-examples');
+                  if (result.wrongAnswers > 0 && showCorrectAnswers) {
+                    exampleDetails.append($('<span>')
+                      .addClass('muikku-field-examples-title')
+                      .text(getLocaleText('plugin.workspace.assigment.checkAnswers.correctSummary.title'))
+                    );
+                    for (var i = 0, l = meta.options.length; i < l; i++) {
+                      if (meta.options[i].correct == true) {
+                        exampleDetails.append($('<span>')
+                          .addClass('muikku-field-example')
+                          .html(meta.options[i].text.replace(/\n/g, '<br/>'))    
+                        );
+                      }
+                    }
+                  }
+                  if (this.options.meta.explanation) {
+                    var explanationWrapper = $('<span>').addClass('explanation-wrapper');
+                    var explanationIcon = $('<span>').addClass('explanation-icon');
+                    var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
+                    exampleDetails.append(explanationWrapper);
+                    explanationWrapper.append(explanationIcon);
+                    explanationWrapper.append(explanationContent);
+                  }
+                  $(this.element).after(exampleDetails);
                 }
                 return result;
               }
@@ -1098,9 +1146,9 @@
               }
             },
             hasDisplayableAnswers: function() {
-              return this.canCheckAnswer(); 
-            },
-            canCheckAnswer: function() {
+              if (this.options.meta.explanation) {
+                return true;
+              }
               for (var i = 0, l = meta.options.length; i < l; i++) {
                 if (meta.options[i].correct == true) {
                   return true;
@@ -1108,21 +1156,78 @@
               }
               return false;
             },
-            isCorrectAnswer: function() {
-              var answer = this.answer();
-              for (var i = 0, l = meta.options.length; i < l; i++) {
-                if (meta.options[i].correct == true && meta.options[i].name == answer) {
-                  return true;
-                }
-              }
-              return false; 
+            canCheckAnswer: function() {
+              return this.hasDisplayableAnswers();
             },
-            getCorrectAnswers: function() {
-              var result = [];
+            checksOwnAnswer: function() {
+              return true;
+            },
+            checkAnswer: function(showCorrectAnswers) {
+              $(this.element).find('.muikku-field-examples').remove();
+              $(this.element).find('input').each(function(index, element) {
+                $(element).removeClass('muikku-field-correct-answer muikku-field-incorrect-answer');
+              });
+              var result = {
+                'correctAnswers': 0,
+                'wrongAnswers': 0
+              }
+              // Radio button selected by user
+              var selectedValues = [];
+              $(this.element).find('input:checked').each(function() {
+                selectedValues.push($(this).val());
+              });
+              // Radio buttons that would be correct
+              var correctValues = [];
               for (var i = 0, l = meta.options.length; i < l; i++) {
                 if (meta.options[i].correct == true) {
-                  result.push(meta.options[i].text);
+                  correctValues.push(meta.options[i].name);
                 }
+              }
+              // If there are correct answers, calculate and recolor
+              if (correctValues.length > 0) {
+                var answer = this.answer();
+                if (correctValues.indexOf(answer) >= 0) {
+                  result.correctAnswers++;
+                  if (showCorrectAnswers) {
+                    $(this.element).find('input').each(function(index, element) {
+                      $(element).addClass('muikku-field-correct-answer');
+                    });
+                  }
+                }
+                else {
+                  result.wrongAnswers++;
+                  if (showCorrectAnswers) {
+                    $(this.element).find('input').each(function(index, element) {
+                      $(element).addClass('muikku-field-incorrect-answer');
+                    });
+                  }
+                }
+              }
+              if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+                var exampleDetails = $('<span>').addClass('muikku-field-examples');
+                if (result.wrongAnswers > 0 && showCorrectAnswers) {
+                  exampleDetails.append($('<span>')
+                    .addClass('muikku-field-examples-title')
+                    .text(getLocaleText('plugin.workspace.assigment.checkAnswers.correctSummary.title'))
+                  );
+                  for (var i = 0, l = meta.options.length; i < l; i++) {
+                    if (meta.options[i].correct == true) {
+                      exampleDetails.append($('<span>')
+                        .addClass('muikku-field-example')
+                        .html(meta.options[i].text.replace(/\n/g, '<br/>'))    
+                      );
+                    }
+                  }
+                }
+                if (this.options.meta.explanation) {
+                  var explanationWrapper = $('<span>').addClass('explanation-wrapper');
+                  var explanationIcon = $('<span>').addClass('explanation-icon');
+                  var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
+                  exampleDetails.append(explanationWrapper);
+                  explanationWrapper.append(explanationIcon);
+                  explanationWrapper.append(explanationContent);
+                }
+                $(this.element).after(exampleDetails);
               }
               return result;
             }
@@ -1207,9 +1312,9 @@
           }
         },
         hasDisplayableAnswers: function() {
-          return this.canCheckAnswer(); 
-        },
-        canCheckAnswer: function() {
+          if (this.options.meta.explanation) {
+            return true;
+          }
           for (var i = 0, l = meta.options.length; i < l; i++) {
             if (meta.options[i].correct == true) {
               return true;
@@ -1217,32 +1322,92 @@
           }
           return false;
         },
-        isCorrectAnswer: function() {
+        canCheckAnswer: function() {
+          return this.hasDisplayableAnswers();
+        },
+        checksOwnAnswer: function() {
+          return true;
+        },
+        checkAnswer: function(showCorrectAnswers) {
+          $(this.element).find('.muikku-field-examples').remove();
+          $(this.element).find('input').each(function(index, element) {
+            $(element).removeClass('muikku-field-correct-answer muikku-field-incorrect-answer');
+          });
+          var result = {
+            'correctAnswers': 0,
+            'wrongAnswers': 0
+          }
+          // Checkboxes selected by user
           var selectedValues = [];
           $(this.element).find('input:checked').each(function() {
             selectedValues.push($(this).val());
           });
+          // Checkboxes marked as correct
           var correctValues = [];
           for (var i = 0, l = meta.options.length; i < l; i++) {
             if (meta.options[i].correct == true) {
               correctValues.push(meta.options[i].name);
             }
           }
-          if (selectedValues.length != correctValues.length) {
-            return false;
+          // If there are correct answers, calculate and recolor
+          if (correctValues.length > 0) {
+            $(this.element).find('input').each($.proxy(function(index, element) {
+              var value = $(element).val();
+              if (correctValues.indexOf(value) >= 0) {
+                if (selectedValues.indexOf(value) >= 0) {
+                  if (showCorrectAnswers) {
+                    $(element).addClass('muikku-field-correct-answer');
+                  }
+                  result.correctAnswers++;
+                }
+                else {
+                  if (showCorrectAnswers) {
+                    $(element).addClass('muikku-field-incorrect-answer');
+                  }
+                  result.wrongAnswers++;
+                }
+              }
+              else {
+                if (selectedValues.indexOf(value) >= 0) {
+                  if (showCorrectAnswers) {
+                    $(element).addClass('muikku-field-incorrect-answer');
+                  }
+                  result.wrongAnswers++;
+                }
+                else {
+                  if (showCorrectAnswers) {
+                    $(element).addClass('muikku-field-correct-answer');
+                  }
+                  result.correctAnswers++;
+                }
+              }
+            }, this));
           }
-          for (var i = 0; i < selectedValues.length; i++) {
-            if (correctValues.indexOf(selectedValues[i]) == -1)
-              return false;
-          }
-          return true;
-        },
-        getCorrectAnswers: function() {
-          var result = [];
-          for (var i = 0, l = meta.options.length; i < l; i++) {
-            if (meta.options[i].correct == true) {
-              result.push(meta.options[i].text);
+          if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+            var exampleDetails = $('<span>').addClass('muikku-field-examples');
+            if (result.wrongAnswers > 0 && showCorrectAnswers) {
+              exampleDetails.append($('<span>')
+                .addClass('muikku-field-examples-title')
+                .text(getLocaleText('plugin.workspace.assigment.checkAnswers.correctSummary.title'))
+              );
+              for (var i = 0, l = meta.options.length; i < l; i++) {
+                if (meta.options[i].correct == true) {
+                  exampleDetails.append($('<span>')
+                    .addClass('muikku-field-example')
+                    .html(meta.options[i].text.replace(/\n/g, '<br/>'))    
+                  );
+                }
+              }
             }
+            if (this.options.meta.explanation) {
+              var explanationWrapper = $('<span>').addClass('explanation-wrapper');
+              var explanationIcon = $('<span>').addClass('explanation-icon');
+              var explanationContent = $('<span>').addClass('explanation-content').text(this.options.meta.explanation);
+              exampleDetails.append(explanationWrapper);
+              explanationWrapper.append(explanationIcon);
+              explanationWrapper.append(explanationContent);
+            }
+            $(this.element).after(exampleDetails);
           }
           return result;
         }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -1053,7 +1053,7 @@
                     }
                   }
                 }
-                if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+                if (showCorrectAnswers && this.hasDisplayableAnswers()) {
                   var exampleDetails = $('<span>').addClass('muikku-field-examples');
                   if (result.wrongAnswers > 0 && showCorrectAnswers) {
                     exampleDetails.append($('<span>')
@@ -1201,7 +1201,7 @@
                   }
                 }
               }
-              if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+              if (showCorrectAnswers && this.hasDisplayableAnswers()) {
                 var exampleDetails = $('<span>').addClass('muikku-field-examples');
                 if (result.wrongAnswers > 0 && showCorrectAnswers) {
                   exampleDetails.append($('<span>')
@@ -1379,7 +1379,7 @@
               }
             }, this));
           }
-          if (this.options.meta.explanation || (result.wrongAnswers > 0 && showCorrectAnswers)) {
+          if (showCorrectAnswers && this.hasDisplayableAnswers()) {
             var exampleDetails = $('<span>').addClass('muikku-field-examples');
             if (result.wrongAnswers > 0 && showCorrectAnswers) {
               exampleDetails.append($('<span>')

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -1132,6 +1132,9 @@
                   .find('input[type="radio"]').removeAttr('disabled');
               }
             },
+            getFieldElements: function() {
+              return $(this.element).find('input');
+            },
             answer: function(val) {
               if (val) {
                 $(this.element).find('input').prop('checked', false);
@@ -1284,6 +1287,9 @@
               .removeAttr('data-disabled') 
               .find('input[type="checkbox"]').removeAttr('disabled');
           }
+        },
+        getFieldElements: function() {
+          return $(this.element).find('input');
         },
         answer: function(val) {
           if (val) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-frontpage.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-frontpage.js
@@ -98,7 +98,7 @@
         workspaceEntityId: workspaceEntityId,
         baseUrl: $('.materialsBaseUrl').val()
       })
-      .muikkuMaterialLoader('loadMaterials', $('.workspace-materials-view-page'));
+      .muikkuMaterialLoader('loadMaterials', $('.material-page'));
     
     mApi().workspace.workspaces.materialProducers
       .read(workspaceEntityId).callback(function (err, materialProducers) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-helppage.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-helppage.js
@@ -8,7 +8,7 @@
         workspaceEntityId: workspaceEntityId,
         baseUrl: $('.materialsBaseUrl').val()
       })
-      .muikkuMaterialLoader('loadMaterials', $('.workspace-materials-view-page'));
+      .muikkuMaterialLoader('loadMaterials', $('.material-page'));
 
   });
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-material-upload.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-material-upload.js
@@ -58,7 +58,7 @@
         var workspaceEntityId = $('.workspaceEntityId').val();
         var parentFolder = $(this.element).prevAll('.folder').first();
         var parentId = parentFolder ? $(parentFolder).data('workspace-material-id') : $('.workspaceRootFolderId').val();
-        var nextMaterial = $(this.element).next('.workspace-materials-view-page');
+        var nextMaterial = $(this.element).next('.material-page');
         var nextSiblingId = $(nextMaterial) && !$(nextMaterial).hasClass('folder') ? $(nextMaterial).data('workspace-material-id') : undefined;
         
         mApi({async: false}).workspace.workspaces.materials.create(workspaceEntityId, {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials-management.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials-management.js
@@ -24,7 +24,7 @@
       .workspaceMaterialUpload({maxFileSize: maxFileSize})
       .on('fileUploaded', function (event, data) {
         var newPage = $('<section>')
-          .addClass('workspace-materials-view-page material-management-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full')
+          .addClass('material-page material-management-view lg-flex-cell-full md-flex-cell-full sm-flex-cell-full')
           .attr({
             'id': 'page-' + data.workspaceMaterialId,
             'data-material-title': data.title,
@@ -107,7 +107,7 @@
       var workspaceMaterialId = $(node).attr('data-workspace-material-id');
       var editorName = 'workspaceMaterialEditor' + (materialType.substring(0, 1).toUpperCase() + materialType.substring(1));
       var pageElement = $('#page-' + workspaceMaterialId);
-      var pageSection = $(pageElement).closest(".workspace-materials-view-page");
+      var pageSection = $(pageElement).closest(".material-page");
       var materialPath = $('.materialsBaseUrl').val() + '/' + path;
       
       mApi().materials.material.workspaceMaterials
@@ -370,11 +370,11 @@
   }
   
   function getPagePublishedRevision(workspaceMaterialId) {
-    return parseInt($('.workspace-materials-view-page[data-workspace-material-id="' + workspaceMaterialId + '"] input[name="published-revision"]').val()||'0');
+    return parseInt($('.material-page[data-workspace-material-id="' + workspaceMaterialId + '"] input[name="published-revision"]').val()||'0');
   }
   
   function setPagePublishedRevision(workspaceMaterialId, revision) {
-    var page = $('.workspace-materials-view-page[data-workspace-material-id="' + workspaceMaterialId + '"]');
+    var page = $('.material-page[data-workspace-material-id="' + workspaceMaterialId + '"]');
     page.find('input[name="published-revision"]').val(revision);
     
     if (getPageCurrentRevision(workspaceMaterialId) != getPagePublishedRevision(workspaceMaterialId)) {
@@ -387,11 +387,11 @@
   }
   
   function getPageCurrentRevision(workspaceMaterialId) {
-    return parseInt($('.workspace-materials-view-page[data-workspace-material-id="' + workspaceMaterialId + '"] input[name="current-revision"]').val()||'0');
+    return parseInt($('.material-page[data-workspace-material-id="' + workspaceMaterialId + '"] input[name="current-revision"]').val()||'0');
   }
   
   function setPageCurrentRevision(workspaceMaterialId, revision) {
-    var page = $('.workspace-materials-view-page[data-workspace-material-id="' + workspaceMaterialId + '"]');
+    var page = $('.material-page[data-workspace-material-id="' + workspaceMaterialId + '"]');
     page.find('input[name="current-revision"]').val(revision);
 
     if (getPageCurrentRevision(workspaceMaterialId) != getPagePublishedRevision(workspaceMaterialId)) {
@@ -1081,7 +1081,7 @@
     var _node = node;
     var _hidden = hidden;
     var workspaceId = $('.workspaceEntityId').val();
-    var nextSibling = node.nextAll('.workspace-materials-view-page').first();
+    var nextSibling = node.nextAll('.material-page').first();
     var nextSiblingId = nextSibling.length > 0 ? nextSibling.attr('data-workspace-material-id') : null;
     var workspaceMaterialId = node.attr('data-workspace-material-id');
     var materialType = node.attr('data-material-type');
@@ -1336,9 +1336,9 @@
         "html": "dust"
       }
     })
-    .muikkuMaterialLoader('loadMaterials', $('.workspace-materials-view-page'));
+    .muikkuMaterialLoader('loadMaterials', $('.material-page'));
 
-    $('.workspace-materials-view-page').waypoint(function(direction) {
+    $('.material-page').waypoint(function(direction) {
       if ($(window).data('scrolling') !== true && $(window).data('initializing') !== true) {
         var workspaceMaterialId = $(this).data('workspace-material-id');
         $('li.active').removeClass('active');
@@ -1449,7 +1449,7 @@
   
   $(document).on('click', '.edit-page', function (event, data) {
     // TODO: Better way to toggle classes and observe hidden/visible states?
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     if (page.hasClass('item-hidden')) {
       page.removeClass('item-hidden');
       page.find('.hide-page').removeClass('icon-show').addClass('icon-hide');
@@ -1459,7 +1459,7 @@
 
   $(document).on('click', '.hide-page', function (event, data) {
     // TODO: Better way to toggle classes and observe hidden/visible states?
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var hidden = page.hasClass('item-hidden');
     toggleVisibility(page, !hidden);
   });
@@ -1542,7 +1542,7 @@
   }
   
   $(document).on('click', '.correct-answers', function (event, data) {
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var correctAnswers = $(page).attr('data-correct-answers');
     var workspaceId = $('.workspaceEntityId').val();
     var workspaceMaterialId = $(page).attr('data-workspace-material-id');
@@ -1587,7 +1587,7 @@
   });
   
   $(document).on('click', '.change-assignment', function (event, data) {
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var assignmentType = $(page).attr('data-assignment-type');
     var workspaceId = $('.workspaceEntityId').val();
     var workspaceMaterialId = $(page).attr('data-workspace-material-id');
@@ -1650,8 +1650,8 @@
 	  
     var parentId = undefined;
     var nextSiblingId = undefined;
-    var previousMaterial = $(this).parent().prevAll('.workspace-materials-view-page').first();
-    var nextMaterial = $(this).parent().nextAll('.workspace-materials-view-page').first();
+    var previousMaterial = $(this).parent().prevAll('.material-page').first();
+    var nextMaterial = $(this).parent().nextAll('.material-page').first();
     
     renderDustTemplate('workspace/materials-management-new.dust', {clipboardItem: localStorage.getItem('muikku-clipboard-material')}, $.proxy(function (text) {
       var newPage = $(text);
@@ -1774,8 +1774,8 @@
         var sourceWorkspaceMaterialId = clipboardData[1];
         var targetNodeId = null;
         var targetNextSiblingId = null;
-        var previousMaterial = $(this).closest('section').prevAll('.workspace-materials-view-page').first();
-        var nextMaterial = $(this).closest('section').nextAll('.workspace-materials-view-page').first();
+        var previousMaterial = $(this).closest('section').prevAll('.material-page').first();
+        var nextMaterial = $(this).closest('section').nextAll('.material-page').first();
         if (!$(nextMaterial).length) {
           if (!$(previousMaterial).length) {
             targetNodeId = $('.workspaceRootFolderId').val();  
@@ -1924,7 +1924,7 @@
   });
   
   $(document).on('htmlMaterialRevisionChanged', function (event, data) {
-    $('.workspace-materials-view-page[data-material-id="' + data.materialId + '"]').each(function (index, page) {
+    $('.material-page[data-material-id="' + data.materialId + '"]').each(function (index, page) {
       var workspaceMaterialId = $(page).attr('data-workspace-material-id');
       setPageCurrentRevision(workspaceMaterialId, data.revisionNumber);
     });
@@ -2048,7 +2048,7 @@
   }
   
   $(document).on('click', '.publish-page', function (event, data) {
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var workspaceMaterialId = $(page).attr('data-workspace-material-id');
     var materialId = $(page).attr('data-material-id');
     var title = $(page).find('.workspace-material-html-editor-title').val();
@@ -2104,7 +2104,7 @@
   }
   
   $(document).on('click', '.revert-page', function (event, data) {
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var workspaceMaterialId = $(page).attr('data-workspace-material-id');
     var materialId = $(page).attr('data-material-id');
     var currentRevision = getPageCurrentRevision(workspaceMaterialId);

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials-reading.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials-reading.js
@@ -48,9 +48,9 @@
       readOnlyFields: MUIKKU_LOGGED_USER ? false: true,
       workspaceEntityId: $('.workspaceEntityId').val(),
       baseUrl: $('.materialsBaseUrl').val()
-    }).muikkuMaterialLoader('loadMaterials', $('.workspace-materials-view-page'));
+    }).muikkuMaterialLoader('loadMaterials', $('.material-page'));
 
-    $('.workspace-materials-view-page').waypoint(function(direction) {
+    $('.material-page').waypoint(function(direction) {
       if ($(window).data('scrolling') !== true && $(window).data('initializing') !== true) {
         var workspaceMaterialId = $(this).data('workspace-material-id');
         $('a.active').removeClass('active');
@@ -64,14 +64,14 @@
       offset: 50
     });
     
-    $('.workspace-materials-view-page[data-assignment-type="EXERCISE"]').each(function (index, page) {
+    $('.material-page[data-assignment-type="EXERCISE"]').each(function (index, page) {
       $(page).prepend($('<div>')
           .addClass('muikku-page-assignment-type exercise')
           .text(getLocaleText("plugin.workspace.materialsLoader.exerciseAssignmentLabel"))
       );
     });
     
-    $('.workspace-materials-view-page[data-assignment-type="EVALUATED"]').each(function (index, page) {
+    $('.material-page[data-assignment-type="EVALUATED"]').each(function (index, page) {
       $(page).prepend($('<div>')
           .addClass('muikku-page-assignment-type assignment')
           .text(getLocaleText("plugin.workspace.materialsLoader.evaluatedAssignmentLabel"))

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
@@ -76,23 +76,23 @@
       readOnlyFields: MUIKKU_LOGGED_USER ? false: true,
       workspaceEntityId: $('.workspaceEntityId').val(),
       baseUrl: $('.materialsBaseUrl').val()
-    }).muikkuMaterialLoader('loadMaterials', $('.workspace-materials-view-page'));
+    }).muikkuMaterialLoader('loadMaterials', $('.material-page'));
 
-    $('.workspace-materials-view-page[data-assignment-type="EXERCISE"]').each(function (index, page) {
+    $('.material-page[data-assignment-type="EXERCISE"]').each(function (index, page) {
       $(page).prepend($('<div>')
           .addClass('muikku-page-assignment-type exercise')
           .text(getLocaleText("plugin.workspace.materialsLoader.exerciseAssignmentLabel"))
       );
     });
     
-    $('.workspace-materials-view-page[data-assignment-type="EVALUATED"]').each(function (index, page) {
+    $('.material-page[data-assignment-type="EVALUATED"]').each(function (index, page) {
       $(page).prepend($('<div>')
           .addClass('muikku-page-assignment-type assignment')
           .text(getLocaleText("plugin.workspace.materialsLoader.evaluatedAssignmentLabel"))
       );
     });
 
-    $('.workspace-materials-view-page').waypoint(function(direction) {
+    $('.material-page').waypoint(function(direction) {
       if ($(window).data('scrolling') !== true && $(window).data('initializing') !== true) {
         var workspaceMaterialId = $(this).data('workspace-material-id');
         $('#materialsScrollableTOC').find('a.active').removeClass('active');
@@ -146,7 +146,7 @@
 
   $(document).on('change', '.muikku-field', function (event, data) {
     $(this).removeClass('muikku-field-correct-answer muikku-field-incorrect-answer');
-    var page = $(this).closest('.workspace-materials-view-page');
+    var page = $(this).closest('.material-page');
     var saveButton = $(page).find('.muikku-save-page');
     if (saveButton.length) {
       saveButton

--- a/muikku-deus-nex-machina/src/main/java/fi/otavanopisto/muikku/plugins/dnm/translator/FieldTranslator.java
+++ b/muikku-deus-nex-machina/src/main/java/fi/otavanopisto/muikku/plugins/dnm/translator/FieldTranslator.java
@@ -83,7 +83,7 @@ public class FieldTranslator {
     else if ("radio_horz".equals(listType)) {
       newListType = "radio-horizontal";
     }
-    return new SelectFieldMeta(name, newListType, translatedOptions);
+    return new SelectFieldMeta(name, newListType, translatedOptions, null);
   }
 
   public MultiSelectFieldMeta translateChecklistField(String paramName, List<MultiSelectFieldOptionMeta> options) {
@@ -91,7 +91,7 @@ public class FieldTranslator {
     for (MultiSelectFieldOptionMeta option : options) {
       translatedOptions.add(new MultiSelectFieldOptionMeta(option.getName(), option.getText(), option.getCorrect()));
     }
-    return new MultiSelectFieldMeta(paramName, "checkbox-vertical", translatedOptions);
+    return new MultiSelectFieldMeta(paramName, "checkbox-vertical", translatedOptions, null);
   }
   
   public ConnectFieldMeta translateConnectField(String name, List<ConnectFieldOption> options) {

--- a/muikku-evaluation-plugin/src/main/resources/META-INF/resources/dust/evaluation/evaluation-assignment-wrapper.dust
+++ b/muikku-evaluation-plugin/src/main/resources/META-INF/resources/dust/evaluation/evaluation-assignment-wrapper.dust
@@ -1,4 +1,4 @@
-<div class="assignment-wrapper {materialType}" {?evaluationDate}data-evaluated="true" {?grade}data-graded="true"{/grade}{/evaluationDate}>
+<div class="assignment-wrapper material-page {materialType}" {?evaluationDate}data-evaluated="true" {?grade}data-graded="true"{/grade}{/evaluationDate}>
   <div class="assignment-title-wrapper">
     <div class="assignment-title">{title}</div>
     <div class="assignment-done">

--- a/muikku/src/main/webapp/WEB-INF/templates/flex-base.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/flex-base.xhtml
@@ -86,7 +86,7 @@
 
       <!-- Flex Grid -->
       <link rel="stylesheet" type="text/css" href="//cdn.muikkuverkko.fi/libs/fni-flexgrid/1.0.0/flexgrid.css"/>
-      <link rel="stylesheet" type="text/css" href="//cdn.muikkuverkko.fi/assets/muikku-icons/1.2.0/style.css"/>
+      <link rel="stylesheet" type="text/css" href="//cdn.muikkuverkko.fi/assets/muikku-icons/1.2.3/style.css"/>
       <ui:insert name="styles"></ui:insert>
     </head>
   

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/_workspaces-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/_workspaces-materials-defaults.scss
@@ -456,7 +456,7 @@ body.workspace-materials-management #contentWorkspaceMaterialsManagement {
     clear:both;
   }
   
-  .workspace-materials-view-page {
+  .material-page {
   
     .correct-answers-count-container {
       display:block;
@@ -890,7 +890,7 @@ p.content-view-restricted-message {
   background:#f9f9f9;
 }
 
-.workspace-materials-view-page[data-view-restricted="true"] {
+.material-page[data-view-restricted="true"] {
 
   .muikku-save-page-wrapper,
   .article-details {
@@ -904,7 +904,7 @@ p.content-view-restricted-message {
 body.workspace-materials #contentWorkspaceMaterials {
   
   /* Save answers button's font-size under basic view */
-  .workspace-materials-view-page {
+  .material-page {
   
     button.muikku-assignment-button {
       font-size:14px;
@@ -936,7 +936,7 @@ body.workspace-materials #contentWorkspaceMaterials {
 body.workspace-materials-reading #contentWorkspaceMaterialsReading {
   
   /* Save answers button's font-size under reading view view */
-  .workspace-materials-view-page {
+  .material-page {
   
     button.muikku-assignment-button {
       font-size:16px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_correct_answers.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_correct_answers.scss
@@ -1,125 +1,57 @@
-// CORRECT ANSWERS COUNTER
-.correct-answers-count-container {
-  display: block;
-  margin: 5px;
-  text-align: center;
-  font-size: 20px;
-  
-  .correct-answers-count-label {
-    padding: 0 5px;
-    display: inline-block;
-  }
-  
-  .correct-answers-count-data {
-    padding: 0 5px;
-    display: inline-block;
-  }
-  
-}
+.material-page {
 
-// EXAMPLE ANSWERS
-span.muikku-field-examples {
-  background: #e2ffe2;
-  border-radius: 3px;
-  display: inline-block;
-  font-size: 14px;
-  font-style: italic;
-  margin: 1px 3px;
-  padding: 3px;
-  vertical-align: middle;
-  width: auto;
-  
-  span.muikku-field-examples-title {
-    font-weight: 600;
-    margin: 0 6px;
-  }
-  
-  span.muikku-field-example {
-    border-left: 1px solid #439ba0;
-    display: inline-block;
-    line-height: 1.5;
-    margin: 3px 0 3px 5px;
-    padding: 0 8px;
-  }
-  
-}
-
-// TEXTFIELD, TEXTAREA, SELECT CORRECT ANSWERS
-div.muikku-text-field.muikku-field-correct-answer,
-div.muikku-memo-field.muikku-field-correct-answer,
-input[type="text"].muikku-field-correct-answer,
-textarea.muikku-field-correct-answer,
-select.muikku-field-correct-answer {
-  border: 2px solid #00ff2a;
-  border-radius: 3px;
-  box-shadow: none;
-  
-  &:hover {
-    border: 2px solid #00ff2a;
-    box-shadow: none;
-  }
-  
-}
-
-// TEXTFIELD, TEXTAREA, SELECT INCORRECT ANSWERS
-div.muikku-text-field.muikku-field-incorrect-answer,
-div.muikku-memo-field.muikku-field-incorrect-answer,
-input[type="text"].muikku-field-incorrect-answer,
-textarea.muikku-field-incorrect-answer,
-select.muikku-field-incorrect-answer {
-  border: 2px solid #f64e4e;
-  box-shadow: none;
-  border-radius: 3px;
-  
-  &:hover {
-    border: 2px solid #f64e4e;
-    box-shadow: none;
-  }
-  
-}
-
-// CONNECT FIELD CORRECT ANSWERS
-div.muikku-connect-field.muikku-field-correct-answer {
-  border: none;
-  box-shadow: none;
-  
-  .muikku-connect-field-counterpart.muikku-connect-field-correct-answer, 
-  .muikku-connect-field-term.muikku-connect-field-correct-answer {
-    background: #55fc70;
-  }
-  
-}
-
-// CONNECT FIELD INCORRECT ANSWERS
-div.muikku-connect-field.muikku-field-incorrect-answer {
-  border: none;
-  box-shadow: none;
-  
-  .muikku-connect-field-counterpart.muikku-connect-field-wrong-answer, 
-  .muikku-connect-field-term.muikku-connect-field-wrong-answer {
-    background: #f64e4e;
+  // CORRECT ANSWERS COUNTER
+  .correct-answers-count-container {
+    display: block;
+    margin: 5px;
+    text-align: center;
+    font-size: 20px;
     
-    &.muikku-connect-field-term-selected {
-      background: #3dc7ff;
-      color: #fff;
-      font-weight: 400;
+    .correct-answers-count-label {
+      padding: 0 5px;
+      display: inline-block;
+    }
+    
+    .correct-answers-count-data {
+      padding: 0 5px;
+      display: inline-block;
     }
     
   }
   
-  // Connect field's correct answer's styling is required here as we mark 
-  // wrapping element to be incorrect when checking exercise
-  .muikku-connect-field-counterpart.muikku-connect-field-correct-answer, 
-  .muikku-connect-field-term.muikku-connect-field-correct-answer {
-    background: #55fc70;
+  // EXAMPLE ANSWERS
+  span.muikku-field-examples {
+    background: #e2ffe2;
+    border-radius: 3px;
+    display: inline-block;
+    font-size: 14px;
+    font-style: italic;
+    margin: 1px 3px;
+    padding: 3px;
+    vertical-align: middle;
+    width: auto;
+    
+    span.muikku-field-examples-title {
+      font-weight: 600;
+      margin: 0 6px;
+    }
+    
+    span.muikku-field-example {
+      border-left: 1px solid #439ba0;
+      display: inline-block;
+      line-height: 1.5;
+      margin: 3px 0 3px 5px;
+      padding: 0 8px;
+    }
+    
   }
   
-}
-
-// ORGANIZER FIELD CORRECT ANSWERS
-div.muikku-organizer-field {
-  
-  .muikku-category.muikku-field-correct-answer {
+  // TEXTFIELD, TEXTAREA, SELECT CORRECT ANSWERS
+  div.muikku-text-field.muikku-field-correct-answer,
+  div.muikku-memo-field.muikku-field-correct-answer,
+  input[type="text"].muikku-field-correct-answer,
+  textarea.muikku-field-correct-answer,
+  select.muikku-field-correct-answer {
     border: 2px solid #00ff2a;
     border-radius: 3px;
     box-shadow: none;
@@ -131,144 +63,179 @@ div.muikku-organizer-field {
     
   }
   
-  .muikku-category.muikku-field-semi-correct-answer {
-    border: 2px solid #dab33d;
-    border-radius: 3px;
-    box-shadow: none;
-    
-    &:hover {
-      border: 2px solid #dab33d;
-      box-shadow: none;
-    }
-    
-  }
-  
-  .muikku-category.muikku-field-incorrect-answer {
+  // TEXTFIELD, TEXTAREA, SELECT INCORRECT ANSWERS
+  div.muikku-text-field.muikku-field-incorrect-answer,
+  div.muikku-memo-field.muikku-field-incorrect-answer,
+  input[type="text"].muikku-field-incorrect-answer,
+  textarea.muikku-field-incorrect-answer,
+  select.muikku-field-incorrect-answer {
     border: 2px solid #f64e4e;
-    border-radius: 3px;
     box-shadow: none;
+    border-radius: 3px;
     
     &:hover {
       border: 2px solid #f64e4e;
       box-shadow: none;
     }
-
+    
   }
   
-}
-
-// ORGANIZER FIELD INCORRECT ANSWERS
-.muikku-sorter-field {
-  
-  .muikku-sorter-items-container.muikku-field-correct-answer {
-    border: 2px solid #00ff2a;
-    border-radius: 3px;
+  // CONNECT FIELD CORRECT ANSWERS
+  div.muikku-connect-field.muikku-field-correct-answer {
+    border: none;
     box-shadow: none;
     
-    &:hover {
-      border: 2px solid #00ff2a;
-      box-shadow: none;
+    .muikku-connect-field-counterpart.muikku-connect-field-correct-answer, 
+    .muikku-connect-field-term.muikku-connect-field-correct-answer {
+      background: #55fc70;
     }
     
   }
   
-  .muikku-sorter-items-container.muikku-field-semi-correct-answer {
-    border: 2px solid #dab33d;
-    border-radius: 3px;
+  // CONNECT FIELD INCORRECT ANSWERS
+  div.muikku-connect-field.muikku-field-incorrect-answer {
+    border: none;
     box-shadow: none;
     
-    &:hover {
-      border: 2px solid #dab33d;
-      box-shadow: none;
-    }
-    
-  }
-  
-  .muikku-sorter-items-container.muikku-field-incorrect-answer {
-    border: 2px solid #f64e4e;
-    border-radius: 3px;
-    box-shadow: none;
-    
-    &:hover {
-      border: 2px solid #f64e4e;
-      box-shadow: none;
-    }
-
-  }
-  
-  .muikku-sorter-items-container {
-  
-    .muikku-sorter-item {
-    
-      &.muikku-field-correct-answer {
-        background: #55fc70;
+    .muikku-connect-field-counterpart.muikku-connect-field-wrong-answer, 
+    .muikku-connect-field-term.muikku-connect-field-wrong-answer {
+      background: #f64e4e;
+      
+      &.muikku-connect-field-term-selected {
+        background: #3dc7ff;
+        color: #fff;
+        font-weight: 400;
       }
       
-      &.muikku-field-incorrect-answer {
-        background: #f64e4e;
+    }
+    
+    // Connect field's correct answer's styling is required here as we mark 
+    // wrapping element to be incorrect when checking exercise
+    .muikku-connect-field-counterpart.muikku-connect-field-correct-answer, 
+    .muikku-connect-field-term.muikku-connect-field-correct-answer {
+      background: #55fc70;
+    }
+    
+  }
+  
+  // ORGANIZER FIELD CORRECT ANSWERS
+  div.muikku-organizer-field {
+    
+    .muikku-category.muikku-field-correct-answer {
+      border: 2px solid #00ff2a;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #00ff2a;
+        box-shadow: none;
+      }
+      
+    }
+    
+    .muikku-category.muikku-field-semi-correct-answer {
+      border: 2px solid #dab33d;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #dab33d;
+        box-shadow: none;
+      }
+      
+    }
+    
+    .muikku-category.muikku-field-incorrect-answer {
+      border: 2px solid #f64e4e;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #f64e4e;
+        box-shadow: none;
+      }
+  
+    }
+    
+  }
+  
+  // ORGANIZER FIELD INCORRECT ANSWERS
+  .muikku-sorter-field {
+    
+    .muikku-sorter-items-container.muikku-field-correct-answer {
+      border: 2px solid #00ff2a;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #00ff2a;
+        box-shadow: none;
+      }
+      
+    }
+    
+    .muikku-sorter-items-container.muikku-field-semi-correct-answer {
+      border: 2px solid #dab33d;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #dab33d;
+        box-shadow: none;
+      }
+      
+    }
+    
+    .muikku-sorter-items-container.muikku-field-incorrect-answer {
+      border: 2px solid #f64e4e;
+      border-radius: 3px;
+      box-shadow: none;
+      
+      &:hover {
+        border: 2px solid #f64e4e;
+        box-shadow: none;
+      }
+  
+    }
+    
+    .muikku-sorter-items-container {
+    
+      .muikku-sorter-item {
+      
+        &.muikku-field-correct-answer {
+          background: #55fc70;
+        }
+        
+        &.muikku-field-incorrect-answer {
+          background: #f64e4e;
+        }
+      
       }
     
     }
-  
+    
   }
   
-}
+  // RADIO BUTTON, CHECKBOX CORRECT ANSWERS
+  input[type="checkbox"].muikku-field-correct-answer,
+  input[type="radio"].muikku-field-correct-answer {
+    box-shadow: 0 0 0 2px rgba(0,255,42,1);
+    
+    &:hover {
+      box-shadow: 0 0 0 2px rgba(0,255,42,1);
+    }
+    
+  }
+  
+  // RADIO BUTTON, CHECKBOX INCORRECT ANSWERS
+  input[type="checkbox"].muikku-field-incorrect-answer,
+  input[type="radio"].muikku-field-incorrect-answer {
+    box-shadow: 0 0 0 2px rgba(255,0,0,1);
+    
+    &:hover {
+      box-shadow: 0 0 0 2px rgba(255,0,0,1);
+    }
+  
+  }
 
-// RADIO BUTTON, CHECKBOX CORRECT ANSWERS
-span.muikku-checkbox-field.muikku-field-correct-answer,
-span.muikku-select-field.muikku-field-correct-answer {
-  box-shadow: none;
-  border: none;
-  
-  input[type="checkbox"],
-  input[type="radio"] {
-    box-shadow: 0 0 0 2px rgba(0,255,42,0.9);
-    
-    &:hover {
-      box-shadow: 0 0 0 2px rgba(0,255,42,0.9);
-    }
-    
-  }
-  
-  &:hover {
-    box-shadow: none;
-    border: none;  
-  }
-  
-}
-
-// RADIO BUTTON, CHECKBOX INCORRECT ANSWERS
-span.muikku-checkbox-field.muikku-field-incorrect-answer,
-span.muikku-select-field.muikku-field-incorrect-answer {
-  box-shadow: none;
-  border: none;
-  
-  input[type="checkbox"],
-  input[type="radio"] {
-    box-shadow: 0 0 0 2px rgba(255,0,0,0.7);
-    
-    &:hover {
-      box-shadow: 0 0 0 2px rgba(255,0,0,0.7);
-    }
-    
-  }
-  
-  &:hover {
-    box-shadow: none;
-    border: none;  
-  }
-  
-  input[type="checkbox"].muikku-field-correct-answer-override,
-  input[type="radio"].muikku-field-correct-answer-override {
-    box-shadow: 0 0 0 2px rgba(0,255,42,0.9);
-    border: 2px solid #00ff2a;
-    border-radius: 3px;
-    
-    &:hover {
-      box-shadow: 0 0 0 2px rgba(0,255,42,0.9);
-      border: 2px solid #00ff2a;
-    }
-  
-  }
-  
 }

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_mobile_workspace.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_mobile_workspace.scss
@@ -89,9 +89,9 @@
     
   }
   
-  .workspace-materials-view-page-section.material-view .workspace-materials-view-page.material-view,
-  .workspace-frontpage-material-page .workspace-materials-view-page.material-view,
-  .workspace-helppage-material-page .workspace-materials-view-page.material-view,
+  .workspace-materials-view-page-section.material-view .material-page.material-view,
+  .workspace-frontpage-material-page .material-page.material-view,
+  .workspace-helppage-material-page .material-page.material-view,
   .workspace-journal-content-wrapper,
   .workspace-students-listing-wrapper,
   h1.workspace-generic-view-title,
@@ -108,15 +108,15 @@
     padding: 5px 10px;
   }
   
-  .workspace-materials-view-page.material-view footer.article-details {
+  .material-page.material-view footer.article-details {
     margin: 0 -10px;
   }
   
-  .workspace-materials-view-page.material-view .muikku-save-page-wrapper {
+  .material-page.material-view .muikku-save-page-wrapper {
     margin: 20px -5px 15px;
   }
   
-  .workspace-materials-view-page-section.material-view .workspace-materials-view-page.material-view {
+  .workspace-materials-view-page-section.material-view .material-page.material-view {
     
     .muikku-page-assignment-type {
       margin: 0 0 0 -15px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -322,51 +322,36 @@
     }
   
   }
-
-  // CHECKBOX & RADIO BUTTON UNSAVED, SAVED, SAVING
-  .muikku-select-field,
-  .muikku-checkbox-field {
   
+  // CHECKBOX & RADIO BUTTON UNSAVED, SAVED, SAVING
+  input[type="checkbox"],
+  input[type="radio"] {
+
     &.muikku-field-unsaved {
-    
-      input[type="checkbox"],
-      input[type="radio"] {
-        box-shadow: 0 0 0 2px #e4e630;
+      box-shadow: 0 0 0 2px #e4e630;
         
-        &:hover {
-          box-shadow: 0 0 0 2px #e4e630;
-        }
-      
+      &:hover {
+        box-shadow: 0 0 0 2px #e4e630;
       }
       
     }
     
     &.muikku-field-saving {
-    
-      input[type="checkbox"],
-      input[type="radio"] {
-        animation: saving-checkbox-radio 4s ease infinite;
-        box-shadow: 0 0 0 2px #e4e630;
-      }
-      
+      animation: saving-checkbox-radio 4s ease infinite;
+      box-shadow: 0 0 0 2px #e4e630;
     }
   
     &.muikku-field-saved {
+      box-shadow: 0 0 0 2px #9cf3c7;
     
-      input[type="checkbox"],
-      input[type="radio"] {
+      &:hover {
         box-shadow: 0 0 0 2px #9cf3c7;
-      
-        &:hover {
-          box-shadow: 0 0 0 2px #9cf3c7;
-        }
-        
       }
       
     }
   
   }
-
+    
   // GENERIC PAGE ELEMENTS
   blockquote {
     font-family: 'Open Sans', Arial, sans-serif;
@@ -806,7 +791,37 @@
       display: inline-block;
       line-height: 1.5;
     }
+
+  }
+  
+  .explanation-wrapper {
+    position: relative;
+  
+    .explanation-button {
+      background: #009fe3;
+      border: 2px solid #fff;
+      border-radius: 100%;
+      color: #fff;
+      font-size: 12px;
+      padding: 2px;
+      
+    }
     
+    .explanation-content {
+      background: #ebf7ff;
+      border: 1px solid #fff;
+      border-radius: 5px;
+      bottom: 25px;
+      box-shadow: 0 0 10px rgba(0,0,0,0.2);
+      color: #000;
+      left: 50%; 
+      line-height: 1.5em;
+      padding: 8px;
+      margin: 0 0 0 -140px;
+      position: absolute;
+      width: 280px;
+    }
+  
   }
 
   .muikku-page-assignment-type {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -996,7 +996,8 @@
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
   color: #000;
   line-height: 1.5em;
-  padding: 8px;
+  max-width: 280px;
+  padding: 2px 4px;
   position: absolute;
   z-index: 99;
 }

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -995,6 +995,8 @@
   border-radius: 5px;
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
   color: #000;
+  font-size: 14px;
+  font-weight: 300;
   line-height: 1.5em;
   max-width: 280px;
   padding: 2px 4px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -1,4 +1,4 @@
-.workspace-materials-view-page { // This is article containing single material page
+.material-page { // This is article containing single material page
   padding: 10px 20px;
   margin: 30px auto;
   position: relative;
@@ -964,7 +964,7 @@
 
 }
 
-.workspace-materials-view-page[data-view-restricted="true"] {
+.material-page[data-view-restricted="true"] {
 
   .muikku-save-page-wrapper,
   .article-details {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -806,22 +806,7 @@
       padding: 2px;
       
     }
-    
-    .explanation-content {
-      background: #ebf7ff;
-      border: 1px solid #fff;
-      border-radius: 5px;
-      bottom: 25px;
-      box-shadow: 0 0 10px rgba(0,0,0,0.2);
-      color: #000;
-      left: 50%; 
-      line-height: 1.5em;
-      padding: 8px;
-      margin: 0 0 0 -140px;
-      position: absolute;
-      width: 280px;
-    }
-  
+          
   }
 
   .muikku-page-assignment-type {
@@ -1002,4 +987,16 @@
   padding: 5px 10px;
   position: absolute;
   z-index: 20;
+}
+
+.explanation-content {
+  background: #ebf7ff;
+  border: 1px solid #fff;
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  color: #000;
+  line-height: 1.5em;
+  padding: 8px;
+  position: absolute;
+  z-index: 99;
 }

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-workspace.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-workspace.scss
@@ -366,7 +366,7 @@ main.content {
 }
 
 /* WORKSPACE GLOBAL MATERIAL PAGE */
-article.material-page {
+.material-page {
   background:#fff;
   padding:20px;
   margin:30px 0;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-workspace.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-workspace.scss
@@ -366,7 +366,7 @@ main.content {
 }
 
 /* WORKSPACE GLOBAL MATERIAL PAGE */
-article.workspace-materials-view-page {
+article.material-page {
   background:#fff;
   padding:20px;
   margin:30px 0;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-help.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-help.scss
@@ -6,7 +6,7 @@
 
 .workspace-helppage-material-page {
 
-  .workspace-materials-view-page {
+  .material-page {
     background: #fff;
     padding: 20px;
     margin: 10px 0;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-index.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-index.scss
@@ -305,7 +305,7 @@ h1.workspace-block-title {
   
 }
 
-.workspace-frontpage-material-page .workspace-materials-view-page {
+.workspace-frontpage-material-page .material-page {
   background: #fff;
   padding: 20px;
   margin: 10px 0;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-management.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-management.scss
@@ -395,7 +395,7 @@ nav.workspace-waterials-management-nav {
 }
   
 // NEW 'DOCUMENT OR SECTION' SELECTION
-.workspace-materials-view-page.material-management-view.workspace-materials-management-new {
+.material-page.material-management-view.workspace-materials-management-new {
   padding: 20px 30px;
   margin: 30px auto;
   box-shadow: 0 0 0 5px rgba(137,212,142,0.95);
@@ -748,7 +748,7 @@ nav.workspace-waterials-management-nav {
 
 
 // DOCUMENT
-.workspace-materials-view-page.material-management-view {
+.material-page.material-management-view {
   position: relative;
   max-width: 695px;
   width: auto;
@@ -811,7 +811,7 @@ nav.workspace-waterials-management-nav {
 }
 
 // DOCUMENT EDIT MODE
-.workspace-materials-view-page.material-management-view.page-edit-mode {
+.material-page.material-management-view.page-edit-mode {
   box-shadow: 0 0 0 10px rgba(148,183,208,0.95);
   position: relative;
   padding: 50px 0 0;
@@ -917,9 +917,9 @@ nav.workspace-waterials-management-nav {
 }
 
 // DOCUMENT'S ATTACHMENT/LICENSE/PRODUCERS EDIT MODE
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-attachments,
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-license,
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-producers {
+.material-page.material-management-view.workspace-materials-management-editing-attachments,
+.material-page.material-management-view.workspace-materials-management-editing-license,
+.material-page.material-management-view.workspace-materials-management-editing-producers {
 
   .workspace-material-html-editor-title-wrapper,
   .cke,
@@ -957,7 +957,7 @@ nav.workspace-waterials-management-nav {
 }
 
 // DOCUMENT ATTACHMENT EDIT MODE CONTROLLER
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-attachments {
+.material-page.material-management-view.workspace-materials-management-editing-attachments {
   
   .workspace-materials-management-view-page-controls {
   
@@ -970,7 +970,7 @@ nav.workspace-waterials-management-nav {
 }
 
 // DOCUMENT LICENSE EDIT MODE CONTROLLER
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-license {
+.material-page.material-management-view.workspace-materials-management-editing-license {
   
   .workspace-materials-management-view-page-controls {
   
@@ -983,7 +983,7 @@ nav.workspace-waterials-management-nav {
 }
 
 // DOCUMENT PRODUCERS EDIT MODE CONTROLLER
-.workspace-materials-view-page.material-management-view.workspace-materials-management-editing-producers {
+.material-page.material-management-view.workspace-materials-management-editing-producers {
 
   .workspace-materials-management-view-page-controls {
   
@@ -1066,7 +1066,7 @@ nav.workspace-waterials-management-nav {
 }
 
 // SECTION
-.workspace-materials-view-page.material-management-view.folder { 
+.material-page.material-management-view.folder { 
   position: relative;
   font-weight: 300;
   max-width: 695px;
@@ -1103,7 +1103,7 @@ nav.workspace-waterials-management-nav {
 }
   
 // SECTION EDIT MODE
-.workspace-materials-view-page.material-management-view.folder.page-edit-mode {
+.material-page.material-management-view.folder.page-edit-mode {
   padding: 50px 0 10px;
   box-sizing: border-box;
 

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-reading.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-reading.scss
@@ -464,7 +464,7 @@ nav.workspace-waterials-reading-nav {
 }
 
 // DOCUMENT
-.workspace-materials-view-page.material-reading-view {
+.material-page.material-reading-view {
   background: #fff;
   box-shadow: $document-shadow;
   margin: 30px auto;
@@ -486,7 +486,7 @@ nav.workspace-waterials-reading-nav {
 }
 
 // SECTION
-.workspace-materials-view-page.material-reading-view.folder {
+.material-page.material-reading-view.folder {
   background: #fff;
   box-shadow: $document-shadow;
   color: #38393a;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-reading.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-materials-reading.scss
@@ -482,27 +482,27 @@ nav.workspace-waterials-reading-nav {
     }
     
   }
-
-}
-
-// SECTION
-.material-page.material-reading-view.folder {
-  background: #fff;
-  box-shadow: $document-shadow;
-  color: #38393a;
-  line-height: 1.3em;
-  max-width: 700px;
-  padding: 30px 20px;
-  position: relative;
-  text-transform: none;
-  width: auto;
-  word-wrap: break-word;
   
-  .page-content {
-    font-size: 27px;
+  // SECTION
+  &.folder {
+    background: #fff;
+    box-shadow: $document-shadow;
+    color: #38393a;
     line-height: 1.3em;
+    max-width: 700px;
+    padding: 30px 20px;
+    position: relative;
+    text-transform: none;
+    width: auto;
+    word-wrap: break-word;
+    
+    .page-content {
+      font-size: 27px;
+      line-height: 1.3em;
+    }
+    
   }
-  
+
 }
 
 @media screen and (max-width: 479px) {


### PR DESCRIPTION
- resolves #3197 
- fixes #3194

Added an explanation support for select fields. The optional explanation is shown together with right answers.

Refactored layout to fix issue 3194 (fields occasionally missing borders that indicate right and wrong answers).

Refactored checkbox fields so that the number of correct and incorrect answers is based on the number of checkboxes. Previously, the answer was either fully right or wrong, worth a single point. This also enabled us to remove a convoluted override of right answers for checkbox fields.