### PR TITLE
Workspace staff member synchronization bug fixes

### DIFF
--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataWorkspaceListener.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/events/DefaultSchoolDataWorkspaceListener.java
@@ -117,6 +117,10 @@ public class DefaultSchoolDataWorkspaceListener {
             if (!workspaceUserEntity.getIdentifier().equals(event.getIdentifier())) {
               workspaceUserEntityController.updateIdentifier(workspaceUserEntity, event.getIdentifier());
             }
+            // #3806: WorkspaceUserEntity exists; check if role has changed
+            if (workspaceUserEntity.getWorkspaceUserRole() == null || !workspaceUserRole.getId().equals(workspaceUserEntity.getWorkspaceUserRole().getId())) {
+              workspaceUserEntityController.updateWorkspaceUserRole(workspaceUserEntity, workspaceUserRole);
+            }
             workspaceUserEntityController.unarchiveWorkspaceUserEntity(workspaceUserEntity);
           }
           

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
@@ -19,9 +19,6 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
-
 import fi.otavanopisto.muikku.model.users.EnvironmentUser;
 import fi.otavanopisto.muikku.model.users.RoleSchoolDataIdentifier;
 import fi.otavanopisto.muikku.model.users.UserEntity;
@@ -551,8 +548,8 @@ public class PyramusUpdater {
       try {
         String courseStaffMemberIdentifier = currentStaffMember.getIdentifier();
         String staffMemberIdentifier = currentStaffMember.getUserSchoolDataIdentifier().getUserEntity().getDefaultIdentifier();
-        Long courseStaffMemberId = NumberUtils.toLong(StringUtils.substringAfterLast(courseStaffMemberIdentifier, "-"));
-        Long staffMemberId = NumberUtils.toLong(StringUtils.substringAfterLast(staffMemberIdentifier, "-"));
+        Long courseStaffMemberId = identifierMapper.getPyramusCourseStaffId(courseStaffMemberIdentifier); 
+        Long staffMemberId = identifierMapper.getPyramusStaffId(staffMemberIdentifier);
         fireCourseStaffMemberRemoved(courseStaffMemberId, staffMemberId, courseId);
       }
       catch (Exception e) {


### PR DESCRIPTION
- fixes #3806 (Muikku didn't react to an existing workspace staff member getting a new role in Pyramus)
- scheduled background synchronization of course staff members now archives those workspace staff members that were removed in Pyramus but Muikku somehow failed to process the related event