### PR TITLE
Speedup of vops view

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptOfRecordsController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptOfRecordsController.java
@@ -1,5 +1,9 @@
 package fi.otavanopisto.muikku.plugins.transcriptofrecords;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
@@ -8,10 +12,17 @@ import org.apache.commons.lang3.StringUtils;
 
 import fi.otavanopisto.muikku.controller.PluginSettingsController;
 import fi.otavanopisto.muikku.model.users.UserEntity;
+import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
+import fi.otavanopisto.muikku.model.workspace.WorkspaceUserEntity;
+import fi.otavanopisto.muikku.schooldata.GradingController;
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.UserSchoolDataController;
 import fi.otavanopisto.muikku.schooldata.entity.Subject;
 import fi.otavanopisto.muikku.schooldata.entity.User;
-import fi.otavanopisto.muikku.schooldata.entity.UserProperty;
+import fi.otavanopisto.muikku.schooldata.entity.WorkspaceAssessment;
+import fi.otavanopisto.muikku.search.SearchProvider;
+import fi.otavanopisto.muikku.search.SearchResult;
+import fi.otavanopisto.muikku.users.WorkspaceUserEntityController;
 
 public class TranscriptOfRecordsController {
 
@@ -20,6 +31,15 @@ public class TranscriptOfRecordsController {
   
   @Inject
   private PluginSettingsController pluginSettingsController;
+  
+  @Inject
+  private GradingController gradingController;
+
+  @Inject
+  private WorkspaceUserEntityController workspaceUserEntityController;
+
+  @Inject
+  private SearchProvider searchProvider;
   
   private static final Pattern UPPER_SECONDARY_SCHOOL_SUBJECT_PATTERN = Pattern.compile("^[A-ZÅÄÖ0-9]+$");
 
@@ -32,13 +52,15 @@ public class TranscriptOfRecordsController {
       return false;
     }
 
-    String mathSyllabus = loadStringProperty(student, "mathSyllabus");
-    String finnish = loadStringProperty(student, "finnish");
-    boolean german = loadBoolProperty(student, "german");
-    boolean french = loadBoolProperty(student, "french");
-    boolean italian = loadBoolProperty(student, "italian");
-    boolean spanish = loadBoolProperty(student, "spanish");
-    String religion = loadStringProperty(student, "religion");
+    TranscriptofRecordsUserProperties userProperties = loadUserProperties(student);
+    
+    String mathSyllabus = userProperties.asString("mathSyllabus");
+    String finnish = userProperties.asString("finnish");
+    boolean german = userProperties.asBoolean("german");
+    boolean french = userProperties.asBoolean("french");
+    boolean italian = userProperties.asBoolean("italian");
+    boolean spanish = userProperties.asBoolean("spanish");
+    String religion = userProperties.asString("religion");
 
     String code = subject.getCode();
 
@@ -89,25 +111,6 @@ public class TranscriptOfRecordsController {
     return true;
   }
 
-  public String loadStringProperty(User user, String propertyName) {
-    UserProperty property = userSchoolDataController.getUserProperty(user, "hops." + propertyName);
-    if (property != null) {
-      return property.getValue();
-    } else {
-      return null;
-    }
-  }
-
-  public boolean loadBoolProperty(User user, String propertyName) {
-    UserProperty property = userSchoolDataController.getUserProperty(user, "hops." + propertyName);
-    if (property != null) {
-      return "yes".equals(property.getValue());
-    } else {
-      return false;
-    }
-  }
-
-
   public void saveStringProperty(User user, String propertyName, String value) {
     if (value != null && !"".equals(value)) {
       userSchoolDataController.setUserProperty(user, "hops." + propertyName, value);
@@ -133,5 +136,55 @@ public class TranscriptOfRecordsController {
     return false;
   }
 
+  public TranscriptofRecordsUserProperties loadUserProperties(User user) {
+    return new TranscriptofRecordsUserProperties(userSchoolDataController.listUserProperties(user));
+  }
 
+  public List<VopsWorkspace> listWorkspaceIdentifiersBySubjectIdentifierAndCourseNumber(String schoolDataSource, String subjectIdentifier, int courseNumber) {
+    SearchResult sr = searchProvider.searchWorkspaces(schoolDataSource, subjectIdentifier, courseNumber);
+    List<VopsWorkspace> retval = new ArrayList<>();
+    List<Map<String, Object>> results = sr.getResults();
+    for (Map<String, Object> result : results) {
+      String searchId = (String) result.get("id");
+      if (StringUtils.isNotBlank(searchId)) {
+        String[] id = searchId.split("/", 2);
+        if (id.length == 2) {
+          String dataSource = id[1];
+          String identifier = id[0];
+          String educationTypeId = (String) result.get("educationSubtypeIdentifier");
+          
+          SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(identifier, dataSource);
+          SchoolDataIdentifier educationSubtypeIdentifier = SchoolDataIdentifier.fromId(educationTypeId);
+          
+          retval.add(new VopsWorkspace(workspaceIdentifier, educationSubtypeIdentifier));
+        }
+      }
+    }
+      
+    return retval;
+  }
+
+  public Map<SchoolDataIdentifier, WorkspaceAssessment> listStudentAssessments(SchoolDataIdentifier studentIdentifier) {
+    List<WorkspaceAssessment> assessmentsByStudent = gradingController.listAssessmentsByStudent(studentIdentifier);
+    
+    Map<SchoolDataIdentifier, WorkspaceAssessment> result = new HashMap<>();
+    for (WorkspaceAssessment assessment : assessmentsByStudent) {
+      WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityController.findWorkspaceUserEntityByWorkspaceUserIdentifier(assessment.getWorkspaceUserIdentifier());
+      
+      WorkspaceEntity workspaceEntity = workspaceUserEntity.getWorkspaceEntity();
+      SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(workspaceEntity.getIdentifier(), workspaceEntity.getDataSource().getIdentifier());
+     
+      if (!result.containsKey(workspaceIdentifier)) {
+        result.put(workspaceIdentifier, assessment);
+      } else {
+        WorkspaceAssessment storedAssessment = result.get(workspaceIdentifier);
+        
+        if (assessment.getDate().after(storedAssessment.getDate()))
+          result.put(workspaceIdentifier, assessment);
+      }
+    }
+    
+    return result;
+  }
+  
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptofRecordsBackingBean.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptofRecordsBackingBean.java
@@ -19,7 +19,6 @@ import org.ocpsoft.rewrite.annotation.RequestAction;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import fi.otavanopisto.muikku.controller.PluginSettingsController;
 import fi.otavanopisto.muikku.jsf.NavigationRules;
 import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.model.TranscriptOfRecordsFile;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptofRecordsUserProperties.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/TranscriptofRecordsUserProperties.java
@@ -1,0 +1,40 @@
+package fi.otavanopisto.muikku.plugins.transcriptofrecords;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import fi.otavanopisto.muikku.schooldata.entity.UserProperty;
+
+public class TranscriptofRecordsUserProperties {
+  
+  public TranscriptofRecordsUserProperties(List<UserProperty> properties) {
+    map(properties);
+  }
+
+  private void map(List<UserProperty> properties) {
+    for (UserProperty property : properties) {
+      this.properties.put(property.getKey(), property);
+    }
+  }
+
+  public String asString(String key) {
+    UserProperty property = properties.get("hops." + key);
+    if (property != null) {
+      return property.getValue();
+    } else {
+      return null;
+    }
+  }
+  
+  public boolean asBoolean(String key) {
+    UserProperty property = properties.get("hops." + key);
+    if (property != null) {
+      return "yes".equals(property.getValue());
+    } else {
+      return false;
+    }
+  }
+  
+  private Map<String, UserProperty> properties = new HashMap<>();
+}

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/VopsWorkspace.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/VopsWorkspace.java
@@ -1,0 +1,22 @@
+package fi.otavanopisto.muikku.plugins.transcriptofrecords;
+
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
+
+public class VopsWorkspace {
+  
+  public VopsWorkspace(SchoolDataIdentifier workspaceIdentifier, SchoolDataIdentifier educationSubtypeIdentifier) {
+    this.workspaceIdentifier = workspaceIdentifier;
+    this.educationSubtypeIdentifier = educationSubtypeIdentifier;
+  }
+  
+  public SchoolDataIdentifier getWorkspaceIdentifier() {
+    return workspaceIdentifier;
+  }
+
+  public SchoolDataIdentifier getEducationSubtypeIdentifier() {
+    return educationSubtypeIdentifier;
+  }
+
+  private final SchoolDataIdentifier workspaceIdentifier;
+  private final SchoolDataIdentifier educationSubtypeIdentifier;
+}

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
@@ -36,7 +36,6 @@ import fi.otavanopisto.muikku.plugins.transcriptofrecords.TranscriptofRecordsUse
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.VopsWorkspace;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.model.TranscriptOfRecordsFile;
 import fi.otavanopisto.muikku.schooldata.CourseMetaController;
-import fi.otavanopisto.muikku.schooldata.GradingController;
 import fi.otavanopisto.muikku.schooldata.RestCatchSchoolDataExceptions;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.WorkspaceController;
@@ -90,9 +89,6 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
 
   @Inject
   private PluginSettingsController pluginSettingsController;
-
-  @Inject
-  private GradingController gradingController;
 
   @GET
   @Path("/files/{ID}/content")

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
@@ -3,8 +3,8 @@ package fi.otavanopisto.muikku.plugins.transcriptofrecords.rest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 import javax.ejb.Stateful;
 import javax.enterprise.context.RequestScoped;
@@ -32,6 +32,8 @@ import fi.otavanopisto.muikku.plugin.PluginRESTService;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.TranscriptOfRecordsController;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.TranscriptOfRecordsFileController;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.TranscriptofRecordsPermissions;
+import fi.otavanopisto.muikku.plugins.transcriptofrecords.TranscriptofRecordsUserProperties;
+import fi.otavanopisto.muikku.plugins.transcriptofrecords.VopsWorkspace;
 import fi.otavanopisto.muikku.plugins.transcriptofrecords.model.TranscriptOfRecordsFile;
 import fi.otavanopisto.muikku.schooldata.CourseMetaController;
 import fi.otavanopisto.muikku.schooldata.GradingController;
@@ -168,29 +170,31 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
     List<VopsRESTModel.VopsRow> rows = new ArrayList<>();
     int numCourses = 0;
     int numMandatoryCourses = 0;
+    Map<SchoolDataIdentifier, WorkspaceAssessment> studentAssessments = vopsController.listStudentAssessments(studentIdentifier);
     
     for (Subject subject : subjects) {
       if (vopsController.subjectAppliesToStudent(student, subject)) {
         List<VopsRESTModel.VopsItem> items = new ArrayList<>();
         for (int i=1; i<MAX_COURSE_NUMBER; i++) {
-          List<Workspace> workspaces =
-              workspaceController.listWorkspacesBySubjectIdentifierAndCourseNumber(
+          List<VopsWorkspace> workspaces =
+              vopsController.listWorkspaceIdentifiersBySubjectIdentifierAndCourseNumber(
                   subject.getSchoolDataSource(),
                   subject.getIdentifier(),
                   i);
+          
           List<WorkspaceAssessment> workspaceAssessments = new ArrayList<>();
           if (!workspaces.isEmpty()) {
             SchoolDataIdentifier educationSubtypeIdentifier = null;
             boolean workspaceUserExists = false;
-            for (Workspace workspace : workspaces) {
+            for (VopsWorkspace workspace : workspaces) {
               WorkspaceEntity workspaceEntity =
-                  workspaceController.findWorkspaceEntity(workspace);
+                  workspaceController.findWorkspaceEntityById(workspace.getWorkspaceIdentifier());
               WorkspaceUserEntity workspaceUser =
                   workspaceUserEntityController.findWorkspaceUserByWorkspaceEntityAndUserIdentifier(
                       workspaceEntity,
                       studentIdentifier);
-              SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(workspace.getIdentifier(), workspace.getSchoolDataSource());
-              WorkspaceAssessment workspaceAssesment = gradingController.findLatestWorkspaceAssessment(workspaceIdentifier, studentIdentifier);
+              WorkspaceAssessment workspaceAssesment = studentAssessments.get(workspace.getWorkspaceIdentifier());
+              
               if (workspaceAssesment != null) {
                 workspaceAssessments.add(workspaceAssesment);
               }
@@ -199,12 +203,14 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
                 workspaceUserExists = true;
               }
             }
-            for (Workspace workspace : workspaces) {
+            
+            for (VopsWorkspace workspace : workspaces) {
               educationSubtypeIdentifier = workspace.getEducationSubtypeIdentifier();
               if (educationSubtypeIdentifier != null) {
                 break;
               }
             }
+            
             Mandatority mandatority = educationTypeMapping.getMandatority(educationSubtypeIdentifier);
             CourseCompletionState state = CourseCompletionState.NOT_ENROLLED;
             if (workspaceUserExists) {
@@ -252,25 +258,27 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
       return null;
     }
 
+    TranscriptofRecordsUserProperties userProperties = vopsController.loadUserProperties(user);
+    
     return new HopsRESTModel(
-        vopsController.loadStringProperty(user, "goalSecondarySchoolDegree"),
-        vopsController.loadStringProperty(user, "goalMatriculationExam"),
-        vopsController.loadStringProperty(user, "vocationalYears"),
-        vopsController.loadStringProperty(user, "goalJustMatriculationExam"),
-        vopsController.loadStringProperty(user, "justTransferCredits"),
-        vopsController.loadStringProperty(user, "transferCreditYears"),
-        vopsController.loadStringProperty(user, "completionYears"),
-        vopsController.loadStringProperty(user, "mathSyllabus"),
-        vopsController.loadStringProperty(user, "finnish"),
-        vopsController.loadBoolProperty(user, "swedish"),
-        vopsController.loadBoolProperty(user, "english"),
-        vopsController.loadBoolProperty(user, "german"),
-        vopsController.loadBoolProperty(user, "french"),
-        vopsController.loadBoolProperty(user, "italian"),
-        vopsController.loadBoolProperty(user, "spanish"),
-        vopsController.loadStringProperty(user, "science"),
-        vopsController.loadStringProperty(user, "religion"),
-        vopsController.loadStringProperty(user, "additionalInfo")
+        userProperties.asString("goalSecondarySchoolDegree"),
+        userProperties.asString("goalMatriculationExam"),
+        userProperties.asString("vocationalYears"),
+        userProperties.asString("goalJustMatriculationExam"),
+        userProperties.asString("justTransferCredits"),
+        userProperties.asString("transferCreditYears"),
+        userProperties.asString("completionYears"),
+        userProperties.asString("mathSyllabus"),
+        userProperties.asString("finnish"),
+        userProperties.asBoolean("swedish"),
+        userProperties.asBoolean("english"),
+        userProperties.asBoolean("german"),
+        userProperties.asBoolean("french"),
+        userProperties.asBoolean("italian"),
+        userProperties.asBoolean("spanish"),
+        userProperties.asString("science"),
+        userProperties.asString("religion"),
+        userProperties.asString("additionalInfo")
     );
   }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
@@ -42,7 +42,6 @@ import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.WorkspaceController;
 import fi.otavanopisto.muikku.schooldata.entity.Subject;
 import fi.otavanopisto.muikku.schooldata.entity.User;
-import fi.otavanopisto.muikku.schooldata.entity.Workspace;
 import fi.otavanopisto.muikku.schooldata.entity.WorkspaceAssessment;
 import fi.otavanopisto.muikku.session.SessionController;
 import fi.otavanopisto.muikku.users.EnvironmentUserController;

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingController.java
@@ -152,6 +152,17 @@ public class GradingController {
     
     return gradingSchoolDataController.listWorkspaceAssessments(studentIdentifier.getDataSource(), workspaceIdentifier.getIdentifier(), studentIdentifier.getIdentifier());
   }
+
+  /**
+   * Lists all assessments for student. Note that they may contain assessments pointed to 
+   * the same workspace.
+   * 
+   * @param studentIdentifier
+   * @return
+   */
+  public List<WorkspaceAssessment> listAssessmentsByStudent(SchoolDataIdentifier studentIdentifier) {
+    return gradingSchoolDataController.listAssessmentsByStudent(studentIdentifier.getDataSource(), studentIdentifier.getIdentifier());
+  }  
   
   public WorkspaceAssessment findLatestWorkspaceAssessment(SchoolDataIdentifier workspaceIdentifier, SchoolDataIdentifier studentIdentifier) {
     List<WorkspaceAssessment> workspaceAssessments = listWorkspaceAssessments(workspaceIdentifier, studentIdentifier);

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingSchoolDataBridge.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingSchoolDataBridge.java
@@ -90,6 +90,8 @@ public interface GradingSchoolDataBridge {
    */
   public List<WorkspaceAssessment> listWorkspaceAssessments(String workspaceIdentifier, String studentIdentifier);
   
+  public List<WorkspaceAssessment> listAssessmentsByStudent(String studentIdentifier);
+  
   /**
    * Updates a workspace assessment
    * 

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingSchoolDataController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/GradingSchoolDataController.java
@@ -332,6 +332,18 @@ class GradingSchoolDataController {
     return null;
   }
 
+  public List<WorkspaceAssessment> listAssessmentsByStudent(String schoolDataSource, String studentIdentifier) {
+    SchoolDataSource dataSource = schoolDataSourceDAO.findByIdentifier(schoolDataSource);
+    GradingSchoolDataBridge schoolDataBridge = getGradingBridge(dataSource);
+    if (schoolDataBridge != null) {
+      return schoolDataBridge.listAssessmentsByStudent(studentIdentifier);
+    } else {
+      logger.log(Level.SEVERE, "School Data Bridge could not be found for data source: "  + dataSource.getIdentifier());
+    }
+  
+    return null;
+  }
+  
   public List<WorkspaceAssessmentRequest> listAssessmentRequestsByStudent(String schoolDataSource, String studentIdentifier) {
     SchoolDataSource dataSource = schoolDataSourceDAO.findByIdentifier(schoolDataSource);
     GradingSchoolDataBridge schoolDataBridge = getGradingBridge(dataSource);

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/UserSchoolDataController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/UserSchoolDataController.java
@@ -206,6 +206,17 @@ public class UserSchoolDataController {
   
   /* User properties */
 
+  public List<UserProperty> listUserProperties(User user) {
+    SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
+    if (schoolDataSource != null) {
+      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
+      if (schoolDataBridge != null) {
+        return schoolDataBridge.listUserPropertiesByUser(user.getIdentifier());
+      }
+    }
+    return null;
+  }
+  
   public UserProperty getUserProperty(User user, String key) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
     if (schoolDataSource != null) {

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/WorkspaceController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/WorkspaceController.java
@@ -4,13 +4,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
-
-import org.apache.commons.lang3.StringUtils;
 
 import fi.otavanopisto.muikku.dao.base.SchoolDataSourceDAO;
 import fi.otavanopisto.muikku.dao.users.RoleSchoolDataIdentifierDAO;
@@ -36,8 +33,6 @@ import fi.otavanopisto.muikku.schooldata.entity.User;
 import fi.otavanopisto.muikku.schooldata.entity.Workspace;
 import fi.otavanopisto.muikku.schooldata.entity.WorkspaceType;
 import fi.otavanopisto.muikku.schooldata.entity.WorkspaceUser;
-import fi.otavanopisto.muikku.search.SearchProvider;
-import fi.otavanopisto.muikku.search.SearchResult;
 import fi.otavanopisto.muikku.users.WorkspaceUserEntityController;
 
 public class WorkspaceController {
@@ -71,9 +66,6 @@ public class WorkspaceController {
 
   @Inject
   private WorkspaceMaterialProducerDAO workspaceMaterialProducerDAO;
-  
-  @Inject
-  private SearchProvider searchProvider;
 
   /* Workspace */
 
@@ -111,33 +103,6 @@ public class WorkspaceController {
 
   public List<Workspace> listWorkspaces(String schoolDataSource) {
     return workspaceSchoolDataController.listWorkspaces(schoolDataSource);
-  }
-  
-  public List<Workspace> listWorkspacesBySubjectIdentifierAndCourseNumber(String schoolDataSource, String subjectIdentifier, int courseNumber) {
-    SearchResult sr = searchProvider.searchWorkspaces(schoolDataSource, subjectIdentifier, courseNumber);
-    List<Workspace> retval = new ArrayList<>();
-    List<Map<String, Object>> results = sr.getResults();
-    for (Map<String, Object> result : results) {
-      String searchId = (String) result.get("id");
-      if (StringUtils.isNotBlank(searchId)) {
-        String[] id = searchId.split("/", 2);
-        if (id.length == 2) {
-          String dataSource = id[1];
-          String identifier = id[0];
-
-          SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(identifier, dataSource);
-          
-          Workspace workspace = findWorkspace(workspaceIdentifier);
-          if (workspace != null) {
-            retval.add(workspace);
-          } else {
-            logger.log(Level.WARNING, "Workspace not found for identifier in index: %s", workspaceIdentifier);
-          }
-        }
-      }
-    }
-      
-    return retval;
   }
   
   public Workspace copyWorkspace(SchoolDataIdentifier workspaceIdentifier, String name, String nameExtension, String description) {
@@ -192,6 +157,10 @@ public class WorkspaceController {
 
   public WorkspaceEntity findWorkspaceEntityById(Long workspaceId) {
     return workspaceEntityDAO.findById(workspaceId);
+  }
+
+  public WorkspaceEntity findWorkspaceEntityById(SchoolDataIdentifier identifier) {
+    return findWorkspaceEntityByDataSourceAndIdentifier(identifier.getDataSource(), identifier.getIdentifier());
   }
 
   public WorkspaceEntity findWorkspaceEntityByUrlName(String urlName) {

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusGradingSchoolDataBridge.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusGradingSchoolDataBridge.java
@@ -397,6 +397,16 @@ public class PyramusGradingSchoolDataBridge implements GradingSchoolDataBridge {
     return entityFactory.createEntity(pyramusClient.get(String.format("/students/students/%d/assessmentRequests/", studentId), CourseAssessmentRequest[].class));
   }
   
+  @Override
+  public List<WorkspaceAssessment> listAssessmentsByStudent(String studentIdentifier) {
+    Long studentId = identifierMapper.getPyramusStudentId(studentIdentifier);
+    if (studentId == null) {
+      logger.severe(String.format("Could not translate %s to Pyramus student", studentIdentifier));
+      return null; 
+    }
+    return entityFactory.createEntity(pyramusClient.get(String.format("/students/students/%d/assessments/", studentId), CourseAssessment[].class));
+  }
+  
   public List<CompositeAssessmentRequest> listCompositeAssessmentRequestsByWorkspace(String workspaceIdentifier) {
     return listCompositeAssessmentRequestsByWorkspace(workspaceIdentifier, new ArrayList<String>());
   }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUserSchoolDataBridge.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUserSchoolDataBridge.java
@@ -425,7 +425,24 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
 
   @Override
   public List<UserProperty> listUserPropertiesByUser(String userIdentifier) {
-    throw new SchoolDataBridgeInternalException("Not implemented");
+    Long studentId = identifierMapper.getPyramusStudentId(userIdentifier);
+    if (studentId != null) {
+      Student student = pyramusClient.get("/students/students/" + studentId, Student.class);
+      Map<String, String> variables = student.getVariables();
+      
+      List<UserProperty> userProperties = new ArrayList<>();
+      
+      for (String key : variables.keySet()) {
+        String value = variables.get(key);
+        if (value != null) {
+          userProperties.add(new PyramusUserProperty(userIdentifier, key, value));
+        }
+      }
+      
+      return userProperties;
+    }
+    
+    throw new SchoolDataBridgeInternalException(String.format("Malformed user identifier %s", userIdentifier));
   }
 
   @Override


### PR DESCRIPTION
Closes #3202 

- Changed loading of student assessments to load all assessments at once (pyramus/#504)
- Removed loading of Workspace object which propagated to loading of educationtypes and subtypes individually from Pyramus
- User properties were already caching but still changed it to a more explicit format of retrieving the whole userproperty stack at once instead of individual queries