### PR TITLE
PyramusScheduler changes

### DIFF
--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
@@ -648,17 +648,14 @@ public class PyramusUpdater {
   }
 
   /**
-   * Updates course students from Pyramus
+   * Updates active course students from Pyramus
    * 
    * @param courseId id of course in Pyramus
    * @return count of updated course students
    */
-  public int updateWorkspaceStudents(WorkspaceEntity workspaceEntity) {
+  public int updateActiveWorkspaceStudents(WorkspaceEntity workspaceEntity) {
     int count = 0;
     Long courseId = identifierMapper.getPyramusCourseId(workspaceEntity.getIdentifier());
-
-    // Synchronize active students of a course
-    
     CourseStudent[] courseStudents = pyramusClient.get().get("/courses/courses/" + courseId + "/students?filterArchived=false&activeStudents=true", CourseStudent[].class);
     if (courseStudents != null) {
       for (CourseStudent courseStudent : courseStudents) {
@@ -681,9 +678,18 @@ public class PyramusUpdater {
         }
       }
     }
-
-    // Synchronize inactive students of a course
-    
+    return count;
+  }
+  
+  /**
+   * Updates inactive course students from Pyramus
+   * 
+   * @param courseId id of course in Pyramus
+   * @return count of updated course students
+   */
+  public int updateInactiveWorkspaceStudents(WorkspaceEntity workspaceEntity) {
+    int count = 0;
+    Long courseId = identifierMapper.getPyramusCourseId(workspaceEntity.getIdentifier());
     CourseStudent[] nonActiveCourseStudents = pyramusClient.get().get("/courses/courses/" + courseId + "/students?filterArchived=false&activeStudents=false", CourseStudent[].class);
     if (nonActiveCourseStudents != null) {
       for (CourseStudent nonActiveCourseStudent : nonActiveCourseStudents) {
@@ -705,10 +711,9 @@ public class PyramusUpdater {
         }
       }
     }
-    
     return count;
   }
-  
+
   private void fireWorkspaceDiscovered(Course course) {
     String identifier = identifierMapper.getWorkspaceIdentifier(course.getId());
     Map<String, Object> extra = new HashMap<>();

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusSchoolDataActiveWorkspaceStudentsUpdateScheduler.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusSchoolDataActiveWorkspaceStudentsUpdateScheduler.java
@@ -1,0 +1,62 @@
+package fi.otavanopisto.muikku.plugins.schooldatapyramus.schedulers;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
+import fi.otavanopisto.muikku.plugins.schooldatapyramus.PyramusUpdater;
+import fi.otavanopisto.muikku.plugins.schooldatapyramus.SchoolDataPyramusPluginDescriptor;
+import fi.otavanopisto.muikku.schooldata.WorkspaceEntityController;
+
+@ApplicationScoped
+public class PyramusSchoolDataActiveWorkspaceStudentsUpdateScheduler extends PyramusDataScheduler implements PyramusUpdateScheduler {
+
+  private static final int BATCH_SIZE = NumberUtils.createInteger(System.getProperty("muikku.pyramus-updater.workspace-students.batchsize", "1"));
+
+  @Inject
+  private Logger logger;
+
+  @Inject
+  private WorkspaceEntityController workspaceEntityController;
+
+  @Inject
+  private PyramusUpdater pyramusUpdater;
+  
+  @Override
+  public String getSchedulerName() {
+    return "workspace-active-students";
+  }
+
+  @Override
+  public void synchronize() {
+    int offset = getOffset();    
+    int count = 0;
+    try {
+
+      List<WorkspaceEntity> workspaceEntities = workspaceEntityController.listWorkspaceEntitiesByDataSource(
+          SchoolDataPyramusPluginDescriptor.SCHOOL_DATA_SOURCE, offset, BATCH_SIZE);
+      if (workspaceEntities.size() == 0) {
+        updateOffset(0);
+      } else {
+        for (WorkspaceEntity workspaceEntity : workspaceEntities) {
+          logger.info(String.format("Synchronizing Pyramus workspace active students of workspace %d", workspaceEntity.getId()));
+          count += pyramusUpdater.updateActiveWorkspaceStudents(workspaceEntity);
+        }
+
+        updateOffset(offset + workspaceEntities.size());
+      }
+    } finally {
+      logger.info(String.format("Synchronized %d Pyramus workspace active students", count));
+    }
+  }
+  
+  @Override
+  public int getPriority() {
+    return 5;
+  }
+}

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusSchoolDataInactiveWorkspaceStudentsUpdateScheduler.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusSchoolDataInactiveWorkspaceStudentsUpdateScheduler.java
@@ -14,7 +14,7 @@ import fi.otavanopisto.muikku.plugins.schooldatapyramus.SchoolDataPyramusPluginD
 import fi.otavanopisto.muikku.schooldata.WorkspaceEntityController;
 
 @ApplicationScoped
-public class PyramusSchoolDataWorkspaceStudentsUpdateScheduler extends PyramusDataScheduler implements PyramusUpdateScheduler {
+public class PyramusSchoolDataInactiveWorkspaceStudentsUpdateScheduler extends PyramusDataScheduler implements PyramusUpdateScheduler {
 
   private static final int BATCH_SIZE = NumberUtils.createInteger(System.getProperty("muikku.pyramus-updater.workspace-students.batchsize", "1"));
 
@@ -29,7 +29,7 @@ public class PyramusSchoolDataWorkspaceStudentsUpdateScheduler extends PyramusDa
   
   @Override
   public String getSchedulerName() {
-    return "workspace-students";
+    return "workspace-inactive-students";
   }
 
   @Override
@@ -44,14 +44,14 @@ public class PyramusSchoolDataWorkspaceStudentsUpdateScheduler extends PyramusDa
         updateOffset(0);
       } else {
         for (WorkspaceEntity workspaceEntity : workspaceEntities) {
-          logger.info(String.format("Synchronizing Pyramus workspace students of workspace %d", workspaceEntity.getId()));
-          count += pyramusUpdater.updateWorkspaceStudents(workspaceEntity);
+          logger.info(String.format("Synchronizing Pyramus workspace inactive students of workspace %d", workspaceEntity.getId()));
+          count += pyramusUpdater.updateInactiveWorkspaceStudents(workspaceEntity);
         }
 
         updateOffset(offset + workspaceEntities.size());
       }
     } finally {
-      logger.info(String.format("Synchronized %d Pyramus workspace students", count));
+      logger.info(String.format("Synchronized %d Pyramus inactive workspace students", count));
     }
   }
   


### PR DESCRIPTION
- concurrent access timeouts seemingly related to firing a large number
of CDI events. They seem to temporarily choke timer service (?) so that
by the next scheduled run, the previous and already finished timer is
still hanging around. Adding an access timeout to the timeout method
seemed to fix the problem
- separated syncing of workspace students to active and inactive
students in order to cut down events fired per sync run
- slight adjustments to timeout values
- resolves #3445