### PR TITLE
Scss buidling without ruby

### DIFF
--- a/muikku/pom.xml
+++ b/muikku/pom.xml
@@ -409,7 +409,7 @@
             <inherited>false</inherited>
             <configuration>
               <sassSourceDirectory>${basedir}/src/main/webapp/resources/theme-muikku/sass</sassSourceDirectory>
-              <destination>${project.build.directory}/${project.build.finalName}/resources/theme-muikku/css</destination>
+              <destination>${project.build.directory}/scss-compiled/theme-muikku/css</destination>
             </configuration>
           </execution>
         </executions>
@@ -426,6 +426,12 @@
             </manifestEntries>
           </archive>
           <classifier>${classifier}</classifier>
+          <webResources>
+            <resource>
+              <directory>target/scss-compiled</directory>
+              <targetPath>resources</targetPath>
+            </resource>
+          </webResources>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Scss files are compiled under target/scss-compiled and from there copied to war with the war plugin in pom.xml.

target/scss-compiled can be used in eclipse by adding it to deployment assembly deploying to 'resources' path