### PR TITLE
Fixes #3928 Deleting word definition does not work as intended

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-word-definition/dialogs/definition.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-word-definition/dialogs/definition.js
@@ -9,8 +9,9 @@ CKEDITOR.dialog.add('muikkuWordDefinitionDialog', function (editor) {
       id: 'tab-basic',
       label: lang.definitionDialogTabTitle,
       elements: [{
-        type: 'text',
+        type: 'textarea',
         id: 'text',
+        class: 'max-size',
         label: lang.definitionDialogTextLabel,
         setup: function(editor) {
           var text = null;
@@ -64,14 +65,17 @@ CKEDITOR.dialog.add('muikkuWordDefinitionDialog', function (editor) {
           
           removeStyle.remove(editor);
           
-          var applyStyle = new CKEDITOR.style({ 
-            element: 'mark',
-            attributes: { 
-              'data-muikku-word-definition': this.getValue() 
-            }
-          });
+          var value = this.getValue();
+          if(value != ""){
+          	var applyStyle = new CKEDITOR.style({ 
+           	 element: 'mark',
+            	attributes: { 
+            	  'data-muikku-word-definition': value 
+            	}
+         	 });
           
-          applyStyle.apply(editor);
+          	applyStyle.apply(editor);
+          }
         }
       }]
     }],

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/custom-ckeditor-contentcss.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/custom-ckeditor-contentcss.scss
@@ -280,6 +280,7 @@ mark[data-muikku-word-definition] {
     min-width: 200px;
     padding: 5px 10px;
     position: absolute;
+    white-space: pre-wrap;
   }
   
 }

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles.scss
@@ -41,6 +41,8 @@ p {
   max-width: 250px;
   padding: 5px 10px;
   position: absolute;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   z-index: 20;
 }
     

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles_backup.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_evaluation_material_styles_backup.scss
@@ -49,6 +49,8 @@ p {
   max-width: 250px;
   padding: 5px 10px;
   position: absolute;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
     
 mark[data-muikku-word-definition] {

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/_workspace-materials-defaults.scss
@@ -1013,6 +1013,8 @@
   max-width: 250px;
   padding: 5px 10px;
   position: absolute;
+  white-space: pre-wrap;
+  word-wrap: break-word;
   z-index: 20;
 }
 

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/custom-ckeditor-contentcss_management.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/custom-ckeditor-contentcss_management.scss
@@ -280,6 +280,7 @@ mark[data-muikku-word-definition] {
     min-width: 200px;
     padding: 5px 10px;
     position: absolute;
+    white-space: pre-wrap;
     z-index: 20;
   }
 

--- a/muikku/src/main/webapp/resources/theme-muikku/sass/flex/custom-ckeditor-contentcss_reading.scss
+++ b/muikku/src/main/webapp/resources/theme-muikku/sass/flex/custom-ckeditor-contentcss_reading.scss
@@ -280,6 +280,7 @@ mark[data-muikku-word-definition] {
     min-width: 200px;
     padding: 5px 10px;
     position: absolute;
+    white-space: pre-wrap;
     z-index: 20;
   }
 


### PR DESCRIPTION
Fixes #3928 Deleting word definition does not work as intended
Deleting fixed.
Memo field for creating a definition has been changed.
A dialog box appearing on hover is now capable of breaking lines/words and growing in height.
NOTE:
Endline/breackline character is not saved by the cke plugin (changed to space). Not that important since definition should not occupy several paragraphs but since it is available in the definition editor it will cause inconsistency. 
