### PR TITLE
Changed how the mandatory courses are calculated

### DIFF
--- a/matriculation-plugin/.gitignore
+++ b/matriculation-plugin/.gitignore
@@ -4,3 +4,4 @@
 /.settings/
 /.project
 /.classpath
+/.externalToolBuilders/

--- a/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
+++ b/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
@@ -550,6 +550,9 @@ class App extends React.Component {
             + date.getFullYear(),
       lastSave: date.getTime()
     };
+    
+    this.isConflictingMandatory = this.isConflictingMandatory.bind(this);
+    this.isConflictingRepeat = this.isConflictingRepeat.bind(this);
   }
 
   componentDidMount() {
@@ -1042,9 +1045,9 @@ class App extends React.Component {
                   amountOfMandatoryAttendances={ this.getAmountOfMandatoryAttendances() }
                   amountOfAcademicSubjectAttendances={ this.getAmountOfAcademicSubjectAttendances() }
                   amountOfMandatoryAdvancedSubjectAttendances = { this.getAmountOfMandatoryAdvancedSubjectAttendances() }
-                  isConflictingMandatory={this.isConflictingMandatory.bind(this)}
+                  isConflictingMandatory={this.isConflictingMandatory}
                   conflictingAttendances={this.isConflictingAttendances()}
-                  isConflictingRepeat={this.isConflictingRepeat.bind(this)}
+                  isConflictingRepeat={this.isConflictingRepeat}
                   conflictingRepeats={this.hasConflictingRepeats()}
                   incompleteAttendances={this.isIncompleteAttendances()}
                   mandatoryConflicts={this.hasMandatoryConflicts()}

--- a/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
+++ b/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
@@ -916,6 +916,8 @@ class App extends React.Component {
   
   isInvalid() {
     return this.isConflictingAttendances()
+      || this.hasConflictingRepeats()
+      || this.hasMandatoryConflicts()
       || this.isIncompleteAttendances()
       || !this.isValidAttendances();
   }
@@ -1040,9 +1042,9 @@ class App extends React.Component {
                   amountOfMandatoryAttendances={ this.getAmountOfMandatoryAttendances() }
                   amountOfAcademicSubjectAttendances={ this.getAmountOfAcademicSubjectAttendances() }
                   amountOfMandatoryAdvancedSubjectAttendances = { this.getAmountOfMandatoryAdvancedSubjectAttendances() }
-                  isConflictingMandatory={(attendance) => { return this.isConflictingMandatory(attendance);}}
+                  isConflictingMandatory={this.isConflictingMandatory.bind(this)}
                   conflictingAttendances={this.isConflictingAttendances()}
-                  isConflictingRepeat={(attendance) => { return this.isConflictingRepeat(attendance);}}
+                  isConflictingRepeat={this.isConflictingRepeat.bind(this)}
                   conflictingRepeats={this.hasConflictingRepeats()}
                   incompleteAttendances={this.isIncompleteAttendances()}
                   mandatoryConflicts={this.hasMandatoryConflicts()}

--- a/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
+++ b/matriculation-plugin/src/main/resources/META-INF/resources/scripts/gui/matriculation/matriculation.jsx
@@ -265,7 +265,7 @@ const Page2 = (props) => (
       {props.enrolledAttendances.map((attendance, i) =>
       <React.Fragment key={i}>
         <div className="pure-u-1-4"
-          style={(attendance.subject === "" || attendance.mandatory === "" || attendance.repeat === "") ? {"background": "pink"} : {}}>
+          style={(attendance.subject === "") ? {"background": "pink"} : {}}>
           <SubjectSelect
             i={i}
             value={attendance.subject}
@@ -274,7 +274,7 @@ const Page2 = (props) => (
             />
         </div>
         <div className="pure-u-1-4"
-          style={(attendance.subject === "" || attendance.mandatory === "" || attendance.repeat === "") ? {"background": "pink"} : {}}>
+          style={(attendance.mandatory === "" || props.isConflictingMandatory(attendance)) ? {"background": "pink"} : {}}>
           <MandatorySelect
             i={i}
             value={attendance.mandatory}
@@ -282,15 +282,14 @@ const Page2 = (props) => (
           />
         </div>
         <div className="pure-u-1-4"
-          style={(attendance.subject === "" || attendance.mandatory === "" || attendance.repeat === "") ? {"background": "pink"} : {}}>
+          style={(attendance.repeat === "" || props.isConflictingRepeat(attendance)) ? {"background": "pink"} : {}}>
           <RepeatSelect
             i={i}
             value={attendance.repeat}
             onChange={({target}) => {props.modifyEnrolledAttendance(i, "repeat", target.value);}}
           />
         </div>
-        <div className="pure-u-1-4"
-          style={(attendance.subject === "" || attendance.mandatory === "" || attendance.repeat === "") ? {"background": "pink"} : {}}>
+        <div className="pure-u-1-4">
           <button style={{marginTop: i==0 ? "1.7rem" : "0.3rem"}}  class="pure-button" onClick={() => {props.deleteEnrolledAttendance(i);}}>
             Poista
           </button>
@@ -328,7 +327,8 @@ const Page2 = (props) => (
             onChange={({target}) => {props.modifyFinishedAttendance(i, "subject", target.value);}}
           />
         </div>
-        <div className="pure-u-1-5">
+        <div className="pure-u-1-5"
+            style={ ( props.enrolledAttendances.filter((era) => { return (era.subject === attendance.subject) && (era.mandatory != attendance.mandatory) }).length > 0 ) ? {"background": "pink"} : {}}>
           <MandatorySelect 
             i={i} 
             value={attendance.mandatory} 
@@ -398,7 +398,21 @@ const Page2 = (props) => (
       <div style={ WARNING_STYLE } className="pure-u-22-24">
       Ole hyvä ja täytä kaikki rivit
       </div>: null}
+        
+    {
+      props.mandatoryConflicts ?
+      <div style={ WARNING_STYLE } className="pure-u-22-24">
+        Ainetta uusittaessa pakollisuustiedon on oltava sama kuin aiemmalla suorituskerralla
+      </div>: null
+    }
 
+    {
+      props.conflictingRepeats ?
+      <div style={ WARNING_STYLE } className="pure-u-22-24">
+        Aine on merkittävä uusittavaksi, kun siitä on aiempi suorituskerta
+      </div>: null
+    }
+    
     {
       props.amountOfFinnishAttendances == REQUIRED_FINNISH_ATTENDANCES && props.amountOfMandatoryAttendances == REQUIRED_MANDATORY_ATTENDANCES && props.amountOfAcademicSubjectAttendances < REQUIRED_ACADEMIC_SUBJECT_ATTENDANCE_LESS_THAN && props.amountOfMandatoryAdvancedSubjectAttendances > REQUIRED_MANDATORY_SUBJECT_ATTENDANCE_MORE_THAN
         ? null
@@ -695,6 +709,28 @@ class App extends React.Component {
   }
 
   /**
+   * Returns an array of attendances which includes enrolledAttendances, plannedAttendances
+   * and such finishedAttendances that have subjects not yet included from the previous
+   * two lists.
+   * 
+   * I.e. the array is missing the duplicates (repeated exams) which come from finished list.
+   */
+  getNonDuplicateAttendances() {
+    const attendances = [].concat(this.state.enrolledAttendances,this.state.plannedAttendances);
+    const attendedSubjects = attendances.map((attendance) => {
+      return attendance.subject;
+    });
+    
+    this.state.finishedAttendances.forEach((finishedAttendance) => {
+      if (attendedSubjects.indexOf(finishedAttendance.subject) === -1) {
+        attendances.push(finishedAttendance);
+      }
+    });
+    
+    return attendances;
+  }
+  
+  /**
    * Returns count of attendances in finnish courses.
    * 
    * Attendances with grade IMPROBATUR are ignored while counting attendances
@@ -702,11 +738,7 @@ class App extends React.Component {
    * @returns count of attendances in finnish courses
    */
   getAmountOfFinnishAttendances() {
-    return this.getAttendances().filter((attendance) => {
-      if (attendance.grade == "IMPROBATUR") {
-        return false;
-      }
-
+    return this.getNonDuplicateAttendances().filter((attendance) => {
       return FINNISH_SUBJECTS.indexOf(attendance.subject) !== -1;
     }).length;
   }
@@ -719,11 +751,7 @@ class App extends React.Component {
    * @returns count of attendances in mandatory courses
    */
   getAmountOfMandatoryAttendances() {
-    return this.getAttendances().filter((attendance) => {
-      if (attendance.grade == "IMPROBATUR") {
-        return false;
-      }
-
+    return this.getNonDuplicateAttendances().filter((attendance) => {
       return attendance.mandatory === "true";
     }).length;
   }
@@ -736,11 +764,7 @@ class App extends React.Component {
    * @returns count of attendances in academic subjects
    */
   getAmountOfAcademicSubjectAttendances() {
-    return this.getAttendances().filter((attendance) => {
-      if (attendance.grade == "IMPROBATUR") {
-        return false;
-      }
-
+    return this.getNonDuplicateAttendances().filter((attendance) => {
       return attendance.mandatory === "true" && ACADEMIC_SUBJECTS.indexOf(attendance.subject) !== -1;
     }).length;
   }
@@ -753,11 +777,7 @@ class App extends React.Component {
    * @returns whether user has valid amount of attendances in mandatory advanced subjects
    */
   getAmountOfMandatoryAdvancedSubjectAttendances() {
-    return this.getAttendances().filter((attendance) => {
-      if (attendance.grade == "IMPROBATUR") {
-        return false;
-      }
-
+    return this.getNonDuplicateAttendances().filter((attendance) => {
       return attendance.mandatory === "true" && ADVANCED_SUBJECTS.indexOf(attendance.subject) !== -1;
     }).length;
   }
@@ -835,6 +855,50 @@ class App extends React.Component {
         return true;
       }
     }
+  }
+
+  /**
+   * Returns true if enrolled attendance is not a repeat but there is a 
+   * previous exam with the same subject.
+   */
+  isConflictingRepeat(attendance) {
+    if (attendance.repeat === "false") {
+      return this.getFinishedSubjects().indexOf(attendance.subject) != -1;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if there are any conflicting repeats; see isConflictingRepeat.
+   */
+  hasConflictingRepeats() {
+    const finishedSubjects = this.getFinishedSubjects();
+    
+    return this.state.enrolledAttendances.filter((attendance) => { 
+      return attendance.repeat === "false" && finishedSubjects.indexOf(attendance.subject) != -1;
+    }).length > 0;
+  }
+  
+  /**
+   * Returns true if there is a finished attendance with the same subject but different mandatory.
+   */
+  isConflictingMandatory(attendance) {
+    return this.state.finishedAttendances.filter((fin) => { 
+      return (fin.subject === attendance.subject) && (fin.mandatory != attendance.mandatory) 
+    }).length > 0;
+  }
+    
+  /**
+   * Returns true if there are any conflicting mandatories; see isConflictingMandatory.
+   */
+  hasMandatoryConflicts() {
+    const attendances = [].concat(this.state.enrolledAttendances, this.state.plannedAttendances);
+    return attendances.filter((attendance) => { 
+      return this.state.finishedAttendances.filter((fin) => { 
+        return (fin.subject === attendance.subject) && (fin.mandatory != attendance.mandatory) 
+      }).length > 0;
+    }).length > 0;
   }
 
   currentTerm() {
@@ -976,8 +1040,12 @@ class App extends React.Component {
                   amountOfMandatoryAttendances={ this.getAmountOfMandatoryAttendances() }
                   amountOfAcademicSubjectAttendances={ this.getAmountOfAcademicSubjectAttendances() }
                   amountOfMandatoryAdvancedSubjectAttendances = { this.getAmountOfMandatoryAdvancedSubjectAttendances() }
+                  isConflictingMandatory={(attendance) => { return this.isConflictingMandatory(attendance);}}
                   conflictingAttendances={this.isConflictingAttendances()}
+                  isConflictingRepeat={(attendance) => { return this.isConflictingRepeat(attendance);}}
+                  conflictingRepeats={this.hasConflictingRepeats()}
                   incompleteAttendances={this.isIncompleteAttendances()}
+                  mandatoryConflicts={this.hasMandatoryConflicts()}
                   invalid={this.isInvalid()}
                   pastTermOptions={this.getPastTermOptions()}
                   nextTermOptions={this.getNextTermOptions()}


### PR DESCRIPTION
* Changed highlighting from whole row to just cells in enrolled list
* Added highlighting of conflicting mandatory cells (when exam is in finished list and is being repeat)
* Added highlighting of repeat cell when the same subject is in finished list (ie implied repeat)
* Added warning messages of the above two
* Changed how most of the counts are taken - previously Improbatur grades were the only ones excluded, but now duplicates of a subject are removed if they come from the finished list, allowing repeat mechanism to work despite the given grade (needs to work this way)

Closes #4571 