### PR TITLE
Bug 3727 ie11 carousel broken

### DIFF
--- a/muikku/src/main/webapp/index.xhtml
+++ b/muikku/src/main/webapp/index.xhtml
@@ -14,7 +14,7 @@
     <script defer="defer" jsf:name="/scripts/gui/dustloader.js"/>
     <ui:fragment rendered="#{!sessionBackingBean.loggedIn}">
       <script defer="defer" type="text/javascript" jsf:name="/scripts/gui/forgotpassword.js"/>
-      <script defer="defer" type="text/javascript" src="//cdn.muikkuverkko.fi/libs/slick/1.6.0/slick.min.js"/>
+      <script defer="defer" type="text/javascript" src="//cdn.muikkuverkko.fi/libs/slick/1.8.0/slick.min.js"/>
       <script defer="defer" jsf:name="/scripts/gui/frontpage.js"/>
     </ui:fragment>    
     <ui:fragment rendered="#{sessionBackingBean.loggedIn}">

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/_generic_context-view.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/_generic_context-view.scss
@@ -19,7 +19,8 @@ body {
       align-items:stretch;
     
       section {
-        flex:2 1;
+        flex-grow: 2;
+        flex-shrink: 1;
         padding:0 20px 0 0;
         
         article {
@@ -77,7 +78,8 @@ body {
       }
       
       nav.gc-navigation {
-        flex:1 0;
+        flex-grow: 1;
+        flex-shrink: 0;
         max-height:100%;
         min-height:670px;
         padding:0 0 0 10px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_mobile_frontpage.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_mobile_frontpage.scss
@@ -96,12 +96,16 @@
   .frontpage-images,
   .frontpage-posts,
   .organization-description-box {
-    flex: 1 1 calc(100% - 20px);
+    flex-basis: calc(100% - 20px); 
+    flex-grow: 1;
+    flex-shrink: 1;
     max-width: calc(100% - 20px);
   }
   
   .organization-some-box {
-    flex: 1 1 calc(50% - 20px);
+    flex-basis: calc(50% - 20px); 
+    flex-grow: 1;
+    flex-shrink: 1;
     order: 2;
   }
   
@@ -111,7 +115,9 @@
   }
   
   .organization-logo-box {
-    flex: 1 1 calc(50% - 20px);
+    flex-basis: calc(50% - 20px);
+    flex-grow: 1;
+    flex-shrink: 1; 
     order: 1;
   }
   
@@ -162,17 +168,23 @@
     }
     
     .of-header-application-bubble-wrapper {
-      flex: 1 1 calc(100% - 30px);
+      flex-basis: calc(100% - 30px);
+      flex-grow: 1;
+      flex-shrink: 1;
       order: 2;
     }
     
     .of-header-site-info-wrapper {
-      flex: 1 0 50%;
+      flex-basis: 50%;
+      flex-grow: 1;
+      flex-shrink: 0;
       order: 1;
     }
     
     .of-header-open-materials-bubble-wrapper {
-      flex: 1 1 calc(100% - 30px);
+      flex-basis: calc(100% - 30px);
+      flex-grow: 1;
+      flex-shrink: 1;
       order: 3;
     }
     
@@ -292,7 +304,9 @@
   .organization-some-box,
   .organization-description-box,
   .organization-logo-box {
-    flex: 1 1 calc(100% - 20px);
+    flex-basis: calc(100% - 20px);
+    flex-grow: 1;
+    flex-shrink: 1;
     max-width: calc(100% - 20px);
   }
   

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/evaluation-index.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/evaluation-index.scss
@@ -74,7 +74,9 @@ body {
   .eval-nav-item {
     color: $evaluation-navigation-item-font-color;
     cursor: pointer;
-    flex: 0 0 26px;
+    flex-basis: 26px;
+    flex-grow: 0;
+    flex-shrink: 0;
     margin: 4px;
     text-align: center;
     
@@ -113,7 +115,9 @@ body {
   }
   
   .eval-search-wrapper {
-    flex: 1 1 auto;
+    flex-basis: auto;
+    flex-grow: 1;
+    flex-shrink: 1;
     margin: 4px;
     padding: 7px 8px;
     text-align: right;
@@ -151,7 +155,12 @@ body {
       box-sizing: border-box;
       color: $environment-font-color;
       display: inline;
-      flex: 0 1 300px;
+      flex-basis: 300px;
+      flex-grow: 0;
+      flex-shrink: 1;
+      flex-basis: 300px;
+      flex-grow: 0;
+      flex-shrink: 1;
       font-size: 16px;
       font-weight: 300;
       padding: 9px 26px 9px 9px;
@@ -190,7 +199,8 @@ body {
       color: $forms-button-font-color;
       cursor: pointer;
       display: inline;
-      flex: 0 0;
+      flex-grow: 0;
+      flex-shrink: 0;
 
       &.icon-search::before {
         font-size: 20px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/evaluation-index.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/evaluation-index.scss
@@ -158,9 +158,6 @@ body {
       flex-basis: 300px;
       flex-grow: 0;
       flex-shrink: 1;
-      flex-basis: 300px;
-      flex-grow: 0;
-      flex-shrink: 1;
       font-size: 16px;
       font-weight: 300;
       padding: 9px 26px 9px 9px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-functionality.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-main-functionality.scss
@@ -921,7 +921,9 @@ ul.mf-tool-label-container {
 
 
 .mf-vops-item-name {
-  flex: 0 0 50px;
+  flex-basis: 50px;
+  flex-grow: 0;
+  flex-shrink: 0;
   min-width: 50px;
   text-align: center;
 }
@@ -930,7 +932,9 @@ ul.mf-tool-label-container {
   align-items: center;
   color: $environment-button-disabled-font-color;
   display: flex;
-  flex: 0 0 30px;
+  flex-basis: 30px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 30px;
   justify-content: center;
   margin-left: 10px;
@@ -995,7 +999,9 @@ ul.mf-tool-label-container {
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
-  flex: 0 0 30px;
+  flex-basis: 30px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 30px;
   justify-content: center;
   margin-left: 10px;
@@ -1175,7 +1181,9 @@ ul.mf-tool-label-container {
 }
 
 .mf-vops-legend-item-grid {
-  flex: 0 0 20px;
+  flex-basis: 20px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 20px;
   margin-right: 10px;
   min-width: 20px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/frontpage.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/frontpage.scss
@@ -77,24 +77,30 @@ nav.of-navigation {
   .of-site-logo {
     background: url('/gfx/of-site-logo-text.png') no-repeat center center;
     box-sizing: border-box;
-    flex: 0 0 auto;
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 0;
     height: 70px;
     width: 175px;
   }
   
   .of-site-links {
-    flex: 1 0 auto;
+    flex-basis: auto;
+    flex-grow: 1;
+    flex-shrink: 0;
     height: 100%;
   }
   
   .of-site-alternate-links {
-    flex: 0 0 auto;
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
   
   .of-site-alternate-links-container {
     align-items: center;
     @include flexbox;
-    min-height: 70px;
+    height: 70px;
   }
   
   ul, li {
@@ -158,7 +164,9 @@ nav.of-navigation {
   }
   
   .of-site-login {
-    flex: 0 0 auto;
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 0;
     margin: 0;
   
     .login {
@@ -290,7 +298,9 @@ header.of-header {
   .of-header-site-info-wrapper,
   .of-header-open-materials-bubble-wrapper {
     box-sizing: border-box;
-    flex: 1 1 calc(33.3333%);
+    flex-basis: 33.3333%;
+    flex-grow: 1;
+    flex-shrink: 1;
   }
   
   .of-header-application-bubble,
@@ -453,7 +463,9 @@ main.of-content {
 h2.frontpage-section-title {
   box-sizing: border-box;
   color: $of-frontpage-section-title-color;
-  flex: 1 1 calc(100% - 20px);
+  flex-basis: calc(100% - 20px);
+  flex-grow: 1;
+  flex-shrink: 1;
   font-size: 38px;
   font-weight: 200;
   margin: 0 10px 20px;
@@ -474,15 +486,21 @@ h2.frontpage-section-title {
 .frontpage-studying {
   
   &.studying-left-box {
-    flex: 1 1 calc(33% - 20px);
+    flex-basis: calc(33% - 20px);
+    flex-grow: 1;
+    flex-shrink: 1;
   } 
   
   &.studying-center-box {
-    flex: 1 1 calc(33% - 20px);
+    flex-basis: calc(33% - 20px);
+    flex-grow: 1;
+    flex-shrink: 1;
   }
   
   &.studying-right-box {
-    flex: 1 1 calc(33% - 20px);
+    flex-basis: calc(33% - 20px);
+    flex-grow: 1;
+    flex-shrink: 1;
   }
   
   .studying-image {
@@ -569,7 +587,9 @@ h2.frontpage-section-title {
 
 .frontpage-videos {
   border-radius: 3px;
-  flex: 1 1 calc(100% - 20px);
+  flex-basis: calc(100% - 20px);
+  flex-grow: 1;
+  flex-shrink: 1;
   max-width: calc(100% - 20px);
   overflow: hidden;
 }
@@ -577,22 +597,30 @@ h2.frontpage-section-title {
 // NEWS SECTION
 
 .frontpage-news {
-  flex: 0 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 0;
+  flex-shrink: 1;
   max-width: calc(50% - 20px);
 }
 
 .frontpage-events {
-  flex: 0 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 0;
+  flex-shrink: 1;
   max-width: calc(50% - 20px);
 }
 
 .frontpage-images {
-  flex: 0 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 0;
+  flex-shrink: 1;
   max-width: calc(50% - 20px);
 }
 
 .frontpage-posts {
-  flex: 0 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 0;
+  flex-shrink: 1;
   max-width: calc(50% - 20px);
 }
 
@@ -654,7 +682,9 @@ ul.blogs-content-wrapper {
 // ORGANIZATION SECTION
 
 .frontpage-organization {
-  flex: 1 1 calc(100% - 20px);
+  flex-basis: calc(100% - 20px);
+  flex-grow: 1;
+  flex-shrink: 1;
   max-width: calc(100% - 20px);
   padding: 30px;
 }
@@ -665,7 +695,9 @@ ul.blogs-content-wrapper {
 }
 
 .organization-some-box {
-  flex: 1 1 calc(33.3333% - 30px);
+  flex-basis: calc(33.3333% - 30px);
+  flex-grow: 1;
+  flex-shrink: 1;
   
   .organization-some-title {
     font-size: 16px;
@@ -701,8 +733,9 @@ ul.blogs-content-wrapper {
 }
 
 .organization-description-box {
-  flex: 1 1 calc(66.6666% - 30px);
-  
+  flex-basis: calc(66.6666% - 30px);
+  flex-grow: 1;
+  flex-shrink: 1;
   
   .organization-description {
     font-size: 17px;
@@ -738,7 +771,9 @@ ul.blogs-content-wrapper {
 }
 
 .organization-logo-box {
-  flex: 1 1 calc(33.3333% - 30px);
+  flex-basis: calc(33.3333% - 30px);
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
 // FOOTER
@@ -751,14 +786,16 @@ footer.of-footer {
   @include flexbox;
   align-items: stretch;
   box-sizing: border-box;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
   margin: 0 auto;
   max-width: 1260px;
 }
 
 .contact-info-container {
   box-sizing: border-box;
-  flex: 1 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 1;
+  flex-shrink: 1;
   margin: 10px;
   padding: 0 30px 30px;
   
@@ -812,7 +849,9 @@ footer.of-footer {
 
 .logo-container {
   box-sizing: border-box;
-  flex: 1 1 calc(50% - 20px);
+  flex-basis: calc(50% - 20px);
+  flex-grow: 1;
+  flex-shrink: 1;
   margin: 10px;
   padding: 0 30px;
   text-align: right;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/profile.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/profile.scss
@@ -90,7 +90,9 @@
 
   .profile-vacation-date {
     box-sizing: border-box;
-    flex: 1 1 50%;
+    flex-basis: 50%;
+    flex-grow: 1;
+    flex-shrink: 1;
 
     &:first-child {
       padding: 0 5px 0 0;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/records.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/records.scss
@@ -140,7 +140,9 @@
 
 
 .tr-vops-item-name {
-  flex: 0 0 50px;
+  flex-basis: 50px;
+  flex-grow: 0;
+  flex-shrink: 0;
   min-width: 50px;
   text-align: center;
 }
@@ -149,7 +151,9 @@
   align-items: center;
   color: $environment-button-disabled-font-color;
   display: flex;
-  flex: 0 0 30px;
+  flex-basis: 30px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 30px;
   justify-content: center;
   margin-left: 10px;
@@ -215,7 +219,9 @@
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
-  flex: 0 0 30px;
+  flex-basis: 30px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 30px;
   justify-content: center;
   margin-left: 10px;
@@ -395,7 +401,9 @@
 }
 
 .tr-vops-legend-item-grid {
-  flex: 0 0 20px;
+  flex-basis: 20px;
+  flex-grow: 0;
+  flex-shrink: 0;
   height: 20px;
   margin-right: 10px;
   min-width: 20px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-index.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/workspace-index.scss
@@ -208,7 +208,9 @@ h1.workspace-block-title {
   
   .workspace-teacher-profile-picture {
     border-radius: 5px;
-    flex: 0 0 58px;
+    flex-basis: 58px;
+    flex-grow: 0;
+    flex-shrink: 0;
     height: 48px;
     width: 48px;
     
@@ -225,7 +227,9 @@ h1.workspace-block-title {
   }
   
   .workspace-teacher-info {
-    flex: 1 1 auto;
+    flex-basis: auto;
+    flex-grow: 1;
+    flex-shrink: 1;
   }
   
   .workspace-teacher-info {


### PR DESCRIPTION
Closes #3727 

Every flex shorthand declarations has been exploded into separate flex properties. Updated slick library to newest version also.
  