### PR TITLE
Fixed continue studies is off sometimes

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
@@ -1,6 +1,12 @@
 (function() {
   'use strict';
   
+   var timeout = null;
+   //this allows that when one user is scrolling really fast only if a section stays active for more than half
+   //a second it'll be saved, this should be enough so that if the user decides to immediatly close, he/she'll probably
+   //take longer
+   var timeOneSectionMustBeOnViewUntilItIsSavedForTheContinueStudiesView = 500;
+  
    function scrollToPage(workspaceMaterialId, animate) {
     var topOffset = 90;
     var scrollTop = $('#page-' + workspaceMaterialId).offset().top - topOffset;
@@ -105,7 +111,8 @@
           Waypoint.refreshAll();
           $(window).data('scrolling', false);
           
-          setLastWorkspace();
+          clearTimeout(timeout);
+          timeout = setTimeout(setLastWorkspace, timeOneSectionMustBeOnViewUntilItIsSavedForTheContinueStudiesView);
         }
       }, 
       offset: 150

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/workspace-materials.js
@@ -29,14 +29,8 @@
       window.location.hash = 'p-' + workspaceMaterialId;
     }
   }
-  
-  $(window).load(function() {
-    if ($(window).data('initial-page')) {
-      scrollToPage($(window).data('initial-page'), true);
-    }
-  });
-
-  $(window).on('beforeunload', function() {
+   
+  function setLastWorkspace(){
     var tocItem = $('#materialsScrollableTOC').find('a.active'); 
     if (tocItem.length) {
       var url = window.location.href;
@@ -53,7 +47,15 @@
       }
       mApi().user.property.create({key: 'last-workspace', value: JSON.stringify(lastWorkspace)});
     }
+  }
+  
+  $(window).load(function() {
+    if ($(window).data('initial-page')) {
+      scrollToPage($(window).data('initial-page'), true);
+    }
   });
+
+  $(window).on('beforeunload', setLastWorkspace);
   
   $(document).on('click', '.workspace-materials-toc-item a', function (event) {
     event.preventDefault();
@@ -102,6 +104,8 @@
           $(window).data('scrolling', true);
           Waypoint.refreshAll();
           $(window).data('scrolling', false);
+          
+          setLastWorkspace();
         }
       }, 
       offset: 150


### PR DESCRIPTION
I found out what it happens, as it was, when you suddenly close the browser, say press the X button because you are done, no other requests are allowed to happen, hence the property setting just doesn't happen as the 'beforeunload' HTTP events doesn't get triggered, even when it could under some circumstances, the browser just wants to close, period.

So with the bugfix the current area will get saved every time the user scrolls to a new section, that way we are avoiding to use it after the beforeunload event, even when I left the event in place; just to keep the old functionality around; nevertheless, it will only get saved as the user scrolls, if the user does not scroll it simply won't happen, so if you navigate to a material screen and you don't scroll it simply won't save. This is the UI behaviour, review code and review the UI behaviour. :)

Fixes #3501 