### PR TITLE
BUG-3330 Firefox complains about dust file conformance

### DIFF
--- a/muikku/src/main/webapp/resources/scripts/gui/dustloader.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/dustloader.js
@@ -14,6 +14,9 @@ dust.onLoad = function(name, callback) {
     mdust.loading[name] = true;
     
     $.ajax(CONTEXTPATH + '/resources/dust/' + name, {
+      //Fixes Firefox complains about XML #3330
+      mimeType: "text/plain",
+      
       success : function(data, textStatus, jqXHR) {
         delete mdust.loading[name];
         callback(false, data);


### PR DESCRIPTION
Fixes #3330 Firefox complains about dust file conformance by adding a mimeType