### PR TITLE
Fixes #3938 Navbar has wrong link to evaluation

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
@@ -82,7 +82,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       modifier: "evaluation",
       trail: "evaluation",
       text: 'plugin.evaluation.evaluation',
-      href: "/evaluation",
+      href: "/evaluation2",
       icon: "evaluate",
       condition: this.props.status.permissions.EVALUATION_VIEW_INDEX
     }, {


### PR DESCRIPTION
Fixes #3938 Navbar has wrong link to evaluation
Changed link in the item list. Now it points to evaluation2/