### PR TITLE
Bug 3368 notifications wrong group

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NotificationController.java
@@ -83,7 +83,8 @@ public class NotificationController {
     map.put("time", String.valueOf(System.currentTimeMillis()));
 
     UserEntity guidanceCounselor = null;
-    List<UserGroupEntity> userGroupEntities = userGroupEntityController.listUserGroupsByUserEntity(recipient);
+    SchoolDataIdentifier userIdentifier = new SchoolDataIdentifier(recipient.getDefaultIdentifier(), recipient.getDefaultSchoolDataSource().getIdentifier());
+    List<UserGroupEntity> userGroupEntities = userGroupEntityController.listUserGroupsByUserIdentifier(userIdentifier);
     
     // #3089: An awkward workaround to use the latest guidance group based on its identifier. Assumes a larger
     // identifier means a more recent entity. A more proper fix would be to sync group creation dates from

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataUserGroupListener.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataUserGroupListener.java
@@ -122,9 +122,11 @@ public class DefaultSchoolDataUserGroupListener {
   public void onSchoolDataUserGroupUserUpdatedEvent(@Observes SchoolDataUserGroupUserUpdatedEvent event) {
     UserGroupUserEntity userGroupUserEntity = userGroupEntityController.findUserGroupUserEntityByDataSourceAndIdentifier(event.getDataSource(), event.getIdentifier());
     UserGroupEntity userGroupEntity = userGroupEntityController.findUserGroupEntityByDataSourceAndIdentifier(event.getUserGroupDataSource(), event.getUserGroupIdentifier());
+    UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByDataSourceAndIdentifier(event.getUserDataSource(), event.getUserIdentifier());
     
-    if ((userGroupUserEntity != null) && (userGroupEntity != null)) {
+    if ((userGroupUserEntity != null) && (userGroupEntity != null) && (userSchoolDataIdentifier != null)) {
       userGroupEntityController.updateUserGroupEntity(userGroupUserEntity, userGroupEntity);
+      userGroupEntityController.updateUserSchoolDataIdentifier(userGroupUserEntity, userSchoolDataIdentifier);
     } else
       logger.warning(String.format("Couldn't find userGroupUserEntity (%s) or userGroupEntity (%s)", event.getIdentifier(), event.getUserGroupIdentifier()));
   }  

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
@@ -359,11 +359,11 @@ public class PyramusUpdater {
       if (userGroupUserEntity != null)
         fireUserGroupUserRemoved(identifier, userGroupIdentifier, userGroupUserEntity.getUserSchoolDataIdentifier().getIdentifier());
     } else {
+      String studentIdentifier = identifierMapper.getStudentIdentifier(studentGroupStudent.getStudentId());
       if (userGroupUserEntity == null) {
-        String studentIdentifier = identifierMapper.getStudentIdentifier(studentGroupStudent.getStudentId());
         fireUserGroupUserDiscovered(identifier, userGroupIdentifier, studentIdentifier);
       } else {
-        fireUserGroupUserUpdated(identifier, userGroupIdentifier, userGroupUserEntity.getUserSchoolDataIdentifier().getIdentifier());
+        fireUserGroupUserUpdated(identifier, userGroupIdentifier, studentIdentifier);
       }
     }
   }


### PR DESCRIPTION
Closes #3368 

* Changed notification to look only on the active identifier groups
* Fixed updating of the student identifier in UserGroupUserEntity if it was changed

