### PR TITLE
Fixes #3561 Don't show chat occupants by default

### DIFF
--- a/muikku/src/main/webapp/resources/scripts/gui/chat.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/chat.js
@@ -17,7 +17,8 @@
         hide_muc_server : true,
         auto_join_rooms : ['muikku@conference.' + location.hostname],
         ping_interval: 45,
-        auto_minimize: true
+        auto_minimize: true,
+        hide_occupants:true
       });
     }
   });


### PR DESCRIPTION
Fixes #3561 Don't show chat occupants by default  by adding a new parameter to the converse call. converse now has option of hiding occupants by default (def value false, current value true).