### PR TITLE
Fixes #3874 Student can not access announcements

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncerPermissions.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncerPermissions.java
@@ -57,7 +57,7 @@ public class AnnouncerPermissions extends AbstractMuikkuPermissionCollection imp
   public static final String LIST_WORKSPACE_ANNOUNCEMENTS = "LIST_WORKSPACE_ANNOUNCEMENTS";
 
   @Scope (PermissionScope.ENVIRONMENT)
-  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER } )
+  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER, EnvironmentRoleArchetype.STUDENT } )
   public static final String FIND_ANNOUNCEMENT = "FIND_ANNOUNCEMENT";
   
   @Scope (PermissionScope.ENVIRONMENT)


### PR DESCRIPTION
Added Environmental permission for the user to FIND_ANNOUNCEMENT, since it is checked on the respective REST point and the user need to have access to it in the redesign web site.
Works only after resetting the permissions on https://dev.muikkuverkko.fi:10443/permissions
Note:
Maybe this permission needs to be a workspace permission rather then environmental for the sake of security. This will require changes in authentication on the REST point.