### PR TITLE
Pyramus scheduler changes

### DIFF
--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
@@ -19,8 +19,8 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
 
-import fi.otavanopisto.muikku.events.ContextDestroyedEvent;
 import fi.otavanopisto.muikku.events.ContextInitializedEvent;
 import fi.otavanopisto.muikku.plugins.schooldatapyramus.SchoolDataPyramusPluginDescriptor;
 
@@ -28,108 +28,74 @@ import fi.otavanopisto.muikku.plugins.schooldatapyramus.SchoolDataPyramusPluginD
 public class PyramusScheduler {
 
   private static final int INITIAL_TIMEOUT = 1000 * 180; // 180 sec
-  private static final int TIMEOUT = 1000 * 15; // 15 sec 
-  private static final int ERROR_TIMEOUT = 1000 * 60; // 60 sec 
-  
+  private static final int TIMEOUT = 1000 * 30; // 30 sec
+  private static final int ERROR_TIMEOUT = 1000 * 60; // 60 sec
+
   @Any
   @Inject
   private Instance<PyramusUpdateScheduler> updateSchedulers;
-  
+
   @Resource
   private TimerService timerService;
-  
+
   @Inject
   private Logger logger;
-  
+
   @PostConstruct
   public void init() {
-    contextInitialized = false;
-    running = false;
     schedulerIndex = 0;
   }
-  
+
   public void onContextInitialized(@Observes ContextInitializedEvent event) {
-    contextInitialized = true;
+    if (!SchoolDataPyramusPluginDescriptor.SCHEDULERS_ACTIVE || "true".equals(System.getProperty("tests.running"))) {
+      return;
+    }
     startTimer(INITIAL_TIMEOUT);
   }
 
-  public void onContextDestroyed(@Observes ContextDestroyedEvent event) {
-    contextInitialized = false;
-    
-    if (this.timer != null) {
-      timer.cancel();
-      timer = null;
-    }
-  }
-  
   @Timeout
   public void syncTimeout(Timer timer) {
     try {
       synchronizePyramusData();
 
       startTimer(TIMEOUT);
-    } catch (Exception ex) {
+    }
+    catch (Exception ex) {
       logger.log(Level.SEVERE, "synchronization failed.", ex);
-      
+
       startTimer(ERROR_TIMEOUT);
     }
   }
-  
+
   public void synchronizePyramusData() {
-    if (!SchoolDataPyramusPluginDescriptor.SCHEDULERS_ACTIVE) {
-      return;
-    }
-    
-    if (contextInitialized) {
-      if (running) {
-        return;  
+    @SuppressWarnings("unchecked")
+    List<PyramusUpdateScheduler> schedulers = IteratorUtils.toList(updateSchedulers.iterator());
+    Collections.sort(schedulers, new Comparator<PyramusUpdateScheduler>() {
+      @Override
+      public int compare(PyramusUpdateScheduler o1, PyramusUpdateScheduler o2) {
+        return o1.getPriority() - o2.getPriority();
       }
+    });
 
-      @SuppressWarnings("unchecked")
-      List<PyramusUpdateScheduler> schedulers = IteratorUtils.toList(updateSchedulers.iterator());
-      Collections.sort(schedulers, new Comparator<PyramusUpdateScheduler>() {
-        @Override
-        public int compare(PyramusUpdateScheduler o1, PyramusUpdateScheduler o2) {
-          return o1.getPriority() - o2.getPriority();
-        }
-      });
-      
-      PyramusUpdateScheduler updateScheduler = schedulers.get(schedulerIndex);
+    PyramusUpdateScheduler updateScheduler = schedulers.get(schedulerIndex);
 
-      try {
-        running = true;
-        updateScheduler.synchronize();
-      } catch (Exception ex) {
-        logger.log(Level.SEVERE, "Synchronization failed", ex);
-      } finally {
-        running = false;
-      }
-
-      schedulerIndex = (schedulerIndex + 1) % schedulers.size();
+    try {
+      logger.info(String.format("Running %s", StringUtils.substringBefore(updateScheduler.getClass().getSimpleName(), "$")));
+      updateScheduler.synchronize();
     }
+    catch (Exception ex) {
+      logger.log(Level.SEVERE, "Scheduler failed", ex);
+    }
+
+    schedulerIndex = (schedulerIndex + 1) % schedulers.size();
   }
-  
+
   private void startTimer(int duration) {
-    if (!contextInitialized)
-      return;
-    
-    if ("true".equals(System.getProperty("tests.running"))) { 
-        return;
-    }
-    
-    if (this.timer != null) {
-      this.timer.cancel();
-      this.timer = null;
-    }
-    
     TimerConfig timerConfig = new TimerConfig();
     timerConfig.setPersistent(false);
-    
-    this.timer = timerService.createSingleActionTimer(duration, timerConfig);
+    timerService.createSingleActionTimer(duration, timerConfig);
   }
-  
-  private Timer timer;
-  private boolean contextInitialized;
-  private boolean running;
+
   private int schedulerIndex;
+
 }


### PR DESCRIPTION
- resolves #3402
- increased pause between scheduled runs from 15 to 30 seconds (more
breathing room for other functionality)
- removed storing and canceling of timers (the underlying timer service
is wholly responsible of single action timers)
- log scheduler being called (to pinpoint possible problems)