### PR TITLE
Fixes #3877 Announcements for all not showing up

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/new-edit-announcement.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/new-edit-announcement.tsx
@@ -160,7 +160,7 @@ class NewEditAnnouncement extends React.Component<NewEditAnnouncementProps, NewE
           archived: false,
           caption: this.state.subject,
           content: this.state.text,
-          publiclyVisible: false,
+          publiclyVisible: this.state.currentTarget.length==0 ? true : false,
           endDate: this.state.endDate.format("YYYY-MM-DD"),
           startDate: this.state.startDate.format("YYYY-MM-DD"),
           userGroupEntityIds: this.state.currentTarget.filter(w=>w.type==="usergroup").map(w=>(w.value as any).id),
@@ -179,7 +179,7 @@ class NewEditAnnouncement extends React.Component<NewEditAnnouncementProps, NewE
         announcement: {
           caption: this.state.subject,
           content: this.state.text,
-          publiclyVisible: false,
+          publiclyVisible: this.state.currentTarget.length==0 ? true : false,
           endDate: this.state.endDate.format("YYYY-MM-DD"),
           startDate: this.state.startDate.format("YYYY-MM-DD"),
           userGroupEntityIds: this.state.currentTarget.filter(w=>w.type==="usergroup").map(w=>(w.value as any).id),

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/new-edit-announcement.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/new-edit-announcement.tsx
@@ -160,7 +160,7 @@ class NewEditAnnouncement extends React.Component<NewEditAnnouncementProps, NewE
           archived: false,
           caption: this.state.subject,
           content: this.state.text,
-          publiclyVisible: this.state.currentTarget.length==0 ? true : false,
+          publiclyVisible: this.state.currentTarget.length===0 ? true : false,
           endDate: this.state.endDate.format("YYYY-MM-DD"),
           startDate: this.state.startDate.format("YYYY-MM-DD"),
           userGroupEntityIds: this.state.currentTarget.filter(w=>w.type==="usergroup").map(w=>(w.value as any).id),
@@ -179,7 +179,7 @@ class NewEditAnnouncement extends React.Component<NewEditAnnouncementProps, NewE
         announcement: {
           caption: this.state.subject,
           content: this.state.text,
-          publiclyVisible: this.state.currentTarget.length==0 ? true : false,
+          publiclyVisible: this.state.currentTarget.length===0 ? true : false,
           endDate: this.state.endDate.format("YYYY-MM-DD"),
           startDate: this.state.startDate.format("YYYY-MM-DD"),
           userGroupEntityIds: this.state.currentTarget.filter(w=>w.type==="usergroup").map(w=>(w.value as any).id),


### PR DESCRIPTION
Fixes #3877 Announcements for all not showing up
Now announcement creator checks the target groups. If there are 0 of them it makes announcement "publiclyVisible"
announcements with at least 1 target group are not "publiclyVisible"