### PR TITLE
Show assignment evaluation even if answer is withdrawn

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/Evaluation2RESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/Evaluation2RESTService.java
@@ -47,6 +47,8 @@ import fi.otavanopisto.muikku.plugins.evaluation.model.WorkspaceMaterialEvaluati
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestAssessment;
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestAssessmentRequest;
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestAssignment;
+import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestAssignmentEvaluation;
+import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestAssignmentEvaluationType;
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestEvaluationEvent;
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestEvaluationEventType;
 import fi.otavanopisto.muikku.plugins.evaluation.rest.model.RestSupplementationRequest;
@@ -588,6 +590,73 @@ public class Evaluation2RESTService {
         supplementationRequest.getRequestText());
 
     return Response.ok(restSupplementationRequest).build();
+  }
+  
+  @GET
+  @Path("/workspace/{WORKSPACEENTITYID}/user/{USERENTITYID}/workspacematerial/{WORKSPACEMATERIALID}/evaluationinfo")
+  @RESTPermit(handling = Handling.INLINE)
+  public Response findWorkspaceMaterialEvaluationInfo(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, @PathParam("USERENTITYID") Long userEntityId, @PathParam("WORKSPACEMATERIALID") Long workspaceMaterialId) {
+    
+    // Access check
+    
+    if (!sessionController.isLoggedIn()) {
+      return Response.status(Status.UNAUTHORIZED).build();
+    }
+    if (!sessionController.hasEnvironmentPermission(MuikkuPermissions.ACCESS_EVALUATION)) {
+      // Allow students to access their own supplementation requests
+      if (!sessionController.getLoggedUserEntity().getId().equals(userEntityId)) {
+        return Response.status(Status.FORBIDDEN).build();
+      }
+    }
+
+    // User entity
+    
+    UserEntity userEntity = userEntityController.findUserEntityById(userEntityId);
+    if (userEntity == null) {
+      return Response.status(Status.BAD_REQUEST).build();
+    }
+    
+    // Workspace material
+
+    WorkspaceMaterial workspaceMaterial = workspaceMaterialController.findWorkspaceMaterialById(workspaceMaterialId);
+    if (workspaceMaterial == null) {
+      return Response.status(Status.NOT_FOUND).entity("workspaceMaterial not found").build();
+    }
+    
+    SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceMaterialAndArchived(userEntityId, workspaceMaterialId, Boolean.FALSE); 
+    WorkspaceMaterialEvaluation workspaceMaterialEvaluation = evaluationController.findLatestWorkspaceMaterialEvaluationByWorkspaceMaterialAndStudent(workspaceMaterial, userEntity);
+    if (supplementationRequest == null && workspaceMaterialEvaluation == null) {
+      // No evaluation, no supplementation request 
+      return Response.status(Status.NO_CONTENT).build();
+    }
+    else if (supplementationRequest != null && (workspaceMaterialEvaluation == null || workspaceMaterialEvaluation.getEvaluated().before(supplementationRequest.getRequestDate()))) {
+      // No evaluation or supplementation request is newer
+      RestAssignmentEvaluation evaluation = new RestAssignmentEvaluation();
+      evaluation.setType(RestAssignmentEvaluationType.INCOMPLETE);
+      evaluation.setDate(supplementationRequest.getRequestDate());
+      evaluation.setText(supplementationRequest.getRequestText());
+      return Response.ok(evaluation).build();
+    }
+    else {
+      // No supplementation request or evaluation is newer
+      RestAssignmentEvaluation evaluation = new RestAssignmentEvaluation();
+      evaluation.setType(RestAssignmentEvaluationType.PASSED);
+      evaluation.setDate(workspaceMaterialEvaluation.getEvaluated());
+      evaluation.setText(workspaceMaterialEvaluation.getVerbalAssessment());
+      GradingScale gradingScale = gradingController.findGradingScale(
+          workspaceMaterialEvaluation.getGradingScaleSchoolDataSource(), workspaceMaterialEvaluation.getGradingScaleIdentifier());
+      if (gradingScale != null) {
+        GradingScaleItem gradingScaleItem = gradingController.findGradingScaleItem(
+            gradingScale, workspaceMaterialEvaluation.getGradeSchoolDataSource(), workspaceMaterialEvaluation.getGradeIdentifier());
+        if (gradingScaleItem != null) {
+          evaluation.setGrade(gradingScaleItem.getName());
+          if (Boolean.FALSE.equals(gradingScaleItem.isPassingGrade())) {
+            evaluation.setType(RestAssignmentEvaluationType.FAILED);
+          }
+        }
+      }
+      return Response.ok(evaluation).build();
+    }
   }
 
   @PUT

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationController.java
@@ -193,6 +193,7 @@ public class EvaluationController {
     if (supplementationRequest.getStudentEntityId() != null && supplementationRequest.getWorkspaceEntityId() != null) {
       markWorkspaceAssessmentRequestsAsHandled(supplementationRequest.getStudentEntityId(), supplementationRequest.getWorkspaceEntityId());
     }
+    handleSupplementationNotifications(supplementationRequest);
     return supplementationRequest;
   }
   

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/rest/model/RestAssignmentEvaluation.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/rest/model/RestAssignmentEvaluation.java
@@ -1,0 +1,44 @@
+package fi.otavanopisto.muikku.plugins.evaluation.rest.model;
+
+import java.util.Date;
+
+public class RestAssignmentEvaluation {
+
+  public RestAssignmentEvaluationType getType() {
+    return type;
+  }
+
+  public void setType(RestAssignmentEvaluationType type) {
+    this.type = type;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public Date getDate() {
+    return date;
+  }
+
+  public void setDate(Date date) {
+    this.date = date;
+  }
+
+  public String getGrade() {
+    return grade;
+  }
+
+  public void setGrade(String grade) {
+    this.grade = grade;
+  }
+
+  private RestAssignmentEvaluationType type;
+  private String text;
+  private Date date;
+  private String grade;
+
+}

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/rest/model/RestAssignmentEvaluationType.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/rest/model/RestAssignmentEvaluationType.java
@@ -1,0 +1,7 @@
+package fi.otavanopisto.muikku.plugins.evaluation.rest.model;
+
+public enum RestAssignmentEvaluationType {
+  PASSED,
+  FAILED,
+  INCOMPLETE
+}


### PR DESCRIPTION
The button to show/hide assignment evaluation (or supplementation request) is now visible even after the student has withdrawn their previous answer. This enables students to work on their answer while still seeing what the evaluating teacher said about the assignment. Submitting a new answer hides the information as it is likely to no longer be applicable. Resolves #4589.