### PR TITLE
Fixes #3243- Creation of temporary room by students

### DIFF
--- a/muikku/src/main/webapp/resources/scripts/gui/chat.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/chat.js
@@ -18,7 +18,8 @@
         ping_interval: 45,
         auto_minimize: true,
         i18n: getLocale() === "fi" ? "fi" : "en",
-        hide_occupants:true
+        hide_occupants:true,
+        limit_room_controls:true
       });
     }
   });


### PR DESCRIPTION
Works fine on the latest converse version 1/16/2018
The issue with saving and loading configuration is not related to this modifications.
chat.js has limit_room_controls parameter set to true (false by default).
This is a list of removed controlls:
      "muc#roomconfig_persistentroom",
      "muc#roomconfig_passwordprotectedroom",
      "muc#roomconfig_roomsecret",
      "muc#roomconfig_membersonly",
      "muc#roomconfig_roomadmins",
      "muc#roomconfig_roomowners",
      "muc#roomconfig_enablelogging",
      "x-muc#roomconfig_registration",
      "x-muc#roomconfig_reservednick",
      "muc#roomconfig_whois",
      "muc#roomconfig_presencebroadcast"