### PR TITLE
' Fix for announcement's reading view's layout issue; removed

### DIFF
--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-reading-view.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/flex-reading-view.scss
@@ -46,9 +46,11 @@ body {
               color: #666;
               border-bottom: 1px solid #eee;
             }
-            .article-workspaces{
-              font-size: 12px;            }
+            
+            .article-workspaces {
+              font-size: 12px;            
             }
+          }
           
           .article-context {
             padding: 10px 5px;
@@ -74,7 +76,7 @@ body {
       nav.gc-navigation {
         max-height: 100%;
         min-height: 670px;
-        padding: 0 0 0 10px;
+        padding: 0;
         
         .gc-navigation-item {
           margin: 0 0 20px;


### PR DESCRIPTION
Closes #3829 
This accidentally fixes the layout issue as the original reason for the issue is that one of the announcements has long title that forces the list to bee woo wide. 