### PR TITLE
NPE fix for listing workspace students

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -935,6 +935,11 @@ public class WorkspaceRESTService extends PluginRESTService {
       SchoolDataIdentifier workspaceUserIdentifier = workspaceUser.getIdentifier();
       WorkspaceUserEntity workspaceUserEntity = workspaceUserEntityMap.get(workspaceUserIdentifier.toId());
       
+      if (workspaceUserEntity == null) {
+        logger.log(Level.WARNING, String.format("Workspace student %s does not exist in Muikku", workspaceUserIdentifier.toId()));
+        continue;
+      }
+      
       if (active == null || active.equals(workspaceUserEntity.getActive())) {
         if (requestedAssessment != null) {
           boolean hasAssessmentRequest = workspaceUserEntity != null && !assessmentRequestController.listByWorkspaceUser(workspaceUserEntity).isEmpty();


### PR DESCRIPTION
- fixes #3250

Some (inactive) workspace students are not yet fully synced between Muikku and Pyramus. PyramusSchoolDataWorkspaceStudentsUpdateScheduler will eventually fix such discrepancies. For now, though, added an existence check and error logging to prevent students missing in Muikku from causing a 500 when listing workspace students.