### PR TITLE
Fixed navigation case not resolved errors

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-management.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-management.xhtml
@@ -39,9 +39,9 @@
     <div id="workspaceMaterialsManagementTOCWrapper">
       <nav class="workspace-waterials-management-nav" id="workspaceMaterialsManagementNav">
         <div class="widget wi-workspace-materials-full-screen-navi-button-toc">
-          <h:link styleClass="icon-navicon w-tooltip" title="Sisällysluettelo" outcome="#">
+          <span class="icon-navicon w-tooltip" title="Sisällysluettelo">
             <span class="workspace-materials-full-screen-tt-container-toc">Sisällysluettelo</span>
-          </h:link>
+          </span>
         </div>
         <div class="widget wi-workspace-materials-full-screen-navi-button-goback">
           <h:link styleClass="icon-goback w-tooltip" title="Palaa takaisin" outcome="/jsf/workspace/materials.jsf?workspaceUrlName=#{workspaceBackingBean.workspaceUrlName}">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/jsf/workspace/materials-reading.xhtml
@@ -33,9 +33,9 @@
     <div id="workspaceMaterialsReadingTOCWrapper">
       <nav class="workspace-waterials-reading-nav" id="workspaceMaterialsReadingNav">
         <div class="widget wi-workspace-materials-full-screen-navi-button-toc">
-          <h:link styleClass="icon-navicon w-tooltip" title="Sisällysluettelo" outcome="#">
+          <span class="icon-navicon w-tooltip" title="Sisällysluettelo">
             <span class="workspace-materials-full-screen-tt-container-toc">Sisällysluettelo</span>
-          </h:link>
+          </span>
         </div>
         <div class="widget wi-workspace-materials-full-screen-navi-button-goback">
           <h:link styleClass="icon-goback w-tooltip" title="Palaa takaisin" outcome="/jsf/workspace/materials.jsf?workspaceUrlName=#{workspaceBackingBean.workspaceUrlName}">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
@@ -139,7 +139,6 @@ export default class Link extends React.Component<LinkProps, LinkState> {
   }
   render(){
     if (this.state.redirect){
-      console.log("REDIRECT");
       return <Redirect push to={this.props.to}/>
     }
     

--- a/muikku/src/main/webapp/WEB-INF/templates/deprecated/flex-main-workspace.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/deprecated/flex-main-workspace.xhtml
@@ -345,7 +345,7 @@
                 <ui:fragment rendered="#{sessionBackingBean.hasWorkspacePermission('MANAGE_WORKSPACE,MANAGE_WORKSPACE_MATERIALS,MANAGE_WORKSPACE_FRONTPAGE,MANAGE_WORKSPACE_HELP,WORKSPACE_ANNOUNCER_TOOL')}">          
                   <!-- EDIT WORKSPACE -->
                   <div class="workspace-management-item">
-                    <a class="icon-settings" title="#{i18n.text['plugin.workspace.dock.workspace-edit']}" jsf:outcome="/jsf/workspace/workspace-edit.jsf?workspaceUrlName=#{workspaceBackingBean.workspaceUrlName}">
+                    <a class="icon-settings" title="#{i18n.text['plugin.workspace.dock.workspace-edit']}" jsf:outcome="/jsf/workspace/workspace-management.jsf?workspaceUrlName=#{workspaceBackingBean.workspaceUrlName}">
                       <span class="workspace-management-item-label">#{i18n.text['plugin.workspace.dock.workspace-edit']}</span>
                     </a>
                   </div>  


### PR DESCRIPTION
* Fixed link in workspace management menu that pointed to a non-existing url
* Fixed two h:links that had outcome="#" which is invalid way to use h:link (outcome should be some jsf resolvable target, which # isn't)
* Removed unnecessary console.log

Closes #4618 