### PR TITLE
Fixes #3775 Evaluated material page does not load mathjax

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/muikku-field.js
@@ -336,6 +336,17 @@
                             .addClass('assignment-date-data')
                             .html(formatDate(moment(evaluation.assessmentDate).toDate())))
                       );
+                      if ((typeof MathJax) != 'undefined') {
+                        MathJax.Hub.Config({
+                          "HTML-CSS": {
+                            scale: 90
+                          },
+                          NativeMML: {
+                            scale: 90
+                          }
+                        });
+                        MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+                      }
                       if (evaluationContainer.attr('data-open') == 'false') {
                         this._toggleEvaluationContainer();
                       }


### PR DESCRIPTION
Fixes #3775 Evaluated material page does not load mathjax
Added a mathjax initializer to a muikku field literals.