### PR TITLE
WebSocket maintenance

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocket.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocket.java
@@ -23,7 +23,7 @@ public class WebSocket {
   
   @OnClose
   public void onClose(final Session session, CloseReason closeReason, @PathParam("TICKET") String ticket) {
-    webSocketMessenger.closeSession(session, ticket);
+    webSocketMessenger.closeSession(session, ticket, closeReason);
   }
 
   @OnMessage

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketMessenger.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketMessenger.java
@@ -40,11 +40,6 @@ public class WebSocketMessenger {
   }
   
   public void sendMessage(String eventType, Object data, List<UserEntity> recipients) {
-    List<Long> recipientIds = new ArrayList<Long>(recipients.size());
-    for (UserEntity userEntity : recipients) {
-      recipientIds.add(userEntity.getId());
-    }
-    
     WebSocketMessage message = new WebSocketMessage(eventType, data);
     ObjectMapper mapper = new ObjectMapper();
     String strMessage = null;
@@ -54,6 +49,11 @@ public class WebSocketMessenger {
     catch (Exception e) {
       logger.warning("Unable to serialize websocket message");
       return;
+    }
+
+    List<Long> recipientIds = new ArrayList<Long>(recipients.size());
+    for (UserEntity userEntity : recipients) {
+      recipientIds.add(userEntity.getId());
     }
     
     for (String ticket : sessions.keySet()) {

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketMessenger.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketMessenger.java
@@ -40,72 +40,102 @@ public class WebSocketMessenger {
   }
   
   public void sendMessage(String eventType, Object data, List<UserEntity> recipients) {
+    List<Long> recipientIds = new ArrayList<Long>(recipients.size());
+    for (UserEntity userEntity : recipients) {
+      recipientIds.add(userEntity.getId());
+    }
+    
+    WebSocketMessage message = new WebSocketMessage(eventType, data);
+    ObjectMapper mapper = new ObjectMapper();
+    String strMessage = null;
     try {
-      List<Long> recipientIds = new ArrayList<Long>(recipients.size());
-      for (UserEntity userEntity : recipients) {
-        recipientIds.add(userEntity.getId());
-      }
-      
-      WebSocketMessage message = new WebSocketMessage(eventType, data);
-      ObjectMapper mapper = new ObjectMapper();
-      String strMessage = mapper.writeValueAsString(message);
-      
-      for (Session session : sessions.values()) {
-        if (session.isOpen()) {
-          Long userId = (Long) session.getUserProperties().get("UserId");
-  
-          if ((userId != null) && (recipientIds.contains(userId))) {
-            session.getBasicRemote().sendText(strMessage);
-          }
-        }
-      }    
+      strMessage = mapper.writeValueAsString(message);
     }
     catch (Exception e) {
-      logger.log(Level.SEVERE, "Failed to send WebSocket message", e);
+      logger.warning("Unable to serialize websocket message");
+      return;
+    }
+    
+    for (String ticket : sessions.keySet()) {
+      Session session = sessions.get(ticket);
+      try {
+        if (session == null || !session.isOpen()) {
+          closeSession(session, ticket, null);
+          continue;
+        }
+        Long userId = (Long) session.getUserProperties().get("UserId");
+        if (userId != null && recipientIds.contains(userId)) {
+          session.getBasicRemote().sendText(strMessage);
+        }
+      }
+      catch (Exception e) {
+        logger.log(Level.WARNING, "Unable to send websocket message", e);
+        closeSession(session, ticket, null);
+      }
     }
   }
   
   public void sendMessage(String eventType, Object data, String ticket) {
+    WebSocketMessage message = new WebSocketMessage(eventType, data);
+    ObjectMapper mapper = new ObjectMapper();
+    String strMessage = null;
     try {
-      WebSocketMessage message = new WebSocketMessage(eventType, data);
-      ObjectMapper mapper = new ObjectMapper();
-      String strMessage = mapper.writeValueAsString(message);
-      Session session = sessions.get(ticket);
-      if (session == null) {
-        logger.log(Level.SEVERE, "Session doesn't exist");
+      strMessage = mapper.writeValueAsString(message);
+    }
+    catch (Exception e) {
+      logger.warning("Unable to serialize websocket message");
+      return;
+    }
+    
+    Session session = sessions.get(ticket);
+    try {
+      if (session == null || !session.isOpen()) {
+        closeSession(session, ticket, null);
       }
-      else if (session.isOpen()) {
+      else {
         session.getBasicRemote().sendText(strMessage);
       }
     }
     catch (Exception e) {
-      logger.log(Level.SEVERE, "Failed to send WebSocket message", e);
+      logger.log(Level.WARNING, "Unable to send websocket message", e);
+      closeSession(session, ticket, null);
     }
   }
   
-  public void openSession(Session session, String ticket) {
+  public void openSession(Session session, String ticketId) {
     try {
-      WebSocketTicket ticket1 = webSocketTicketController.findTicket(ticket);
-  
-      if (verifyTicket(ticket1)) {
-        session.getUserProperties().put("UserId", ticket1.getUser());
-        sessions.put(ticket, session);
+      WebSocketTicket ticket = webSocketTicketController.findTicket(ticketId);
+      if (ticket != null) {
+        session.getUserProperties().put("UserId", ticket.getUser());
+        sessions.put(ticketId, session);
       }
       else {
-        try {
-          session.close(new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Ticket could not be validated."));
-        }
-        catch (Exception e) {
-          // Closing failed, ignore
-        }
+        CloseReason reason = new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Invalid ticket");
+        closeSession(session, ticketId, reason);
       }
     }
     catch (Exception e) {
-      logger.log(Level.SEVERE, "Failed to open WebSocket session", e);
+      logger.log(Level.WARNING, "Failed to open WebSocket session", e);
     }
   }
 
-  public void closeSession(Session session, String ticket) {
+  public void closeSession(Session session, String ticket, CloseReason closeReason) {
+    // In normal cases the session is already closed (by client) but should it still
+    // be open for any reason, make a silent last-ditch effort to close it gracefully 
+    if (session != null && session.isOpen()) {
+      try {
+        if (closeReason != null) {
+          session.close(closeReason);
+        }
+        else {
+          session.close();
+        }
+      }
+      catch (Exception e) {
+        // Closing failed, at least we tried...
+      }
+    }
+    // Remove session and its corresponding ticket
     sessions.remove(ticket);
     webSocketTicketController.removeTicket(ticket);
   }
@@ -120,16 +150,13 @@ public class WebSocketMessenger {
         webSocketMessageEvent.select(new MuikkuWebSocketEventLiteral(messageData.getEventType())).fire(event);
       }
       else {
-        session.close(new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Invalid ticket"));
+        CloseReason reason = new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Invalid ticket");
+        closeSession(session, ticketId, reason);
       }
     }
     catch (Exception e) {
-      logger.log(Level.SEVERE, "Failed to handle WebSocket message", e);
+      logger.log(Level.WARNING, "Failed to handle WebSocket message", e);
     }
-  }
-  
-  private boolean verifyTicket(WebSocketTicket ticket) {
-    return ticket != null;
   }
   
 }

--- a/muikku/src/main/webapp/resources/scripts/gui/websocket.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/websocket.js
@@ -142,7 +142,6 @@
           this._pinging = true;
         }
         else {
-          if (console) console.log("ping failed, reconnecting...");
           this._pinging = false;
           clearInterval(this._pingHandle);
           this._pingHandle = null;

--- a/muikku/src/main/webapp/resources/scripts/gui/websocket.js
+++ b/muikku/src/main/webapp/resources/scripts/gui/websocket.js
@@ -4,9 +4,8 @@
   $.widget("custom.muikkuWebSocket", {
     
     options: {
-      reconnectInterval: 200,
-      pingTimeStep: 1000,
-      pingTimeout: 10000
+      reconnectInterval: 2000,
+      pingTimeStep: 10000
     },
     
     _create : function() {
@@ -16,20 +15,19 @@
       this._messagesPending = [];
       this._pingHandle = null;
       this._pinging = false;
-      this._pingTime = 0;
-      
-      this._getTicket($.proxy(function (ticket) {
-        if (this._ticket) {
-          this._openWebSocket();
-          this._startPinging();
-        } else {
-          $('.notification-queue').notificationQueue('notification', 'error', "Could not open WebSocket because ticket was missing");
-        }
-      }, this));
 
       this.element.on("webSocketConnected", $.proxy(this._onWebSocketConnected, this));
       this.element.on("webSocketDisconnected", $.proxy(this._onWebSocketDisconnected, this));
       $(window).on("beforeunload", $.proxy(this._onBeforeWindowUnload, this));
+
+      this._getTicket($.proxy(function (ticket) {
+        if (this._ticket) {
+          this._openWebSocket();
+        }
+        else {
+          $('.notification-queue').notificationQueue('notification', 'error', "Could not open WebSocket because ticket was missing");
+        }
+      }, this));
     },
     
     sendMessage: function (eventType, data) {
@@ -41,14 +39,15 @@
       if (this._socketOpen) {
         try {
           this._webSocket.send(JSON.stringify(message));
-        } catch (e) {
+        }
+        catch (e) {
           this._messagesPending.push({
             eventType: eventType,
             data: data
           });
-          this._reconnect();
         }
-      } else {
+      }
+      else {
         this._messagesPending.push({
           eventType: eventType,
           data: data
@@ -106,7 +105,6 @@
       
       if (this._webSocket) {
         this._webSocket.onmessage = $.proxy(this._onWebSocketMessage, this);
-        this._webSocket.onerror = $.proxy(this._onWebSocketError, this);
         this._webSocket.onclose = $.proxy(this._onWebSocketClose, this);
         switch (this._webSocket.readyState) {
           case this._webSocket.CONNECTING:
@@ -127,10 +125,10 @@
     _createWebSocket: function (url) {
       if ((typeof window.WebSocket) !== 'undefined') {
         return new WebSocket(url);
-      } else if ((typeof window.MozWebSocket) !== 'undefined') {
+      }
+      else if ((typeof window.MozWebSocket) !== 'undefined') {
         return new MozWebSocket(url);
       }
-      
       return null;
     },
     
@@ -142,16 +140,13 @@
         if (!this._pinging) {
           this.sendMessage("ping:ping", {});
           this._pinging = true;
-        } else {
-          this._pingTime += this.options.pingTimeStep;
-          
-          if (this._pingTime > this.options.pingTimeout) {
-            if (console) console.log("ping failed, reconnecting...");
-            this._pinging = false;
-            this._pingTime = 0;
-            
-            this._reconnect();
-          }
+        }
+        else {
+          if (console) console.log("ping failed, reconnecting...");
+          this._pinging = false;
+          clearInterval(this._pingHandle);
+          this._pingHandle = null;
+          this._reconnect();
         }
       }, this), this.options.pingTimeStep);
     },
@@ -165,7 +160,6 @@
         try {
           if (this._webSocket) {
             this._webSocket.onmessage = function () {};
-            this._webSocket.onerror = function () {};
             this._webSocket.onclose = function () {};
             if (wasOpen) {
               this._webSocket.close();
@@ -178,7 +172,8 @@
         this._getTicket($.proxy(function (ticket) {
           if (this._ticket) {
             this._openWebSocket();
-          } else {
+          }
+          else {
             $('.notification-queue').notificationQueue('notification', 'error', "Could not open WebSocket because ticket was missing");
           }
         }, this));
@@ -190,10 +185,6 @@
       this.element.trigger("webSocketConnected"); 
     },
     
-    _onWebSocketError: function () {
-      this._reconnect();
-    },
-    
     _onWebSocketClose: function () {
       this.element.trigger("webSocketDisconnected"); 
       this._reconnect();
@@ -201,7 +192,7 @@
     
     _onWebSocketConnected: function () {
       this._socketOpen = true;
-      
+      this._startPinging();
       while (this._socketOpen && this._messagesPending.length) {
         var message = this._messagesPending.shift();
         this.sendMessage(message.eventType, message.data);
@@ -210,16 +201,17 @@
     
     _onWebSocketDisconnected: function () {
       this._socketOpen = false;
+      clearInterval(this._pingHandle);
+      this._pingHandle = null;
     },
    
     _onWebSocketMessage: function (event) {
       var message = JSON.parse(event.data);
       var eventType = message.eventType;
-      
       if (eventType == "ping:pong") {
         this._pinging = false;
-        this._pingTime = 0;
-      } else {
+      }
+      else {
         this.element.trigger(eventType, message.data);
       }
     },
@@ -227,7 +219,6 @@
     _onBeforeWindowUnload: function () {
       if (this._webSocket) {
         this._webSocket.onmessage = function () {};
-        this._webSocket.onerror = function () {};
         this._webSocket.onclose = function () {};
         if (this._socketOpen) {
           this._webSocket.close();


### PR DESCRIPTION
- resolves #3366 (?)
- **client:** changed WebSocket ping frequency from 1 to 10 seconds
- **client:** start pinging only after WebSocket is open
- **client:** removed reconnect on WebSocket error as they close the socket which, too, reconnects
- **client:** only reconnect when WebSocket closes abnormally (see above)
- **client:** changed reconnect delay from 0.2 to 2 seconds
- **client:** initialize WebSocket lifetime listeners before establishing connection (not after)
- **server:** better cleanup of WebSockets (and tickets) that are lost or no longer open
- **server:** discard WebSocket (and ticket) on communication failure
- **server:** separate error handling for problems with WebSocket messages and connections