### PR TITLE
Skip attempting chat room membership removal when chat is not enabled

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/chat/SyncStudentEventHandler.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/chat/SyncStudentEventHandler.java
@@ -59,8 +59,11 @@ public class SyncStudentEventHandler {
     
     WorkspaceEntity workspace = workspaceEntityController.findWorkspaceByDataSourceAndIdentifier(workspaceDataSource, workspaceIdentifier);
     
-    chatSyncController.removeChatRoomMembership(user, workspace);
+    WorkspaceChatSettings workspaceChatStatus = chatController.findWorkspaceChatSettings(workspace.getId());
     
+    if (workspaceChatStatus != null && workspaceChatStatus.getStatus() == WorkspaceChatStatus.ENABLED) {
+      chatSyncController.removeChatRoomMembership(user, workspace);
+    }
   }
   
   public synchronized void onWorkspaceChatSettingsEnabledEvent (@Observes WorkspaceChatSettingsEnabledEvent event) {


### PR DESCRIPTION
Added the same check for chat room membership removal as there is for addition.