### PR TITLE
Ftr 3691 announcer styling

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
@@ -29,21 +29,27 @@ class AnnouncementView extends React.Component<MessageViewProps, MessageVitewSta
     return (
       <div className="application-list application-list--open">
         <div className={`application-list__item ${this.props.announcements.current.workspaces.length ? "application-list__item--workspace-announcement" : "application-list__item--environment-announcement"}`}>
-          <div className="application-list__item-header">
-            <div className="text text--announcer-announcement-header">
-              <span className="text__icon icon-clock"></span>
-              <span className="text text--announcer-times">
-                {this.props.i18n.time.format(this.props.announcements.current.startDate)} - {this.props.i18n.time.format(this.props.announcements.current.endDate)}
-              </span>
+          <div className="application-list__item-header  application-list__item-header--announcer-announcement">
+            <div className="container container--announcer-announcement-meta">
+              <div className="application-list__item-header-main application-list__item-header-main--announcer-announcement-dates">
+                <div className="text text--announcer-announcement-header">
+                  <span className="text__icon icon-clock"></span>
+                  <span className="text text--announcer-times">
+                    {this.props.i18n.time.format(this.props.announcements.current.startDate)} - {this.props.i18n.time.format(this.props.announcements.current.endDate)}
+                  </span>
+                </div>
+              </div>
+              <div className="application-list__item-header-aside application-list__item-header-aside--announcer-announcement-workspace">
+                <div className="text text--announcer-announcement-workspace">
+                  <span className="text__icon icon-books"></span>
+                  <span className="text text--announcer-workspace"></span>
+                </div>
+              </div>
             </div>
           </div>
           <div className="application-list__item-body">
-            <div className="text text--announcer-body">
-              <article className="text text--item-article">
-                <header className="text text--item-article-header">{this.props.announcements.current.caption}</header>
-                <p dangerouslySetInnerHTML={{__html: this.props.announcements.current.content}}></p>                                
-             </article>
-           </div>
+            <header className="text text--announcer-announcement-caption">{this.props.announcements.current.caption}</header>
+            <section className="text text--announcer-announcement-content" dangerouslySetInnerHTML={{__html: this.props.announcements.current.content}}></section>                                
           </div>                    
         </div>                 
       </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
@@ -28,10 +28,10 @@ class AnnouncementView extends React.Component<MessageViewProps, MessageVitewSta
     
     return (
       <div className="application-list application-list--open"> 
-        <div className='application-list__item application-list__item--environment-announcement'>
+        <div className={`application-list__item ${this.props.announcements.current.workspaces.length ? "application-list__item--workspace-announcement" : "application-list__item--environment-announcement"}`}>
           <div className="application-list__item-header">   
-            <div className="text text--announcer-header-main">
-              <span className="icon icon-clock"></span>
+            <div className="text text--announcer-announcement-header">
+              <span className="text__icon icon-clock"></span>
               <span className="text text--announcer-times">
                 {this.props.i18n.time.format(this.props.announcements.current.startDate)} - {this.props.i18n.time.format(this.props.announcements.current.endDate)}
               </span>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
@@ -36,7 +36,7 @@ class AnnouncementView extends React.Component<MessageViewProps, MessageVitewSta
                 {this.props.i18n.time.format(this.props.announcements.current.startDate)} - {this.props.i18n.time.format(this.props.announcements.current.endDate)}
               </span>
             </div>                 
-          </div>                  
+          </div>
           <div className="application-list__item-body">
             <div className="text text--announcer-body">
               <article className="text text--item-article">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcement-view.tsx
@@ -27,15 +27,15 @@ class AnnouncementView extends React.Component<MessageViewProps, MessageVitewSta
     }
     
     return (
-      <div className="application-list application-list--open"> 
+      <div className="application-list application-list--open">
         <div className={`application-list__item ${this.props.announcements.current.workspaces.length ? "application-list__item--workspace-announcement" : "application-list__item--environment-announcement"}`}>
-          <div className="application-list__item-header">   
+          <div className="application-list__item-header">
             <div className="text text--announcer-announcement-header">
               <span className="text__icon icon-clock"></span>
               <span className="text text--announcer-times">
                 {this.props.i18n.time.format(this.props.announcements.current.startDate)} - {this.props.i18n.time.format(this.props.announcements.current.endDate)}
               </span>
-            </div>                 
+            </div>
           </div>
           <div className="application-list__item-body">
             <div className="text text--announcer-body">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
@@ -70,12 +70,10 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
                         </span>
                       </div> 
                       {announcement.workspaces.map((workspace)=>{
-                        return <div className="text text--announcer-announcement-workspace"> 
-                          <span key={workspace.id}>
-                            <span className="text__icon icon-books"></span>
-                            <span className="text text--announcer-workspace">
-                              {workspace.name}
-                            </span>
+                        return <div className="text text--announcer-announcement-workspace" key={workspace.id}> 
+                          <span className="text__icon icon-books"></span>
+                          <span className="text text--announcer-workspace">
+                            {workspace.name}
                           </span>
                         </div>
                       })}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
@@ -3,6 +3,7 @@ import {connect, Dispatch} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {colorIntToHex} from '~/util/modifiers';
 import equals = require("deep-equal");
+
 import NewEditAnnouncement from './new-edit-announcement';
 
 import {i18nType} from '~/reducers/base/i18n';
@@ -11,6 +12,8 @@ import '~/sass/elements/empty.scss';
 import '~/sass/elements/loaders.scss';
 import '~/sass/elements/application-list.scss';
 import '~/sass/elements/text.scss';
+import '~/sass/elements/announcement.scss';
+
 import { AnnouncementsType, AnnouncementType } from '~/reducers/main-function/announcer/announcements';
 import BodyScrollKeeper from '~/components/general/body-scroll-keeper';
 import SelectableList from '~/components/general/selectable-list';
@@ -40,8 +43,8 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
           selectModeClassAddition="application-list--select-mode" dataState={this.props.announcements.state}>
           {this.props.announcements.announcements.map((announcement: AnnouncementType)=>{
             let className = announcement.workspaces.length ? 
-                'application-list__item application-list__item--workspace-announcement' :
-                'application-list__item application-list__item--environment-announcement';
+                'application-list__item announcement--workspace' :
+                'application-list__item announcement--environment';
             return {
               className,
               onSelect: this.props.addToAnnouncementsSelected.bind(null, announcement),
@@ -52,11 +55,11 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
               notSelectable: announcement.archived,
               notSelectableModifier: "archived",
               contents: (checkbox: React.ReactElement<any>)=>{
-                return <div>
+                return <div className="application-list__item-content-wrapper announcement__content">
                   <div className="application-list__item-header">
                     {checkbox}        
                     <div className="text text--announcer-header-main">
-                      <span className="icon icon-clock"></span>
+                      <span className="text__icon icon-clock"></span>
                       <span className="text text--announcer-times">
                         {this.props.i18n.time.format(announcement.startDate)} - {this.props.i18n.time.format(announcement.endDate)}
                       </span>
@@ -64,7 +67,7 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
                     <div className="text text--announcer-header-aside">
                       {announcement.workspaces.map((workspace)=>{
                         return <span key={workspace.id}>
-                          <span className="icon icon-books"></span>
+                          <span className="text__icon icon-books"></span>
                           <span className="text text--announcer-workspace">
                             {workspace.name}
                           </span>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/announcements.tsx
@@ -39,12 +39,12 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
   }
   render(){
     return (<BodyScrollKeeper hidden={!!this.props.announcements.current}>
-        <SelectableList className="application-list application-list__items"
+        <SelectableList className="application-list"
           selectModeClassAddition="application-list--select-mode" dataState={this.props.announcements.state}>
           {this.props.announcements.announcements.map((announcement: AnnouncementType)=>{
             let className = announcement.workspaces.length ? 
-                'application-list__item announcement--workspace' :
-                'application-list__item announcement--environment';
+                'application-list__item announcement announcement--workspace' :
+                'application-list__item announcement announcement--environment';
             return {
               className,
               onSelect: this.props.addToAnnouncementsSelected.bind(null, announcement),
@@ -56,42 +56,48 @@ class Announcements extends React.Component<AnnouncementsProps, AnnouncementsSta
               notSelectableModifier: "archived",
               contents: (checkbox: React.ReactElement<any>)=>{
                 return <div className="application-list__item-content-wrapper announcement__content">
-                  <div className="application-list__item-header">
-                    {checkbox}        
-                    <div className="text text--announcer-header-main">
-                      <span className="text__icon icon-clock"></span>
-                      <span className="text text--announcer-times">
-                        {this.props.i18n.time.format(announcement.startDate)} - {this.props.i18n.time.format(announcement.endDate)}
-                      </span>
-                    </div> 
-                    <div className="text text--announcer-header-aside">
-                      {announcement.workspaces.map((workspace)=>{
-                        return <span key={workspace.id}>
-                          <span className="text__icon icon-books"></span>
-                          <span className="text text--announcer-workspace">
-                            {workspace.name}
-                          </span>
+                  <div className="application-list__item-content application-list__item-content--aside">
+                    <div className="announcement__select-container">
+                      {checkbox}
+                    </div>
+                  </div>
+                  <div className="application-list__item-content application-list__item-content--main">
+                    <div className="application-list__item-header">
+                      <div className="text text--announcer-announcement-header">
+                        <span className="text__icon icon-clock"></span>
+                        <span className="text text--announcer-times">
+                          {this.props.i18n.time.format(announcement.startDate)} - {this.props.i18n.time.format(announcement.endDate)}
                         </span>
+                      </div> 
+                      {announcement.workspaces.map((workspace)=>{
+                        return <div className="text text--announcer-announcement-workspace"> 
+                          <span key={workspace.id}>
+                            <span className="text__icon icon-books"></span>
+                            <span className="text text--announcer-workspace">
+                              {workspace.name}
+                            </span>
+                          </span>
+                        </div>
                       })}
                     </div>                  
-                  </div>                  
-                  <div className="application-list__item-body">
-                    <div className="text text--announcer-body">
-                      <article className="text text--item-article">
-                        <header className="text text--item-article-header">{announcement.caption}</header>
-                        <p dangerouslySetInnerHTML={{__html:announcement.content}}></p>
-                      </article>
+                    <div className="application-list__item-body">
+                      <div className="text text--announcer-body">
+                        <article className="text text--item-article">
+                          <header className="text text--item-article-header">{announcement.caption}</header>
+                          <p dangerouslySetInnerHTML={{__html:announcement.content}}></p>
+                        </article>
+                      </div>
+                    </div>                
+                    <div className="application-list__item-footer">                  
+                      <NewEditAnnouncement announcement={announcement}>
+                        <Link className="link link--application-list-item-footer">{this.props.i18n.text.get('plugin.announcer.link.edit')}</Link>
+                      </NewEditAnnouncement>
+                      <DeleteAnnouncementDialog announcement={announcement}>
+                        <Link className="link link--application-list-item-footer">{this.props.i18n.text.get('plugin.announcer.link.delete')}</Link>
+                      </DeleteAnnouncementDialog>
                     </div>
-                  </div>                
-                  <div className="application-list__item-footer">                  
-                    <NewEditAnnouncement announcement={announcement}>
-                      <Link className="link link--application-list-item-footer">{this.props.i18n.text.get('plugin.announcer.link.edit')}</Link>
-                    </NewEditAnnouncement>
-                    <DeleteAnnouncementDialog announcement={announcement}>
-                      <Link className="link link--application-list-item-footer">{this.props.i18n.text.get('plugin.announcer.link.delete')}</Link>
-                    </DeleteAnnouncementDialog>
                   </div>
-               </div>
+                </div>
              }
             }
           })}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view.tsx
@@ -108,7 +108,7 @@ class MessageView extends React.Component<MessageViewProps, MessageVitewState> {
                   */}                 
                 </div>  
               </div>                  
-              <div className="application-list__item-body--communicator-message">
+              <div className="application-list__item-body application-list__item-body--communicator-message">
                 <header className="text text--communicator-message-caption">{message.caption}</header>
                 <section className="text text--communicator-message-content" dangerouslySetInnerHTML={{ __html: message.content}}></section>
               </div>                

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
@@ -102,7 +102,7 @@ class CommunicatorMessages extends BodyScrollLoader<CommunicatorMessagesProps, C
             key: message.communicatorMessageId,
             contents: (checkbox: React.ReactElement<any>)=>{
               return <div className="application-list__item-content-wrapper message__content">
-                  <div className="application-list__item-content application-list__item-content--aside message__content-aside--communicator">
+                  <div className="application-list__item-content application-list__item-content--aside">
                     <div className="message__select-container">
                       {checkbox}
                     </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
@@ -4,7 +4,6 @@ import {bindActionCreators} from 'redux';
 import {colorIntToHex} from '~/util/modifiers';
 import equals = require("deep-equal");
 
-
 import actions from '~/actions/main-function/communicator/communicator-messages';
 
 import {LoadMoreMessagesTriggerType, RemoveFromCommunicatorSelectedMessagesTriggerType, AddToCommunicatorSelectedMessagesTriggerType} from '~/actions/main-function/communicator/communicator-messages';

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
@@ -31,12 +31,12 @@ class AnnouncementsPanel extends React.Component<AnnouncementsPanelProps, Announ
           {this.props.announcements.length !== 0 ?
             <div className="item-list item-list--panel-announcements">
               {this.props.announcements.map((announcement: AnnouncementType)=>{
-                return <Link key={announcement.id} className={`item-list__item item-list__item--accouncements ${announcement.workspaces ? "item-list__item--has-workspaces" : ""}`}
+                return <Link key={announcement.id} className={`item-list__item item-list__item--announcements ${announcement.workspaces ? "item-list__item--has-workspaces" : ""}`}
                   href={`/announcements?announcementId=${announcement.id}`}>
                   <span className="item-list__icon item-list__icon--announcements icon-announcer"></span>
                   <span className="text item-list__text-body item-list__text-body--multiline">
                     {announcement.caption}
-                    <span className="text text--announcements-date">
+                    <span className="text item-list__announcement-date">
                       {this.props.i18n.time.format(announcement.created)}
                     </span>
                   </span>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/announcement.scss
@@ -1,7 +1,7 @@
-$color-announcement-workspace: #afe5d3;
-$color-announcement-environment: #539fde ;
-
-
+$color-announcement-workspace: #2fd4af;
+$color-announcement-environment: #009fe3;
+$color-announcement-border: #f0f0f0;
+$color-announcement-open-header-background: #f8f8f8;
 $color-announcement-workspace-border: $color-announcement-workspace;
 $color-announcement-workspace-icon: $color-announcement-workspace;
 $color-announcement-environment-border: $color-announcement-environment;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/announcement.scss
@@ -1,6 +1,6 @@
 $color-announcement-workspace: #2fd4af;
 $color-announcement-environment: #009fe3;
-$color-announcement-border: #f0f0f0;
+$color-announcement-border: #f2f2f2;
 $color-announcement-open-header-background: #f8f8f8;
 $color-announcement-workspace-border: $color-announcement-workspace;
 $color-announcement-workspace-icon: $color-announcement-workspace;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/index.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/index.scss
@@ -13,9 +13,8 @@ $color-index-item-list-item-panel-workspaces-icon: $color-index-text-for-panels-
 $color-index-item-list-item-panel-latest-messages-icon: #aaa;
 $color-index-item-list-item-panel-latest-messages-unread-icon: $color-index-text-for-panels-title-latest-messages-icon-background;
 $color-index-item-list-item-panel-announcements-unread-icon: $color-index-text-for-panels-title-announcements-icon-background;
-$color-index-text-panel-latest-messages-date: $color-index-item-list-item-panel-latest-messages-icon;
+$color-index-text-panels-date-color: #aaa;
 $color-index-item-list-item-panel-latest-messages-border: #f0f0f0;
-$color-index-text-panel-announcements-date: #bbb;
 $color-index-item-list-item-panel-announcements-border: #ccc;
 $color-index-item-list-item-panel-announcements-icon: $color-index-text-for-panels-title-announcements-icon-background;
 $color-index-item-list-item-panel-announcements-has-workspaces-icon: #2fd4af

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/main-function.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/main-function.scss
@@ -25,7 +25,7 @@ $color-main-function-button-pill-navigation-edit-label-text: rgba(0, 0, 0, 0.5);
 $color-main-function-button-pill-navigation-edit-label-text-hover: rgba(0, 0, 0, 1);
 $color-main-function-button-pill-navigation-edit-label-text-active: rgba(0, 0, 0, 1);
 $color-main-function-application-panel-actions-border: #ebebeb;
-$color-main-function-application-list-item-open-border: #f8f8f8;
+$color-main-function-application-list-item-open-border: #f0f0f0;
 $color-main-function-application-list-item-checkbox-border: #c7c7c7;
 $color-main-function-application-list-item-checkbox-checked-mark: $color-default;
 $color-main-function-application-list-item-checkbox-checked-background: $color-application-list-item-checkmark-selected;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/message.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/message.scss
@@ -1,3 +1,3 @@
-$color-message-border: #f0f0f0;
+$color-message-border: #f2f2f2;
 $color-message-open-header-background: #f8f8f8;
 $color-message-unread-border: #E30086;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
@@ -4,7 +4,7 @@
 
 .announcement {
   border-top: 1px solid $color-announcement-border;
-  padding: 10px 12px 10px 4px;
+  padding: 14px 12px 14px 4px;
   
   &.selected {
     border-top: 1px solid $color-default;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
@@ -16,13 +16,14 @@
 }
 
 .announcement__content {
+  flex-flow: row nowrap;
   padding: 0 0 0 9px;
 }
 
 .announcement--environment {
   
   .announcement__content {
-    border-left: solid 3px $color-message-unread-border;
+    border-left: solid 3px $color-announcement-environment-border;
     padding: 0 0 0 6px;
   }
 }
@@ -30,7 +31,13 @@
 .announcement--workspace {
   
   .announcement__content {
-    border-left: solid 3px$color-announcement-environment-border;
+    border-left: solid 3px $color-announcement-workspace-border;
     padding: 0 0 0 6px;
   }
+}
+
+.announcement__select-container {
+  align-items: center;
+  display: flex;
+  padding: 2px 8px 2px 2px;
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
@@ -1,0 +1,36 @@
+@import "../base/colors";
+@import "../base/mixins";
+@import "../base/breakpoints";
+
+.announcement {
+  border-top: 1px solid $color-message-border;
+  padding: 10px 12px 10px 4px;
+  
+  &.selected {
+    border-top: 1px solid $color-default;
+  }
+  
+  &:first-child {
+    border: 0;
+  }
+}
+
+.announcement__content {
+  padding: 0 0 0 9px;
+}
+
+.announcement--environment {
+  
+  .announcement__content {
+    border-left: solid 3px $color-message-unread-border;
+    padding: 0 0 0 6px;
+  }
+}
+
+.announcement--workspace {
+  
+  .announcement__content {
+    border-left: solid 3px$color-announcement-environment-border;
+    padding: 0 0 0 6px;
+  }
+}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/announcement.scss
@@ -3,7 +3,7 @@
 @import "../base/breakpoints";
 
 .announcement {
-  border-top: 1px solid $color-message-border;
+  border-top: 1px solid $color-announcement-border;
   padding: 10px 12px 10px 4px;
   
   &.selected {
@@ -26,6 +26,10 @@
     border-left: solid 3px $color-announcement-environment-border;
     padding: 0 0 0 6px;
   }
+  
+  .text__icon {
+    color: $color-announcement-environment;
+  }
 }
 
 .announcement--workspace {
@@ -33,6 +37,10 @@
   .announcement__content {
     border-left: solid 3px $color-announcement-workspace-border;
     padding: 0 0 0 6px;
+  }
+  
+  .text__icon {
+    color: $color-announcement-workspace;
   }
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
@@ -25,15 +25,7 @@
   transition: background-color 0.2s ease-in-out;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
-  
-/*   &:hover, &.hover { */
-/*     background-color: darken($color-application-list-item-background, 5%); */
-/*   } */
 
-/*   &:active, &.active { */
-/*     background-color: darken($color-application-list-item-background, 10%); */
-/*   } */
-  
   &.selected {
     background-color: $color-application-list-item-background-selected;
     
@@ -131,7 +123,6 @@
   -ms-overflow-style: -ms-autohiding-scrollbar;
   overflow: -moz-scrollbars-none;
   overflow-y: auto;
-  padding: 10px 4px;
   
    &::-webkit-scrollbar { 
     display: none; 
@@ -157,13 +148,7 @@
 } 
 
 // Announcer
-.application-list__item--workspace-announcement, 
-.application-list__item--environment-announcement {
-  padding: 0 0 0 6px;
-}
-
 .application-list__item--workspace-announcement {
-/*   border-left: 3px solid $color-announcement-workspace-border; */
     
   .text__icon::before {
     color: $color-announcement-workspace-icon;
@@ -171,10 +156,21 @@
 }
 
 .application-list__item--environment-announcement { 
-/*    border-left: 3px solid $color-announcement-environment-border;   */
    
   .text__icon::before {
     color: $color-announcement-environment-icon;
+  }
+}
+
+.application-list__item-header--announcer-announcement {
+  flex-direction: column;
+}
+
+.application-list__item--workspace-announcement:first-child,
+.application-list__item--environment-announcement:first-child {
+  
+  .application-list__item-header {
+    background-color: $color-announcement-open-header-background;
   }
 }
 
@@ -200,8 +196,8 @@
   flex-direction: column;
 }
 
-// This is against the BEM, but convenient because of the pseudo classes
 .application-list__item--communicator-message:first-child {
+  
   .application-list__item-header {
     background-color: $color-message-open-header-background;
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
@@ -184,8 +184,8 @@
 .application-list__item--communicator-message {  
   border-bottom: 5px solid $color-main-function-application-list-item-open-border;
   cursor: default;
-  margin: 0;
-  padding: 0 0 1px 0;
+  margin: 0 0 5px;
+  padding: 0 0 10px;
   
   &:last-child {
     border: 0;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
@@ -26,13 +26,13 @@
   -webkit-user-select: none;
   -webkit-touch-callout: none;
   
-  &:hover, &.hover {
-    background-color: darken($color-application-list-item-background, 5%);
-  }
+/*   &:hover, &.hover { */
+/*     background-color: darken($color-application-list-item-background, 5%); */
+/*   } */
 
-  &:active, &.active {
-    background-color: darken($color-application-list-item-background, 10%);
-  }
+/*   &:active, &.active { */
+/*     background-color: darken($color-application-list-item-background, 10%); */
+/*   } */
   
   &.selected {
     background-color: $color-application-list-item-background-selected;
@@ -159,11 +159,11 @@
 // Announcer
 .application-list__item--workspace-announcement, 
 .application-list__item--environment-announcement {
-  padding: 0 0 0 9px;
+  padding: 0 0 0 6px;
 }
 
 .application-list__item--workspace-announcement {
-  border-left: 3px solid $color-announcement-workspace-border;
+/*   border-left: 3px solid $color-announcement-workspace-border; */
     
   .text__icon::before {
     color: $color-announcement-workspace-icon;
@@ -171,7 +171,7 @@
 }
 
 .application-list__item--environment-announcement { 
-   border-left: 3px solid $color-announcement-environment-border;  
+/*    border-left: 3px solid $color-announcement-environment-border;   */
    
   .text__icon::before {
     color: $color-announcement-environment-icon;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
@@ -128,10 +128,10 @@
 }
 
 .application-list--open {
-  overflow-y: auto;
-  padding: 10px 15px 10px 27px;    
   -ms-overflow-style: -ms-autohiding-scrollbar;
   overflow: -moz-scrollbars-none;
+  overflow-y: auto;
+  padding: 10px 4px;
   
    &::-webkit-scrollbar { 
     display: none; 
@@ -157,22 +157,23 @@
 } 
 
 // Announcer
-.application-list__item--workspace-announcement, .application-list__item--environment-announcement {
-  padding: 10px;
+.application-list__item--workspace-announcement, 
+.application-list__item--environment-announcement {
+  padding: 0 0 0 9px;
 }
 
 .application-list__item--workspace-announcement {
-  border-left: 5px solid $color-announcement-workspace-border;
+  border-left: 3px solid $color-announcement-workspace-border;
     
-  .icon::before {
+  .text__icon::before {
     color: $color-announcement-workspace-icon;
   }
 }
 
 .application-list__item--environment-announcement { 
-   border-left: 5px solid $color-announcement-environment-border;  
+   border-left: 3px solid $color-announcement-environment-border;  
    
-  .icon::before {
+  .text__icon::before {
     color: $color-announcement-environment-icon;
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/container.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/container.scss
@@ -71,6 +71,11 @@
   }
 }
 
+.container--announcer-announcement-meta {
+  display: flex;
+  padding: 10px;
+}
+
 .container--communicator-message-meta {
   display: flex;
   padding: 10px;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/item-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/item-list.scss
@@ -42,7 +42,7 @@
 }
 
 .item-list__item--latest-messages,
-.item-list__item--latest-announcements {
+.item-list__item--announcements {
   align-items: flex-start;
   border-top: solid 1px $color-index-item-list-item-panel-latest-messages-border;
   margin: 0;
@@ -118,8 +118,9 @@
 }
 
 // List item dates
-.item-list__latest-message-date {
-  color: $color-index-text-panel-latest-messages-date;
+.item-list__latest-message-date,
+.item-list__announcement-date {
+  color: $color-index-text-panels-date-color;
   font-size: calc(#{$text-mobile-font-size} / 1.1);
   font-style: italic;
   padding: 6px 0 0;
@@ -128,3 +129,4 @@
     font-size: calc(#{$text-desktop-font-size} / 1.1);
   }
 }
+

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
@@ -4,7 +4,7 @@
 
 .message {
   border-top: 1px solid $color-message-border;
-  padding: 10px 12px 10px 4px;
+  padding: 14px 12px 14px 4px;
   
   &.selected {
     border-top: 1px solid $color-default;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
@@ -16,6 +16,7 @@
 }
 
 .message__content {
+  flex-flow: row nowrap;
   padding: 0 0 0 9px;
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/message.scss
@@ -26,6 +26,10 @@
     border-left: solid 3px $color-message-unread-border;
     padding: 0 0 0 6px;
   }
+  
+  .text--communicator-username {
+    font-weight: 600;
+  }
 }
 
 .message--thread-op {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -427,6 +427,7 @@ b {
   display: inline-block;
   margin-left: 5px;
   font-size: 15px;
+  font-weight: 600;
 }
 
 .text--announcer-announcement-header {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -277,7 +277,7 @@ b {
 
 .text--item-article-header {
   font-weight: 600;
-  padding: 0 0 10px 0;
+  padding: 0 0 10px;
 }
 
 .text--item-counter {
@@ -432,9 +432,9 @@ b {
 }
 
 .text--announcer-announcement-workspace {
-   align-items: center;
-  flex: 0 0 auto;
+  align-items: center;
   display: flex;
+  flex: 0 0 auto;
   justify-content: end;
   margin: 0 0 0 20px;
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -438,7 +438,6 @@ b {
 }
 
 .text--announcer-announcement-workspace {
-  opacity: 0.75;
   flex: 1 1 auto;
   display: flex;
   justify-content: end;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -276,8 +276,8 @@ b {
 }
 
 .text--item-article-header {
-  font-weight: 400;
-  padding: 10px 0;
+  font-weight: 600;
+  padding: 0 0 10px 0;
 }
 
 .text--item-counter {
@@ -285,7 +285,6 @@ b {
   border-radius: 50%;
   background-color: #FFF6AE;
   display: flex;
-  font-size: .75rem;
   height: 22px;
   justify-content: center;
   width: 22px;
@@ -293,7 +292,7 @@ b {
   
 .text--communicator-message-caption {
   font-weight: 600;  
-  margin-bottom: 10px;    
+
   padding: 10px; 
 }  
 
@@ -334,9 +333,8 @@ b {
 }
 
 .text--communicator-date {
-  font-size: .75rem;
-  width: 5rem; // This needs to grow if user increases browser's font size
   text-align: right;
+  width: 5.2rem; // This needs to grow if user increases browser's font size
 }
   
 .text--communicator-body {
@@ -418,36 +416,41 @@ b {
   display: inline-block;
 }
 
-.text--communicator-message-created {
-  font-size: .75rem;
-}
-
 // Announcer
 .text--announcer-times {
   display: inline-block;
   margin-left: 5px;
-  font-size: 15px;
   font-weight: 600;
 }
 
 .text--announcer-announcement-header {
   align-items: center;
   display: flex;
-  flex: 1;    
+  flex: 1 1 auto;
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: wrap; 
 }
 
 .text--announcer-announcement-workspace {
-  flex: 1 1 auto;
+   align-items: center;
+  flex: 0 0 auto;
   display: flex;
   justify-content: end;
-  align-items: center;
+  margin: 0 0 0 20px;
+}
+
+.text--announcer-announcement-caption {
+  font-weight: 600;  
+  
+  padding: 10px; 
+}  
+
+.text--announcer-announcement-content {
+  padding: 10px;  
 }
 
 .text--announcer-workspace {
   color: #000;
-  font-size: 15px;
   margin-left: 5px;
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -429,15 +429,15 @@ b {
   font-size: 15px;
 }
 
-.text--announcer-header-main {
+.text--announcer-announcement-header {
   align-items: center;
   display: flex;
+  flex: 1;    
   flex-direction: row;
   flex-wrap: wrap;
-  flex: 0 2 auto;
 }
 
-.text--announcer-header-aside {
+.text--announcer-announcement-workspace {
   opacity: 0.75;
   flex: 1 1 auto;
   display: flex;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/text.scss
@@ -291,12 +291,6 @@ b {
   width: 22px;
 }
   
-.text--announcements-date {
-  color: $color-index-text-panel-announcements-date;
-  font-size: .75rem;
-  padding-bottom: 7px;
-}
-  
 .text--communicator-message-caption {
   font-weight: 600;  
   margin-bottom: 10px;    


### PR DESCRIPTION
Closes #3691 Some major and minor adjustments for announcer's markup so it follows communicator's markup more closely. Some parts are still prefixed by communicator or announcer names and might be able to be named globally.