### PR TITLE
Fixes #3495 Label's edit icons are not in line vertically

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/item-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/item-list.scss
@@ -138,7 +138,7 @@
 .item-list__text-body {
   flex-basis: auto;
   flex-grow: 1;
-  flex-shrink: 1;
+  flex-shrink: 100;
   font-size: $text-mobile-font-size;
   line-height: $item-list-item-min-size;
   margin-left: 5px;


### PR DESCRIPTION
Fixes #3495 Label's edit icons are not in line vertically
Setting flex-shrink to 100 will make the textarea shrink enough so everything will be inline.