### PR TITLE
Fixes #3658 -Renew evaluation date when re-evaluating incomplete

### DIFF
--- a/muikku-evaluation-plugin/src/main/resources/META-INF/resources/scripts/gui/evaluation-modal.js
+++ b/muikku-evaluation-plugin/src/main/resources/META-INF/resources/scripts/gui/evaluation-modal.js
@@ -392,6 +392,7 @@
     
     _onMaterialsLoaded: function(event, data) {
       $.each(data.assignments, $.proxy(function(index, assignment) {
+        console.log(assignment.evaluated);
         renderDustTemplate("evaluation/evaluation-assignment-wrapper.dust", {
           materialType: assignment.evaluable ? 'assignment' : 'exercise',
           title: assignment.title,
@@ -507,7 +508,7 @@
                 // Verbal assessment
                 CKEDITOR.instances.assignmentEvaluateFormLiteralEvaluation.setData(assessment.verbalAssessment);
                 // Date
-                $('#assignmentEvaluationDate').datepicker('setDate', moment(assessment.assessmentDate).toDate());
+                $('#assignmentEvaluationDate').datepicker('setDate', new Date());
                 // Assessor
                 $('#assignmentAssessor').val(assessment.assessorIdentifier);
                 // Grading
@@ -540,7 +541,7 @@
                 // Verbal assessment
                 CKEDITOR.instances.assignmentEvaluateFormLiteralEvaluation.setData(supplementationRequest.requestText);
                 // Date
-                $('#assignmentEvaluationDate').datepicker('setDate', moment(supplementationRequest.requestDate).toDate());
+                $('#assignmentEvaluationDate').datepicker('setDate', new Date());
                 // Assessor
                 $('#assignmentAssessor option[data-user-entity-id="' + supplementationRequest.userEntityId + '"]').attr('selected','selected');
                 // Grading
@@ -637,7 +638,7 @@
             // Verbal assessment
             CKEDITOR.instances.workspaceEvaluateFormLiteralEvaluation.setData(assessment.verbalAssessment);
             // Date
-            $('#workspaceEvaluationDate').datepicker('setDate', moment(assessment.assessmentDate).toDate());
+            $('#workspaceEvaluationDate').datepicker('setDate', new Date());
             // Assessor
             $('#workspaceAssessor').val(assessment.assessorIdentifier);
             // Grading
@@ -669,7 +670,7 @@
             // Verbal assessment
             CKEDITOR.instances.workspaceEvaluateFormLiteralEvaluation.setData(supplementationRequest.requestText);
             // Date
-            $('#workspaceEvaluationDate').datepicker('setDate', moment(supplementationRequest.requestDate).toDate());
+            $('#workspaceEvaluationDate').datepicker('setDate', new Date());
             // Assessor
             $('#workspaceAssessor option[data-user-entity-id="' + supplementationRequest.userEntityId + '"]').attr('selected','selected');
             // Grading

--- a/muikku-evaluation-plugin/src/main/resources/META-INF/resources/scripts/gui/evaluation-modal.js
+++ b/muikku-evaluation-plugin/src/main/resources/META-INF/resources/scripts/gui/evaluation-modal.js
@@ -392,7 +392,6 @@
     
     _onMaterialsLoaded: function(event, data) {
       $.each(data.assignments, $.proxy(function(index, assignment) {
-        console.log(assignment.evaluated);
         renderDustTemplate("evaluation/evaluation-assignment-wrapper.dust", {
           materialType: assignment.evaluable ? 'assignment' : 'exercise',
           title: assignment.title,


### PR DESCRIPTION
Changed lines that sets the dates from setting the evaluation dates of evaluated assignments and workspaces to current date.