### PR TITLE
4094 communicator label messages

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
@@ -20,6 +20,7 @@ import org.jsoup.nodes.Entities.EscapeMode;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
 
+import fi.otavanopisto.muikku.controller.TagController;
 import fi.otavanopisto.muikku.model.base.Tag;
 import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.model.users.UserGroupEntity;
@@ -93,6 +94,9 @@ public class CommunicatorController {
   private CommunicatorMessageRecipientWorkspaceGroupDAO communicatorMessageRecipientWorkspaceGroupDAO;
 
   @Inject
+  private TagController tagController;
+  
+  @Inject
   @Any
   private Instance<SearchProvider> searchProviders;
   
@@ -123,6 +127,10 @@ public class CommunicatorController {
 
   public List<CommunicatorMessageRecipient> listReceivedItemsByUserAndRead(UserEntity userEntity, boolean read, boolean trashed) {
     return communicatorMessageRecipientDAO.listByUserAndRead(userEntity, read, trashed);
+  }
+  
+  public List<CommunicatorMessage> listLabelItems(UserEntity userEntity, CommunicatorLabel label, Integer firstResult, Integer maxResults) {
+    return communicatorMessageDAO.listThreadsInLabelFolder(userEntity, label, firstResult, maxResults);
   }
   
   public List<CommunicatorMessage> listTrashItems(UserEntity userEntity, Integer firstResult, Integer maxResults) {
@@ -564,5 +572,15 @@ public class CommunicatorController {
     }
     return true;
   }
-  
+ 
+  public Set<String> tagIdsToStr(Set<Long> tagIds) {
+    Set<String> tagsStr = new HashSet<String>();
+    for (Long tagId : tagIds) {
+      Tag tag = tagController.findTagById(tagId);
+      if (tag != null)
+        tagsStr.add(tag.getText());
+    }
+    return tagsStr;
+  }
+
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
@@ -129,7 +129,7 @@ public class CommunicatorController {
     return communicatorMessageRecipientDAO.listByUserAndRead(userEntity, read, trashed);
   }
   
-  public List<CommunicatorMessage> listLabelItems(UserEntity userEntity, CommunicatorLabel label, Integer firstResult, Integer maxResults) {
+  public List<CommunicatorMessage> listThreadsByLabel(UserEntity userEntity, CommunicatorLabel label, Integer firstResult, Integer maxResults) {
     return communicatorMessageDAO.listThreadsInLabelFolder(userEntity, label, firstResult, maxResults);
   }
   

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorLabelRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorLabelRESTService.java
@@ -242,7 +242,7 @@ public class CommunicatorLabelRESTService extends PluginRESTService {
       return Response.status(Status.NOT_FOUND).build();
     }
       
-    List<CommunicatorMessage> receivedItems = communicatorController.listLabelItems(
+    List<CommunicatorMessage> receivedItems = communicatorController.listThreadsByLabel(
         user, label, firstResult, maxResults);
 
     List<CommunicatorThreadRESTModel> result = new ArrayList<CommunicatorThreadRESTModel>();

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorLabelRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorLabelRESTService.java
@@ -1,17 +1,22 @@
 package fi.otavanopisto.muikku.plugins.communicator.rest;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.ejb.Stateful;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -23,7 +28,9 @@ import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorLabel;
 import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorMessage;
 import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorMessageId;
 import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorMessageIdLabel;
+import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorMessageRecipient;
 import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorUserLabel;
+import fi.otavanopisto.muikku.rest.model.UserBasicInfo;
 import fi.otavanopisto.muikku.servlet.BaseUrl;
 import fi.otavanopisto.muikku.session.SessionController;
 import fi.otavanopisto.security.AuthorizationException;
@@ -222,24 +229,78 @@ public class CommunicatorLabelRESTService extends PluginRESTService {
   }
 
   @GET
+  @Path ("/userLabels/{USERLABELID}/messages")
+  @RESTPermit(handling = Handling.INLINE, requireLoggedIn = true)
+  public Response listUserLabeledMessagesByLabel( 
+      @PathParam ("USERLABELID") Long userLabelId,
+      @QueryParam("firstResult") @DefaultValue ("0") Integer firstResult, 
+      @QueryParam("maxResults") @DefaultValue ("10") Integer maxResults) {
+    UserEntity user = sessionController.getLoggedUserEntity();
+
+    CommunicatorLabel label = communicatorController.findUserLabelById(userLabelId);
+    if (label == null || !canAccessLabel(user, label)) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+      
+    List<CommunicatorMessage> receivedItems = communicatorController.listLabelItems(
+        user, label, firstResult, maxResults);
+
+    List<CommunicatorThreadRESTModel> result = new ArrayList<CommunicatorThreadRESTModel>();
+    
+    for (CommunicatorMessage receivedItem : receivedItems) {
+      String categoryName = receivedItem.getCategory() != null ? receivedItem.getCategory().getName() : null;
+      boolean hasUnreadMsgs = false;
+      Date latestMessageDate = receivedItem.getCreated();
+      
+      List<CommunicatorMessageRecipient> recipients = communicatorController.listCommunicatorMessageRecipientsByUserAndMessage(
+          user, receivedItem.getCommunicatorMessageId(), false);
+      
+      for (CommunicatorMessageRecipient recipient : recipients) {
+        hasUnreadMsgs = hasUnreadMsgs || Boolean.FALSE.equals(recipient.getReadByReceiver()); 
+        Date created = recipient.getCommunicatorMessage().getCreated();
+        latestMessageDate = latestMessageDate == null || latestMessageDate.before(created) ? created : latestMessageDate;
+      }
+      
+      UserBasicInfo senderBasicInfo = restModels.getSenderBasicInfo(receivedItem);
+      Long messageCountInThread = communicatorController.countMessagesByUserAndMessageId(user, receivedItem.getCommunicatorMessageId(), false);
+
+      List<CommunicatorMessageIdLabel> labels = communicatorController.listMessageIdLabelsByUserEntity(user, receivedItem.getCommunicatorMessageId());
+      List<CommunicatorMessageIdLabelRESTModel> restLabels = restModels.restLabel(labels);
+      
+      Set<String> tags = communicatorController.tagIdsToStr(receivedItem.getTags());
+      
+      result.add(new CommunicatorThreadRESTModel(
+          receivedItem.getId(), receivedItem.getCommunicatorMessageId().getId(), receivedItem.getSender(), senderBasicInfo, categoryName, 
+          receivedItem.getCaption(), receivedItem.getCreated(), tags, hasUnreadMsgs, latestMessageDate, 
+          messageCountInThread, restLabels));
+    }
+
+    return Response.ok(
+      result
+    ).build();
+  }
+  
+  @GET
   @Path ("/userLabels/{USERLABELID}/messages/{COMMUNICATORMESSAGEID}")
   @RESTPermit(handling = Handling.INLINE, requireLoggedIn = true)
-  public Response listUserUnreadCommunicatorMessagesByMessageId( 
+  public Response getUserLabeledMessagesByLabelAndThread( 
       @PathParam ("USERLABELID") Long userLabelId,
-      @PathParam ("COMMUNICATORMESSAGEID") Long communicatorMessageId) {
+      @PathParam ("COMMUNICATORMESSAGEID") Long threadId) {
     UserEntity userEntity = sessionController.getLoggedUserEntity();
     CommunicatorUserLabel userLabel = communicatorController.findUserLabelById(userLabelId);
     
     if ((userLabel != null) && canAccessLabel(userEntity, userLabel)) {
-      CommunicatorMessageId threadId = communicatorController.findCommunicatorMessageId(communicatorMessageId);
+      CommunicatorMessageId thread = communicatorController.findCommunicatorMessageId(threadId);
       
-      List<CommunicatorMessage> receivedItems = communicatorController.listMessagesByMessageId(userEntity, threadId, false);
+      List<CommunicatorMessage> receivedItems = communicatorController.listMessagesByMessageId(userEntity, thread, false);
   
-      List<CommunicatorMessageIdLabel> labels = communicatorController.listMessageIdLabelsByUserEntity(userEntity, threadId);
+      List<CommunicatorMessageIdLabel> labels = communicatorController.listMessageIdLabelsByUserEntity(userEntity, thread);
       List<CommunicatorMessageIdLabelRESTModel> restLabels = restModels.restLabel(labels);
 
-      CommunicatorMessageId olderThread = communicatorController.findOlderThreadId(userEntity, threadId, CommunicatorFolderType.LABEL, userLabel);
-      CommunicatorMessageId newerThread = communicatorController.findNewerThreadId(userEntity, threadId, CommunicatorFolderType.LABEL, userLabel);
+      CommunicatorMessageId olderThread = communicatorController.findOlderThreadId(
+          userEntity, thread, CommunicatorFolderType.LABEL, userLabel);
+      CommunicatorMessageId newerThread = communicatorController.findNewerThreadId(
+          userEntity, thread, CommunicatorFolderType.LABEL, userLabel);
       
       return Response.ok(
         restModels.restThreadViewModel(receivedItems, olderThread, newerThread, restLabels)

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
@@ -162,7 +162,7 @@ public class CommunicatorRESTService extends PluginRESTService {
       
       result.add(new CommunicatorThreadRESTModel(
           receivedItem.getId(), receivedItem.getCommunicatorMessageId().getId(), receivedItem.getSender(), senderBasicInfo, categoryName, 
-          receivedItem.getCaption(), receivedItem.getCreated(), tags , hasUnreadMsgs, latestMessageDate, 
+          receivedItem.getCaption(), receivedItem.getCreated(), tags, hasUnreadMsgs, latestMessageDate, 
           messageCountInThread, restLabels));
     }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
@@ -158,9 +158,11 @@ public class CommunicatorRESTService extends PluginRESTService {
       List<CommunicatorMessageIdLabel> labels = communicatorController.listMessageIdLabelsByUserEntity(user, receivedItem.getCommunicatorMessageId());
       List<CommunicatorMessageIdLabelRESTModel> restLabels = restModels.restLabel(labels);
       
+      Set<String> tags = communicatorController.tagIdsToStr(receivedItem.getTags());
+      
       result.add(new CommunicatorThreadRESTModel(
           receivedItem.getId(), receivedItem.getCommunicatorMessageId().getId(), receivedItem.getSender(), senderBasicInfo, categoryName, 
-          receivedItem.getCaption(), receivedItem.getCreated(), tagIdsToStr(receivedItem.getTags()), hasUnreadMsgs, latestMessageDate, 
+          receivedItem.getCaption(), receivedItem.getCreated(), tags , hasUnreadMsgs, latestMessageDate, 
           messageCountInThread, restLabels));
     }
 
@@ -225,9 +227,11 @@ public class CommunicatorRESTService extends PluginRESTService {
 
       Long recipientCount = (long) messageRecipients.size() + userGroupRecipients.size() + workspaceGroupRecipients.size();
       
+      Set<String> tags = communicatorController.tagIdsToStr(sentItem.getTags());
+
       result.add(new CommunicatorSentThreadRESTModel(
           sentItem.getId(), sentItem.getCommunicatorMessageId().getId(), sentItem.getSender(), senderBasicInfo, categoryName, 
-          sentItem.getCaption(), sentItem.getCreated(), tagIdsToStr(sentItem.getTags()), hasUnreadMsgs, latestMessageDate, 
+          sentItem.getCaption(), sentItem.getCreated(), tags, hasUnreadMsgs, latestMessageDate, 
           messageCountInThread, restLabels, restRecipients, restUserGroupRecipients, restWorkspaceRecipients, recipientCount));
     }
     
@@ -493,16 +497,6 @@ public class CommunicatorRESTService extends PluginRESTService {
     }
     
     return Response.noContent().build();
-  }
-
-  private Set<String> tagIdsToStr(Set<Long> tagIds) {
-    Set<String> tagsStr = new HashSet<String>();
-    for (Long tagId : tagIds) {
-      Tag tag = tagController.findTagById(tagId);
-      if (tag != null)
-        tagsStr.add(tag.getText());
-    }
-    return tagsStr;
   }
 
   private Set<Tag> parseTags(Set<String> tags) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/gui/communicator.js
@@ -196,13 +196,12 @@
     
     loadItems: function (firstResult, maxResults, mainCallback) {
       var params = {
-        labelId: this._labelId,
         firstResult: firstResult,
         maxResults: maxResults
       };
       
-      mApi().communicator.items
-        .read(params)
+      mApi().communicator.userLabels.messages
+        .read(this._labelId, params)
         .callback(mainCallback);
     },
     loadThread: function (threadId, firstResult, maxResults, callback) {


### PR DESCRIPTION
Added new endpoint for threads under labels in Communicator to also show sent&labeled items there. The endpoint itself is mainly the same as inbox endpoint and DAO is almost the same as the trash DAO.

Closes #4094 