### PR TITLE
Removed unused caption from matriculation enrollment email

### DIFF
--- a/matriculation-plugin/src/main/resources/jade/enrollment-notification.jade
+++ b/matriculation-plugin/src/main/resources/jade/enrollment-notification.jade
@@ -137,7 +137,6 @@ mixin signatureSection()
 +basicBlock("Osoite", enrollment.address)
 +basicBlock("Postinumero", enrollment.postalCode)
 +basicBlock("Postitoimipaikka", enrollment.city)
-+basicBlock("Jos tietosi ovat muuttuneet&#44; ilmoita siitä tässä", enrollment.changedContactInfo)
 
 +header("Opiskelijatiedot")
 +basicBlock("Ohjaaja", enrollment.guider)


### PR DESCRIPTION
Enrollment doesn't have property changedContactInfo so the block is not needed

Closes #4690 