### PR TITLE
Fixes #3723 Converse crashes if there's an incompatible (non-prebind)

### DIFF
--- a/muikku/src/main/webapp/resources/scripts/gui/chat.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/chat.js
@@ -8,7 +8,7 @@
       converse.initialize({
         bosh_service_url : '/http-bind/',
         authentication : "prebind",
-        keepalive : true,
+        keepalive : false,
         prebind_url : "/rest/chat/prebind",
         auto_login : true,
         muc_domain : 'conference.' + location.hostname,


### PR DESCRIPTION
Fixes #3723 Converse crashes if there's an incompatible (non-prebind) keepalive session