### PR TITLE
Fixes and tests to announcements

### DIFF
--- a/muikku-atests-plugin-rest-model/src/main/java/fi/otavanopisto/muikku/atests/Announcement.java
+++ b/muikku-atests-plugin-rest-model/src/main/java/fi/otavanopisto/muikku/atests/Announcement.java
@@ -8,11 +8,13 @@ public class Announcement {
   public Announcement() {
   }
   
-  public Announcement(Long id, Long publisherUserEntityId, List<Long> userGroupIds, String caption, String content, Date created, Date startDate, Date endDate, Boolean archived, Boolean publiclyVisible) {
+  public Announcement(Long id, Long publisherUserEntityId, List<Long> userGroupIds, List<Long> workspaceEntityIds, 
+      String caption, String content, Date created, Date startDate, Date endDate, Boolean archived, Boolean publiclyVisible) {
     super();
     this.id = id;
     this.publisherUserEntityId = publisherUserEntityId;
     this.userGroupEntityIds = userGroupIds;
+    this.workspaceEntityIds = workspaceEntityIds;
     this.caption = caption;
     this.content = content;
     this.created = created;
@@ -102,6 +104,14 @@ public class Announcement {
     this.publiclyVisible = publiclyVisible;
   }
   
+  public List<Long> getWorkspaceEntityIds() {
+    return workspaceEntityIds;
+  }
+
+  public void setWorkspaceEntityIds(List<Long> workspaceEntityIds) {
+    this.workspaceEntityIds = workspaceEntityIds;
+  }
+
   private Long id;
   private Long publisherUserEntityId;
   private String caption;
@@ -111,6 +121,7 @@ public class Announcement {
   private Date endDate;
   private Boolean archived;
   private List<Long> userGroupEntityIds;
+  private List<Long> workspaceEntityIds;
   private Boolean publiclyVisible;
 
 }

--- a/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
+++ b/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 
 import fi.otavanopisto.muikku.controller.TagController;
-import fi.otavanopisto.muikku.dao.workspace.WorkspaceMaterialProducerDAO;
 import fi.otavanopisto.muikku.model.base.Tag;
 import fi.otavanopisto.muikku.model.users.Flag;
 import fi.otavanopisto.muikku.model.users.FlagShare;
@@ -76,7 +75,6 @@ import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.WorkspaceController;
 import fi.otavanopisto.muikku.schooldata.WorkspaceEntityController;
 import fi.otavanopisto.muikku.schooldata.events.SchoolDataWorkspaceDiscoveredEvent;
-import fi.otavanopisto.muikku.security.impl.WorkspaceEntityContextResolverImpl;
 import fi.otavanopisto.muikku.session.local.LocalSession;
 import fi.otavanopisto.muikku.session.local.LocalSessionController;
 import fi.otavanopisto.muikku.users.FlagController;

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/AbstractRESTTest.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/AbstractRESTTest.java
@@ -3,8 +3,11 @@ package fi.otavanopisto.muikku;
 import static com.jayway.restassured.RestAssured.certificate;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,6 +22,7 @@ import com.jayway.restassured.config.RestAssuredConfig;
 import com.jayway.restassured.mapper.factory.Jackson2ObjectMapperFactory;
 
 import fi.otavanopisto.muikku.rest.test.PyramusMocksRest;
+import fi.otavanopisto.muikku.rest.test.RestTestRequest;
 
 public abstract class AbstractRESTTest extends AbstractIntegrationTest {
   
@@ -58,5 +62,20 @@ public abstract class AbstractRESTTest extends AbstractIntegrationTest {
   @After
   public void resetMocks() throws Exception {
     PyramusMocksRest.resetWireMock();
+  }
+  
+  protected Set<RestTestRequest> roles(TestRole ... roles) {
+    Set<RestTestRequest> set = new HashSet<>();
+    
+    if (ArrayUtils.contains(roles, TestRole.ADMIN))
+      set.add(new RestTestRequest(asAdmin(), TestRole.ADMIN));
+    if (ArrayUtils.contains(roles, TestRole.MANAGER))
+      set.add(new RestTestRequest(asManager(), TestRole.MANAGER));
+    if (ArrayUtils.contains(roles, TestRole.TEACHER))
+      set.add(new RestTestRequest(asTeacher(), TestRole.TEACHER));
+    if (ArrayUtils.contains(roles, TestRole.STUDENT))
+      set.add(new RestTestRequest(asStudent(), TestRole.STUDENT));
+    
+    return set;
   }
 }

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/TestRole.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/TestRole.java
@@ -1,0 +1,10 @@
+package fi.otavanopisto.muikku;
+
+public enum TestRole {
+  
+  ADMIN,
+  MANAGER,
+  TEACHER,
+  STUDENT
+  
+}

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/PyramusMocksRest.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/PyramusMocksRest.java
@@ -90,6 +90,11 @@ import fi.otavanopisto.pyramus.webhooks.WebhookStudentGroupStudentCreatePayload;
  */
 public class PyramusMocksRest extends AbstractPyramusMocks {
   
+  public static final Long WORKSPACE1_ID = 1l;
+  public static final Long WORKSPACE2_ID = 2l;
+  
+  public static final Long USERGROUP1_ID = 2l;
+
   public static void mockDefaults(List<String> payloads) throws JsonProcessingException {
     mockCommons();
     mockRoles(payloads);
@@ -455,7 +460,8 @@ public class PyramusMocksRest extends AbstractPyramusMocks {
   }
 
   public static void mockWorkspaces(List<String> payloads) throws JsonProcessingException {
-    mockWorkspace(1l, payloads);
+    mockWorkspace(WORKSPACE1_ID, payloads);
+    mockWorkspace(WORKSPACE2_ID, payloads);
   }
   
   public static void mockWorkspace(Long id, List<String> payloads) throws JsonProcessingException {
@@ -601,7 +607,7 @@ public class PyramusMocksRest extends AbstractPyramusMocks {
 
     OffsetDateTime begin = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     Long creatorId = 1l;
-    Long groupId = 2l;
+    Long groupId = USERGROUP1_ID;
     
     StudentGroup studentGroup = new StudentGroup(groupId, "Group1", "", begin, creatorId, begin, creatorId, begin, null, false, false);
     StudentGroup[] studentGroups = new StudentGroup[] { studentGroup };

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/RestTestRequest.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/RestTestRequest.java
@@ -1,0 +1,32 @@
+package fi.otavanopisto.muikku.rest.test;
+
+import com.jayway.restassured.specification.RequestSpecification;
+
+import fi.otavanopisto.muikku.TestRole;
+
+public class RestTestRequest {
+  
+  public RestTestRequest(RequestSpecification request, TestRole role) {
+    this.request = request;
+    this.role = role;
+  }
+
+  public TestRole getRole() {
+    return role;
+  }
+
+  public void setRole(TestRole role) {
+    this.role = role;
+  }
+
+  public RequestSpecification getRequest() {
+    return request;
+  }
+
+  public void setRequest(RequestSpecification request) {
+    this.request = request;
+  }
+
+  private RequestSpecification request;
+  private TestRole role;
+}

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AbstractAnnouncerRESTTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AbstractAnnouncerRESTTestsIT.java
@@ -1,0 +1,11 @@
+package fi.otavanopisto.muikku.rest.test.plugins.announcer;
+
+import fi.otavanopisto.muikku.AbstractRESTTest;
+
+public class AbstractAnnouncerRESTTestsIT extends AbstractRESTTest {
+
+  protected void permanentDeleteAnnouncements() {
+    asAdmin().delete("/test/announcements");
+  }
+  
+}

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
@@ -141,12 +141,21 @@ public class AnnouncerPermissionsTestsIT extends AbstractAnnouncerRESTTestsIT {
 
   @Test
   public void testNonMemberWorkspaceAnnouncement() throws NoSuchFieldException {
-    // Workspace announcement should be fectchable even though users are not members of it
-    roles(TestRole.ADMIN, TestRole.MANAGER, TestRole.TEACHER, TestRole.STUDENT).forEach(role -> { 
+    // Workspace announcement is fetchable via FIND_ANNOUNCEMENT permission
+    roles(TestRole.ADMIN, TestRole.MANAGER, TestRole.TEACHER).forEach(role -> { 
       Response response = role.getRequest()
         .get("/announcer/announcements/{ID}", workspace2AnnouncementId);
       assertEquals(String.format("Role %s can not see announcement they should", role.getRole()), 200, response.statusCode());
     });
+  }
+
+  @Test
+  public void testNonMemberStudentWorkspaceAnnouncement() throws NoSuchFieldException {
+    // Student that is not member of a workspace cannot see the announcements
+
+    Response response = asStudent()
+      .get("/announcer/announcements/{ID}", workspace2AnnouncementId);
+    assertEquals(String.format("Role %s can not see announcement they should", TestRole.STUDENT), 403, response.statusCode());
   }
 
   @Test

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
@@ -1,0 +1,206 @@
+package fi.otavanopisto.muikku.rest.test.plugins.announcer;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.RequestSpecification;
+
+import fi.otavanopisto.muikku.TestRole;
+import fi.otavanopisto.muikku.atests.Announcement;
+import fi.otavanopisto.muikku.rest.test.PyramusMocksRest;
+
+public class AnnouncerPermissionsTestsIT extends AbstractAnnouncerRESTTestsIT {
+
+  private Long publicAnnouncementId = null;
+  private Long workspace2AnnouncementId = null;
+
+  @Before
+  public void beforePublicAnnouncement() {
+    Announcement publicAnnouncement = new Announcement(
+        null,                           // id, 
+        0l,                             // publisherUserEntityId, 
+        null,                           // userGroupIds, 
+        null,                           // workspaceEntityIds,
+        "Test Announcement",            // caption, 
+        "Lorem Ipsum",                  // content, 
+        new Date(),                     // created, 
+        date(100, 1, 1),                // startDate,
+        date(150, 12, 31),              // endDate, 
+        false,                          // archived, 
+        true                            // publiclyVisible
+    );
+    
+    Response response = asAdmin()
+      .contentType("application/json")
+      .body(publicAnnouncement)
+      .post("/announcer/announcements");
+    
+    publicAnnouncementId = new Long(response.body().jsonPath().getInt("id"));
+  }
+  
+  @Before
+  public void beforeWorkspaceAnnouncement() {
+    List<Long> workspaceEntityIds = new ArrayList<>();
+    workspaceEntityIds.add(PyramusMocksRest.WORKSPACE1_ID);
+    
+    Announcement publicAnnouncement = new Announcement(
+        null,                           // id, 
+        0l,                             // publisherUserEntityId, 
+        null,                           // userGroupIds, 
+        workspaceEntityIds,             // workspaceEntityIds,
+        "Test Announcement",            // caption, 
+        "Lorem Ipsum",                  // content, 
+        new Date(),                     // created, 
+        date(100, 1, 1),                // startDate,
+        date(150, 12, 31),              // endDate, 
+        false,                          // archived, 
+        true                            // publiclyVisible
+    );
+    
+    asAdmin()
+      .contentType("application/json")
+      .body(publicAnnouncement)
+      .post("/announcer/announcements");
+  }
+  
+  @Before
+  public void beforeWorkspaceAnnouncement2() {
+    List<Long> workspaceEntityIds = new ArrayList<>();
+    workspaceEntityIds.add(PyramusMocksRest.WORKSPACE2_ID);
+    
+    Announcement publicAnnouncement = new Announcement(
+        null,                           // id, 
+        0l,                             // publisherUserEntityId, 
+        null,                           // userGroupIds, 
+        workspaceEntityIds,             // workspaceEntityIds,
+        "Test Announcement",            // caption, 
+        "Lorem Ipsum",                  // content, 
+        new Date(),                     // created, 
+        date(100, 1, 1),                // startDate,
+        date(150, 12, 31),              // endDate, 
+        false,                          // archived, 
+        true                            // publiclyVisible
+    );
+    
+    Response response = asAdmin()
+      .contentType("application/json")
+      .body(publicAnnouncement)
+      .post("/announcer/announcements");
+    
+    workspace2AnnouncementId = new Long(response.body().jsonPath().getInt("id"));
+  }
+  
+  @Before
+  public void beforeGroupAnnouncement() {
+    List<Long> groupIds = new ArrayList<>();
+    groupIds.add(PyramusMocksRest.USERGROUP1_ID);
+    
+    Announcement publicAnnouncement = new Announcement(
+        null,                           // id, 
+        0l,                             // publisherUserEntityId, 
+        groupIds,                       // userGroupIds, 
+        null,                           // workspaceEntityIds,
+        "Test Announcement",            // caption, 
+        "Lorem Ipsum",                  // content, 
+        new Date(),                     // created, 
+        date(100, 1, 1),                // startDate,
+        date(150, 12, 31),              // endDate, 
+        false,                          // archived, 
+        false                           // publiclyVisible
+    );
+    
+    asAdmin()
+      .contentType("application/json")
+      .body(publicAnnouncement)
+      .post("/announcer/announcements");
+  }
+  
+  @After
+  public void after() {
+    permanentDeleteAnnouncements();
+  }
+
+  @Test
+  public void testFindPublicAnnouncement() throws NoSuchFieldException {
+    roles(TestRole.ADMIN, TestRole.MANAGER, TestRole.TEACHER, TestRole.STUDENT).forEach(role -> 
+      role.getRequest()
+        .get("/announcer/announcements/{ID}", publicAnnouncementId)
+        .then()
+        .statusCode(200)
+    );
+  }
+
+  @Test
+  public void testNonMemberWorkspaceAnnouncement() throws NoSuchFieldException {
+    // Workspace announcement should be fectchable even though users are not members of it
+    roles(TestRole.ADMIN, TestRole.MANAGER, TestRole.TEACHER, TestRole.STUDENT).forEach(role -> { 
+      Response response = role.getRequest()
+        .get("/announcer/announcements/{ID}", workspace2AnnouncementId);
+      assertEquals(String.format("Role %s can not see announcement they should", role.getRole()), 200, response.statusCode());
+    });
+  }
+
+  @Test
+  public void testListAndFindAdmin() {
+    /**
+     * Manager can see
+     *  - The public announcement
+     *  - The workspace announcement (member)
+     *  - The group announcement (member + special)
+     */
+    testListAndFind(asAdmin(), TestRole.ADMIN, 3);
+  }
+
+  @Test
+  public void testListAndFindManager() {
+    /**
+     * Manager can see
+     *  - The public announcement
+     *  - The group announcement (special permission)
+     */
+    testListAndFind(asManager(), TestRole.MANAGER, 2);
+  }
+  
+  @Test
+  public void testListAndFindTeacher() {
+    /**
+     * Teacher can see
+     *  - The public announcement
+     */
+    testListAndFind(asTeacher(), TestRole.TEACHER, 1);
+  }
+
+  @Test
+  public void testListAndFindStudent() {
+    /**
+     * Student can see
+     *  - The public announcement
+     *  - The workspace announcement (member)
+     *  - The group announcement (member)
+     */
+    testListAndFind(asStudent(), TestRole.STUDENT, 3);
+  }
+  
+  private void testListAndFind(RequestSpecification request, TestRole role, int expectedCount) {
+    Response response = request.get("/announcer/announcements");
+    
+    response.then().statusCode(200).body("id.size()", is(expectedCount));
+      
+    List<Long> ids = response.body().jsonPath().getList("id", Long.class);
+    for (Long announcementId : ids) {
+      Response findResponse = request
+        .get("/announcer/announcements/{ID}", announcementId);
+      assertEquals(String.format("Role %s cannot find listed announcement %d.", role, announcementId), 200, findResponse.statusCode());
+    }
+  }
+    
+}

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/AbstractUITest.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/AbstractUITest.java
@@ -1120,9 +1120,9 @@ public class AbstractUITest extends AbstractIntegrationTest implements SauceOnDe
       .statusCode(204);
   }
   
-  protected Long createAnnouncement(Long publisherUserEntityId, String caption, String content, Date startDate, Date endDate, Boolean archived, Boolean publiclyVisible, List<Long> userGroupIds) throws Exception {
+  protected Long createAnnouncement(Long publisherUserEntityId, String caption, String content, Date startDate, Date endDate, Boolean archived, Boolean publiclyVisible, List<Long> userGroupIds, List<Long> workspaceEntityIds) throws Exception {
     ObjectMapper objectMapper = new ObjectMapper().registerModule(new JSR310Module()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    Announcement payload = new Announcement(null, publisherUserEntityId, userGroupIds, caption, content, new Date(), startDate, endDate, archived, publiclyVisible);                 
+    Announcement payload = new Announcement(null, publisherUserEntityId, userGroupIds, workspaceEntityIds, caption, content, new Date(), startDate, endDate, archived, publiclyVisible);                 
     Response response = asAdmin()
       .contentType("application/json")
       .body(payload)

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/announcer/AnnouncerTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/announcer/AnnouncerTestsBase.java
@@ -106,7 +106,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
       mockBuilder.addStaffMember(admin).addStudent(student).mockLogin(admin).build();
       login();
       try{
-        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, true, null);
+        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, true, null, null);
         logout();
         mockBuilder.mockLogin(student);
         login();
@@ -129,7 +129,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
       mockBuilder.addStaffMember(admin).addStudent(student).mockLogin(admin).build();
       login();
       try{
-        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, true, null);
+        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, true, null, null);
         logout();
         mockBuilder.mockLogin(student);
         login();
@@ -162,7 +162,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
       try{
         List<Long> userGroups = new ArrayList<>();
         userGroups.add(2l);
-        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, false, userGroups);
+        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, false, userGroups, null);
         logout();
         mockBuilder.mockLogin(student);
         login();
@@ -188,7 +188,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
       try{
         List<Long> userGroups = new ArrayList<>();
         userGroups.add(2l);
-        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, false, userGroups);
+        createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(125, 10, 12), false, false, userGroups, null);
         logout();
         mockBuilder.mockLogin(student);
         login();
@@ -214,7 +214,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
     MockCourseStudent mcs = new MockCourseStudent(2l, courseId, student.getId());
     mockBuilder.addCourseStudent(workspace.getId(), mcs).build();
     
-    createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(115, 10, 15), false, true, null);
+    createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(115, 10, 15), false, true, null, null);
     try {
       navigate("/announcer", true);
       waitForPresent("div.mf-content-empty");
@@ -244,8 +244,8 @@ public class AnnouncerTestsBase extends AbstractUITest {
     MockCourseStudent mcs = new MockCourseStudent(2l, courseId, student.getId());
     mockBuilder.addCourseStudent(workspace.getId(), mcs).build();
     
-    createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), new java.util.Date(), false, true, null);
-    createAnnouncement(another.getId(), "Another test title", "Another announcer test announcement", date(115, 10, 12), new java.util.Date(), false, true, null);
+    createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), new java.util.Date(), false, true, null, null);
+    createAnnouncement(another.getId(), "Another test title", "Another announcer test announcement", date(115, 10, 12), new java.util.Date(), false, true, null, null);
     try {
       navigate("/announcer", true);
       waitForPresent(".an-announcement-topic");

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/announcer/CourseAnnouncerTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/announcer/CourseAnnouncerTestsBase.java
@@ -106,7 +106,7 @@ public class CourseAnnouncerTestsBase extends AbstractUITest {
     MockCourseStudent mcs = new MockCourseStudent(2l, courseId, student.getId());
     mockBuilder.addCourseStudent(workspace.getId(), mcs).build();
     
-    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null);
+    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null, null);
     updateAnnouncementWorkspace(announcementId, workspace.getId());
     logout();
     mockBuilder
@@ -138,7 +138,7 @@ public class CourseAnnouncerTestsBase extends AbstractUITest {
     MockCourseStudent mcs = new MockCourseStudent(2l, courseId, student.getId());
     mockBuilder.addCourseStudent(workspace.getId(), mcs).build();
    
-    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null);
+    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null, null);
     updateAnnouncementWorkspace(announcementId, workspace.getId());
     logout();
     mockBuilder
@@ -175,7 +175,7 @@ public class CourseAnnouncerTestsBase extends AbstractUITest {
     MockCourseStudent mcs = new MockCourseStudent(2l, courseId, student.getId());
     mockBuilder.addCourseStudent(workspace.getId(), mcs).build();
    
-    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null);
+    Long announcementId = createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", new Date(115, 10, 12), new Date(125, 10, 12), false, true, null, null);
     updateAnnouncementWorkspace(announcementId, workspace.getId());
     logout();
     mockBuilder


### PR DESCRIPTION
* Fixed createAnnouncement to actually return the created entity
* Changed permission of finding a single announcement so that students can actually view what they can list

Closes #3874 