### PR TITLE
Fixes #3757 -Workspace materials - counter for memofield

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -514,9 +514,9 @@
               $('<span>').addClass('muikku-field-examples-title').text(getLocaleText('plugin.workspace.assigment.checkAnswers.detailsSummary.title'))
             );
             exampleDetails.append($('<span>').addClass('muikku-field-example').html(this.options.meta.example.replace(/(?:\r\n|\r|\n)/g, '<br/>')));
-            var wordCountContainer = $(this.element).parent().find('.word-count-container');
-            if (wordCountContainer.length) {
-              $(wordCountContainer).after(exampleDetails);
+            var countContainer = $(this.element).parent().find('.count-container');
+            if (countContainer.length) {
+              $(countContainer).after(exampleDetails);
             }
             else {
               $(this.element).after(exampleDetails);
@@ -530,13 +530,17 @@
       if (data.fieldlessMode) {
         $(object).replaceWith(memoFieldElement);
         
-        var wordCountContainer = $('<div class="word-count-container">')
+        var countContainer = $('<div class="count-container">')
+          .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
+          .append('<span class="character-count">')
           .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
           .append('<span class="word-count">');
-        memoFieldElement.after(wordCountContainer);
+        memoFieldElement.after(countContainer);
 
         var text = data.value || "";
-        $(wordCountContainer).find('.word-count').text(text === '' ? 0 : text.split(/\s+/).length);
+        $(countContainer).find('.character-count').text(text === '' ? 0 : text.trim().replace(/(\s|\r\n|\r|\n)+/g,'').split("").length);
+        $(countContainer).find('.word-count').text(text === '' ? 0 : text.trim().split(/\s+/).length);
+        
       }
       else {
         if (data.meta.richedit == true) {
@@ -546,13 +550,16 @@
         
         // #3120 memo word counter (non-richedit)
         if (data.meta.richedit != true) {
-          var wordCountContainer = $('<div class="word-count-container">')
+          var countContainer = $('<div class="count-container">')
+            .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
+            .append('<span class="character-count">')
             .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
             .append('<span class="word-count">');
-          memoFieldElement.after(wordCountContainer);
+          memoFieldElement.after(countContainer);
           var countMethod = function() {
             var text = memoFieldElement.val().trim();
-            $(wordCountContainer).find('.word-count').text(text === '' ? 0 : text.split(/\s+/).length);
+            $(countContainer).find('.character-count').text(text === '' ? 0 : text.replace(/(\s|\r\n|\r|\n)+/g,'').split("").length);
+            $(countContainer).find('.word-count').text(text === '' ? 0 : text.split(/\s+/).length);
           };
           var timer = null;
           memoFieldElement.on('focus', $.proxy(function() {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -530,11 +530,15 @@
       if (data.fieldlessMode) {
         $(object).replaceWith(memoFieldElement);
         
-        var countContainer = $('<div class="count-container">')
+        var characterCounter = $('<div class="character-count-container">')
           .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
-          .append('<span class="character-count">')
+          .append('<span class="character-count">');
+        var wordCounter = $('<div class="word-count-container">')
           .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
           .append('<span class="word-count">');
+        this._countContainer = $('<div class="count-container">')
+          .append(characterCounter)
+          .append(wordCounter);
         memoFieldElement.after(countContainer);
 
         var text = data.value || "";
@@ -550,11 +554,15 @@
         
         // #3120 memo word counter (non-richedit)
         if (data.meta.richedit != true) {
-          var countContainer = $('<div class="count-container">')
+          var characterCounter = $('<div class="character-count-container">')
             .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
-            .append('<span class="character-count">')
+            .append('<span class="character-count">');
+          var wordCounter = $('<div class="word-count-container">')
             .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
             .append('<span class="word-count">');
+          this._countContainer = $('<div class="count-container">')
+            .append(characterCounter)
+            .append(wordCounter);
           memoFieldElement.after(countContainer);
           var countMethod = function() {
             var text = memoFieldElement.val().trim();

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-material-loader.js
@@ -536,7 +536,7 @@
         var wordCounter = $('<div class="word-count-container">')
           .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
           .append('<span class="word-count">');
-        this._countContainer = $('<div class="count-container">')
+        var countContainer = $('<div class="count-container">')
           .append(characterCounter)
           .append(wordCounter);
         memoFieldElement.after(countContainer);
@@ -560,7 +560,7 @@
           var wordCounter = $('<div class="word-count-container">')
             .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
             .append('<span class="word-count">');
-          this._countContainer = $('<div class="count-container">')
+          var countContainer = $('<div class="count-container">')
             .append(characterCounter)
             .append(wordCounter);
           memoFieldElement.after(countContainer);

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-rich-memo-field-component.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-rich-memo-field-component.js
@@ -44,11 +44,15 @@
       this._editor.on('contentChange', $.proxy(this._onContentChange, this));
       this._editor.on('instanceReady', $.proxy(this._onInstanceReady, this));
       
-      // #3120 memo word counter (ui)
-      this._wordCountContainer = $('<div class="word-count-container">')
+      // #3120 memo word counter (ui) changed in #3757
+      this._countContainer = $('<div class="count-container">')
+        .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
+        .append('<span class="character-count">')
         .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
         .append('<span class="word-count">'); 
-      $(this.element[0]).after(this._wordCountContainer);
+      $(this.element[0]).after(this._countContainer);
+      
+      
     },
 
     setReadOnly: function (readonly) {
@@ -64,15 +68,22 @@
       }
     },
     
+    //#3757 memo letter counter (functionality)
+    _countLetters:function(){
+      var text = $(this._editor.getData()).text();
+      $(this._countContainer).find('.character-count').text(text === '' ? 0 : text.trim().replace(/(\s|\r\n|\r|\n)+/g,'').split("").length);
+    },
+    
     // #3120 memo word counter (functionality)
     _countWords: function() {
       var text = $(this._editor.getData()).text();
-      $(this._wordCountContainer).find('.word-count').text(text === '' ? 0 : text.split(/\s+/).length);
+      $(this._countContainer).find('.word-count').text(text === '' ? 0 : text.trim().split(/\s+/).length);
     },
 
     _onInstanceReady: function (event, data) {
       this.setReadOnly(this._readonly);
       this._countWords();
+      this._countLetters();
     },
     
     _onContentChange: function (event, data) {
@@ -80,6 +91,7 @@
         .val(this._editor.getData())
         .trigger("change");
       this._countWords();
+      this._countLetters();
     },
     
     _destroy: function () {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-rich-memo-field-component.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-rich-memo-field-component.js
@@ -45,11 +45,15 @@
       this._editor.on('instanceReady', $.proxy(this._onInstanceReady, this));
       
       // #3120 memo word counter (ui) changed in #3757
-      this._countContainer = $('<div class="count-container">')
+      var characterCounter = $('<div class="character-count-container">')
         .append($('<span class="character-count-title">').text(getLocaleText('plugin.workspace.memoField.characterCount')))
-        .append('<span class="character-count">')
+        .append('<span class="character-count">');
+      var wordCounter = $('<div class="word-count-container">')
         .append($('<span class="word-count-title">').text(getLocaleText('plugin.workspace.memoField.wordCount')))
-        .append('<span class="word-count">'); 
+        .append('<span class="word-count">');
+      this._countContainer = $('<div class="count-container">')
+        .append(characterCounter)
+        .append(wordCounter);
       $(this.element[0]).after(this._countContainer);
       
       

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
@@ -125,10 +125,12 @@ div.muikku-text-field {
   
   .character-count-container{
     display: inline-block;
+    padding:5px;
   }
 
   .word-count-container{
     display: inline-block;
+    adding:5px;
   }
   
   .character-count-title {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
@@ -118,10 +118,21 @@ div.muikku-text-field {
 }
 
 // MEMOFIELD WORD COUNT
-.word-count-container {
+.count-container {
   font-size: 13px;
   line-height: 1;
   text-align: right;
+  
+  .character-count-title {
+    display: inline-block;
+    padding: 2px;
+  }
+  
+  .character-count {
+    background: #f3faff;
+    display: inline-block;
+    padding: 2px;
+  }
   
   .word-count-title {
     display: inline-block;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
@@ -123,14 +123,14 @@ div.muikku-text-field {
   line-height: 1;
   text-align: right;
   
-  .character-count-container{
+  .character-count-container {
     display: inline-block;
     padding:5px;
   }
 
-  .word-count-container{
+  .word-count-container {
     display: inline-block;
-    adding:5px;
+    padding:5px;
   }
   
   .character-count-title {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
@@ -123,6 +123,14 @@ div.muikku-text-field {
   line-height: 1;
   text-align: right;
   
+  .character-count-container{
+    display: inline-block;
+  }
+
+  .word-count-container{
+    display: inline-block;
+  }
+  
   .character-count-title {
     display: inline-block;
     padding: 2px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -207,10 +207,12 @@
     
     .character-count-container{
       display: inline-block;
+      padding: 5px;
     }
     
     .word-count-container{
       display: inline-block;
+      padding: 5px;
     }
     
     .character-count-title {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -205,6 +205,14 @@
     line-height: 1;
     text-align: right;
     
+    .character-count-container{
+      display: inline-block;
+    }
+    
+    .word-count-container{
+      display: inline-block;
+    }
+    
     .character-count-title {
       display: inline-block;
       padding: 2px;

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -205,12 +205,12 @@
     line-height: 1;
     text-align: right;
     
-    .character-count-container{
+    .character-count-container {
       display: inline-block;
       padding: 5px;
     }
     
-    .word-count-container{
+    .word-count-container {
       display: inline-block;
       padding: 5px;
     }

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -200,10 +200,21 @@
   
   }
   
-  .word-count-container {
+  .count-container {
     font-size: 13px;
     line-height: 1;
     text-align: right;
+    
+    .character-count-title {
+      display: inline-block;
+      padding: 2px;
+    }
+    
+    .character-count {
+      background: #f3faff;
+      display: inline-block;
+      padding: 2px;
+    }
     
     .word-count-title {
       display: inline-block;


### PR DESCRIPTION
Fixes #3757 -Workspace materials - counter for memofield
added character counter. excluded /(\s|\r\n|\r|\n)+/g
Changed word-count+container to count-container in both view and styles to make it generic.
Fixed word counter by trimming the String before calculating words. It was showing additional words if there were spaces at the beginning or at the end of string.