### PR TITLE
Refactored PyramusScheduler and PyramusRestClient GET exception handling

### DIFF
--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/UserSchoolDataController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/UserSchoolDataController.java
@@ -47,39 +47,23 @@ public class UserSchoolDataController {
   /* User */
 
   public User createUser(SchoolDataSource schoolDataSource, String firstName, String lastName) {
-    UserSchoolDataBridge userBridge = getUserBridge(schoolDataSource);
-    if (userBridge != null) {
-      return userBridge.createUser(firstName, lastName);
-    }
-
-    return null;
+    return getUserBridge(schoolDataSource).createUser(firstName, lastName);
   }
 
   public User findUser(SchoolDataSource schoolDataSource, String userIdentifier) {
-    UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-    if (schoolDataBridge != null) {
-      return schoolDataBridge.findUser(userIdentifier);
-    }
-
-    return null;
+    return getUserBridge(schoolDataSource).findUser(userIdentifier);
   }
 
   public User findUser(String schoolDataSource, String userIdentifier) {
     SchoolDataSource dataSource = schoolDataSourceDAO.findByIdentifier(schoolDataSource);
-    if (dataSource != null) {
-      return findUser(dataSource, userIdentifier);
+    if (dataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", schoolDataSource));
     }
-
-    return null;
+    return findUser(dataSource, userIdentifier);
   }
 
   public User findActiveUser(SchoolDataSource schoolDataSource, String identifier) {
-    UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-    if (schoolDataBridge != null) {
-      return schoolDataBridge.findActiveUser(identifier);
-    }
-
-    return null;
+    return getUserBridge(schoolDataSource).findActiveUser(identifier);
   }
 
   public List<User> listUsers() {
@@ -153,103 +137,66 @@ public class UserSchoolDataController {
   public UserEntity findUserEntity(User user) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
     UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierDAO.findByDataSourceAndIdentifierAndArchived(schoolDataSource, user.getIdentifier(), Boolean.FALSE);
-    if (userSchoolDataIdentifier != null) {
-      return userSchoolDataIdentifier.getUserEntity();
-    }
-
-    return null;
+    return userSchoolDataIdentifier == null ? null : userSchoolDataIdentifier.getUserEntity();
   }
 
   public UserEntity findUserEntityByDataSourceAndIdentifier(SchoolDataSource dataSource, String identifier) {
     UserSchoolDataIdentifier userSchoolDataIdentifier = userSchoolDataIdentifierDAO.findByDataSourceAndIdentifierAndArchived(dataSource, identifier, Boolean.FALSE);
-    if (userSchoolDataIdentifier != null) {
-      return userSchoolDataIdentifier.getUserEntity();
-    }
-
-    return null;
+    return userSchoolDataIdentifier == null ? null : userSchoolDataIdentifier.getUserEntity();
   }
 
   /* User Emails */
 
   public List<UserEmail> listUserEmails(User user) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserEmailsByUserIdentifier(user.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-
-    return null;
+    return getUserBridge(schoolDataSource).listUserEmailsByUserIdentifier(user.getIdentifier());
   }
 
   public List<UserEmail> listUserEmails(SchoolDataIdentifier userIdentifier) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(userIdentifier.getDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserEmailsByUserIdentifier(userIdentifier.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", userIdentifier.getDataSource()));
     }
-
-    return null;
+    return getUserBridge(schoolDataSource).listUserEmailsByUserIdentifier(userIdentifier.getIdentifier());
   }
 
   public UserEmail findUserEmail(SchoolDataSource schoolDataSource, String identifier) {
-    UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-    if (schoolDataBridge != null) {
-      return schoolDataBridge.findUserEmail(identifier);
-    }
-
-    return null;
+    return getUserBridge(schoolDataSource).findUserEmail(identifier);
   }
   
   /* User properties */
 
   public List<UserProperty> listUserProperties(User user) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserPropertiesByUser(user.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-    return null;
+    return getUserBridge(schoolDataSource).listUserPropertiesByUser(user.getIdentifier());
   }
   
   public UserProperty getUserProperty(User user, String key) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.getUserProperty(user.getIdentifier(), key);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-    return null;
+    return getUserBridge(schoolDataSource).getUserProperty(user.getIdentifier(), key);
   }
 
   public UserProperty setUserProperty(User user, String key, String value) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.setUserProperty(user.getIdentifier(), key, value);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-    return null;
+    return getUserBridge(schoolDataSource).setUserProperty(user.getIdentifier(), key, value);
   }
 
   /* Roles */
 
   public Role findRole(SchoolDataSource schoolDataSource, String identifier) {
-    UserSchoolDataBridge userBridge = getUserBridge(schoolDataSource);
-    if (userBridge != null) {
-      return userBridge.findRole(identifier);
-    } else {
-      logger.severe("Could not find userBridge for school data source " + schoolDataSource.getIdentifier());
-    }
-
-    return null;
+    return getUserBridge(schoolDataSource).findRole(identifier);
   }
 
   public List<Role> listRoles() {
@@ -264,92 +211,58 @@ public class UserSchoolDataController {
 
   public Role findUserEnvironmentRole(User user) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.findUserEnvironmentRole(user.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-
-    return null;
+    return getUserBridge(schoolDataSource).findUserEnvironmentRole(user.getIdentifier());
   }
 
   /* UserGroups */
 
   public UserGroup findUserGroup(SchoolDataSource schoolDataSource, String identifier) {
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.findUserGroup(identifier);
-      }
-    }
-    return null;
+    return getUserBridge(schoolDataSource).findUserGroup(identifier);
   }
 
   public List<UserGroup> listUserGroups(SchoolDataSource schoolDataSource) {
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserGroups();
-      }
-    }
-    return null;
+    return getUserBridge(schoolDataSource).listUserGroups();
   }
 
   /* Group users */
 
   public GroupUser findGroupUser(SchoolDataSource schoolDataSource, String groupIdentifier, String identifier) {
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.findGroupUser(groupIdentifier, identifier);
-      }
-    }
-    return null;
+    return getUserBridge(schoolDataSource).findGroupUser(groupIdentifier, identifier);
   }
   
   public List<GroupUser> listGroupUsersByGroup(UserGroup userGroup){
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(userGroup.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listGroupUsersByGroup(userGroup.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", userGroup.getSchoolDataSource()));
     }
-    return null;
+    return getUserBridge(schoolDataSource).listGroupUsersByGroup(userGroup.getIdentifier());
   }
 
   public List<GroupUser> listGroupUsersByGroupAndType(UserGroup userGroup, GroupUserType type){
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(userGroup.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listGroupUsersByGroupAndType(userGroup.getIdentifier(), type);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", userGroup.getSchoolDataSource()));
     }
-    return null;
+    return getUserBridge(schoolDataSource).listGroupUsersByGroupAndType(userGroup.getIdentifier(), type);
   }
   
   public List<UserAddress> listUserAddressses(SchoolDataIdentifier userIdentifier){
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(userIdentifier.getDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserAddresses(userIdentifier);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", userIdentifier.getDataSource()));
     }
-    
-    return null;
+    return getUserBridge(schoolDataSource).listUserAddresses(userIdentifier);
   }
   
   public void updateUser(User user) {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        schoolDataBridge.updateUser(user);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
+    getUserBridge(schoolDataSource).updateUser(user);
   }
 	
 	public void updateUserAddress(
@@ -361,30 +274,24 @@ public class UserSchoolDataController {
       String country
   ) throws SchoolDataBridgeUnauthorizedException {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(addressIdentifier.getDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        schoolDataBridge.updateUserAddress(
-            studentIdentifier,
-            addressIdentifier,
-            street,
-            postalCode,
-            city,
-            country);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", addressIdentifier.getDataSource()));
     }
+    getUserBridge(schoolDataSource).updateUserAddress(
+      studentIdentifier,
+      addressIdentifier,
+      street,
+      postalCode,
+      city,
+      country);
 	}
   
   public List<UserPhoneNumber> listUserPhoneNumbers(SchoolDataIdentifier userIdentifier){
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(userIdentifier.getDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.listUserPhoneNumbers(userIdentifier);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", userIdentifier.getDataSource()));
     }
-    
-    return null;
+    return getUserBridge(schoolDataSource).listUserPhoneNumbers(userIdentifier);
   }
 
   private UserSchoolDataBridge getUserBridge(SchoolDataSource schoolDataSource) {
@@ -395,8 +302,7 @@ public class UserSchoolDataController {
         return userSchoolDataBridge;
       }
     }
-
-    return null;
+    throw new SchoolDataBridgeInternalException(String.format("No UserBridge for data source %s", schoolDataSource));
   }
 
   private User findUserByIdentifier(UserSchoolDataBridge userBridge, String identifier) {
@@ -416,42 +322,26 @@ public class UserSchoolDataController {
 
   public String findUsername(User user) throws SchoolDataBridgeUnauthorizedException {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        return schoolDataBridge.findUsername(user.getIdentifier());
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
-    
-    return null;
+    return getUserBridge(schoolDataSource).findUsername(user.getIdentifier());
 	}
 	
 	public void updateUserCredentials(User user, String oldPassword, String newUsername, String newPassword) throws SchoolDataBridgeUnauthorizedException {
     SchoolDataSource schoolDataSource = schoolDataSourceDAO.findByIdentifier(user.getSchoolDataSource());
-    if (schoolDataSource != null) {
-      UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-      if (schoolDataBridge != null) {
-        schoolDataBridge.updateUserCredentials(user.getIdentifier(), oldPassword, newUsername, newPassword);
-      }
+    if (schoolDataSource == null) {
+      throw new SchoolDataBridgeInternalException(String.format("Invalid data source %s", user.getSchoolDataSource()));
     }
+    getUserBridge(schoolDataSource).updateUserCredentials(user.getIdentifier(), oldPassword, newUsername, newPassword);
 	}
 	
   public String requestPasswordResetByEmail(SchoolDataSource schoolDataSource, String email) throws SchoolDataBridgeUnauthorizedException {
-    UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-    if (schoolDataBridge != null) {
-      return schoolDataBridge.requestPasswordResetByEmail(email);
-    }
-    
-    return null;
+    return getUserBridge(schoolDataSource).requestPasswordResetByEmail(email);
   }
 
   public boolean confirmResetPassword(SchoolDataSource schoolDataSource, String resetCode, String newPassword) throws SchoolDataBridgeUnauthorizedException {
-    UserSchoolDataBridge schoolDataBridge = getUserBridge(schoolDataSource);
-    if (schoolDataBridge != null) {
-      return schoolDataBridge.confirmResetPassword(resetCode, newPassword);
-    }
-    
-    return false;
+    return getUserBridge(schoolDataSource).confirmResetPassword(resetCode, newPassword);
   }
 
 }

--- a/muikku-school-data-pyramus/pom.xml
+++ b/muikku-school-data-pyramus/pom.xml
@@ -80,6 +80,12 @@
       <scope>provided</scope>
     </dependency>
     
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>    
+    
     <!-- RestEasy -->
     
     <dependency>

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/rest/PyramusRestClient.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/rest/PyramusRestClient.java
@@ -2,7 +2,6 @@ package fi.otavanopisto.muikku.plugins.schooldatapyramus.rest;
 
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
@@ -99,10 +98,6 @@ class PyramusRestClient implements Serializable {
     Response response = request.get();
     try {
       return createResponse(response, type, path);
-    } catch (Throwable t) {
-      // TODO Remove catch once Pyramus 403 issue is resolved   
-      logger.log(Level.SEVERE, String.format("Pyramus GET request into %s failed", path), t);
-      return null;
     } finally {
       response.close();
     }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
@@ -9,17 +9,16 @@ import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import javax.ejb.AccessTimeout;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
-import javax.ejb.Timeout;
-import javax.ejb.Timer;
-import javax.ejb.TimerConfig;
-import javax.ejb.TimerService;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.transaction.UserTransaction;
 
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,75 +28,68 @@ import fi.otavanopisto.muikku.plugins.schooldatapyramus.SchoolDataPyramusPluginD
 @Startup
 @Singleton
 @ApplicationScoped
+@TransactionManagement(value=TransactionManagementType.BEAN)
 public class PyramusScheduler {
 
-  private static final int INITIAL_TIMEOUT = 1000 * 300; // 5 minutes
-  private static final int TIMEOUT = 1000 * 30; // 30 sec
-  private static final int ERROR_TIMEOUT = 1000 * 60; // 60 sec
+  private static final int INITIAL_TIMEOUT = 300; // 5 minutes
+  private static final int TIMEOUT = 60; // 1 minute
 
   @Any
   @Inject
   private Instance<PyramusUpdateScheduler> updateSchedulers;
 
-  @Resource
-  private TimerService timerService;
-
   @Inject
   private Logger logger;
-
+  
+  @Resource
+  private ManagedScheduledExecutorService scheduledExecutorService;
+  
+  @Resource
+  private UserTransaction userTransaction;
+  
   @PostConstruct
   public void init() {
-    logger.info(String.format("Launching PyramusScheduler in %dms", INITIAL_TIMEOUT));
     if (!SchoolDataPyramusPluginDescriptor.SCHEDULERS_ACTIVE || "true".equals(System.getProperty("tests.running"))) {
       return;
     }
+    logger.info(String.format("Launching PyramusScheduler in %ds", INITIAL_TIMEOUT));
     schedulerIndex = 0;
-    startTimer(INITIAL_TIMEOUT);
+    scheduledExecutorService.scheduleWithFixedDelay(this::synchronizePyramusData, INITIAL_TIMEOUT, TIMEOUT, TimeUnit.SECONDS);
   }
 
-  @Timeout
-  @AccessTimeout(value = 2, unit = TimeUnit.MINUTES)
-  public void syncTimeout(Timer timer) {
+  private void synchronizePyramusData() {
     try {
-      synchronizePyramusData();
-      startTimer(TIMEOUT);
-    }
-    catch (Exception ex) {
-      logger.log(Level.SEVERE, "Synchronization failed.", ex);
-      startTimer(ERROR_TIMEOUT);
-    }
-  }
-
-  public void synchronizePyramusData() {
-    @SuppressWarnings("unchecked")
-    List<PyramusUpdateScheduler> schedulers = IteratorUtils.toList(updateSchedulers.iterator());
-    Collections.sort(schedulers, new Comparator<PyramusUpdateScheduler>() {
-      @Override
-      public int compare(PyramusUpdateScheduler o1, PyramusUpdateScheduler o2) {
-        return o1.getPriority() - o2.getPriority();
-      }
-    });
-
-    PyramusUpdateScheduler updateScheduler = schedulers.get(schedulerIndex);
-    String schedulerName = StringUtils.substringBefore(updateScheduler.getClass().getSimpleName(), "$");
-    logger.fine(String.format("Running %s", schedulerName));
-    
-    try {
+      userTransaction.begin();
+      
+      @SuppressWarnings("unchecked")
+      List<PyramusUpdateScheduler> schedulers = IteratorUtils.toList(updateSchedulers.iterator());
+      Collections.sort(schedulers, new Comparator<PyramusUpdateScheduler>() {
+        @Override
+        public int compare(PyramusUpdateScheduler o1, PyramusUpdateScheduler o2) {
+          return o1.getPriority() - o2.getPriority();
+        }
+      });
+  
+      PyramusUpdateScheduler updateScheduler = schedulers.get(schedulerIndex);
+      String schedulerName = StringUtils.substringBefore(updateScheduler.getClass().getSimpleName(), "$");
+      logger.info(String.format("Running %s", schedulerName));
+      
       updateScheduler.synchronize();
+  
+      schedulerIndex = (schedulerIndex + 1) % schedulers.size();
+
+      userTransaction.commit();
     }
-    catch (Exception ex) {
-      logger.log(Level.WARNING, String.format("%s failed", schedulerName), ex);
+    catch (Exception e) {
+      logger.log(Level.WARNING, "Pyramus synchronization failed", e);
+      try {
+        userTransaction.rollback();
+      }
+      catch (Exception rbe) {
+        logger.log(Level.WARNING, "Pyramus synchronization rollback failed", e);
+      }      
     }
-
-    schedulerIndex = (schedulerIndex + 1) % schedulers.size();
   }
-
-  private void startTimer(int duration) {
-    TimerConfig timerConfig = new TimerConfig();
-    timerConfig.setPersistent(false);
-    timerService.createSingleActionTimer(duration, timerConfig);
-  }
-
   private int schedulerIndex;
 
 }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/schedulers/PyramusScheduler.java
@@ -80,13 +80,13 @@ public class PyramusScheduler {
 
     PyramusUpdateScheduler updateScheduler = schedulers.get(schedulerIndex);
     String schedulerName = StringUtils.substringBefore(updateScheduler.getClass().getSimpleName(), "$");
-    logger.info(String.format("Running %s", schedulerName));
+    logger.fine(String.format("Running %s", schedulerName));
     
     try {
       updateScheduler.synchronize();
     }
     catch (Exception ex) {
-      logger.log(Level.SEVERE, String.format("%s failed", schedulerName, ex));
+      logger.log(Level.WARNING, String.format("%s failed", schedulerName), ex);
     }
 
     schedulerIndex = (schedulerIndex + 1) % schedulers.size();


### PR DESCRIPTION
- resolves #3795; Pyramus REST client will now relay all GET exceptions to caller instead of silently ignoring them
- refactored PyramusScheduler to use ManagedScheduledExecutorService; the change aims to address scheduler timeouts and especially fixes the issue of scheduler fails leading to boththe server and scheduler code attempting a retry, possibly causing unexpected concurrency issues
- refactored UserSchoolDataController to relay problems with school data bridge instead of silently ignoring them

**Note:** Okay to be reviewed/commented but might be better to merge only after issues #3801 and #3802 have been addressed. Due to #3795, views retrieving data from Pyramus are now susceptible to exceptions they haven't take into consideration, leading to rather graceless error views.