### PR TITLE
Fixes #3480-ActiveAnnouncementsAreVisibleInPastAnnouncements

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/dao/AnnouncementDAO.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/dao/AnnouncementDAO.java
@@ -85,7 +85,7 @@ public class AnnouncementDAO extends CorePluginsDAO<Announcement> {
         predicates.add(criteriaBuilder.greaterThan(root.get(Announcement_.startDate), currentDate));
       break;
       case EXPIRED:
-        predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(Announcement_.endDate), currentDate));
+        predicates.add(criteriaBuilder.lessThan(root.get(Announcement_.endDate), currentDate));
       break;
     }
     


### PR DESCRIPTION
Fixes #3480 active announcements are visible in past announcements