### PR TITLE
4973 - Memo field's default height 

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
@@ -159,17 +159,18 @@ export default class MemoField extends React.Component<MemoFieldProps, MemoField
 
     //now we need the field
     let field;
+    let minRows = (this.props.content.rows != "" || this.props.content.rows != null || this.props.content.rows != undefined) ? parseInt(this.props.content.rows) : 3;
     //if readonly
     if  (this.props.readOnly){
       //depending to whether rich edit or not we make it be with the value as inner html or just raw text
       field = !this.props.content.richedit ? <TextareaAutosize readOnly className="material-page__memofield" cols={parseInt(this.props.content.columns)}
-          minRows={parseInt(this.props.content.rows)} value={this.state.value} onChange={this.onInputChange}/> :
+        minRows={minRows} value={this.state.value} onChange={this.onInputChange}/> :
             <span className="material-page__ckeditor-replacement material-page__ckeditor-replacement--readonly" dangerouslySetInnerHTML={{__html: this.state.value}}/>
     } else {
       //here we make it be a simple textarea or a rich text editor
       //note how somehow numbers come as string...
       field = !this.props.content.richedit ? <TextareaAutosize className="material-page__memofield" cols={parseInt(this.props.content.columns)}
-          minRows={parseInt(this.props.content.rows)} value={this.state.value} onChange={this.onInputChange}/> :
+        minRows={minRows} value={this.state.value} onChange={this.onInputChange}/> :
             <CKEditor configuration={ckEditorConfig}
              onChange={this.onCKEditorChange}>{this.state.value}</CKEditor>
     }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
@@ -6,6 +6,7 @@ import equals = require("deep-equal");
 import Synchronizer from "./base/synchronizer";
 import { escapeHTML } from "~/util/modifiers";
 import TextareaAutosize from 'react-textarea-autosize';
+import { isNumber } from "util";
 
 interface MemoFieldProps {
   type: string,
@@ -159,7 +160,7 @@ export default class MemoField extends React.Component<MemoFieldProps, MemoField
 
     //now we need the field
     let field;
-    let minRows: number = this.props.content.rows && this.props.content.rows.trim() !== "" ? parseInt(this.props.content.rows) : 3;
+    let minRows = this.props.content.rows && this.props.content.rows !== "" && !isNaN(Number(this.props.content.rows)) ? Number(this.props.content.rows) : 3;
     //if readonly
     if  (this.props.readOnly){
       //depending to whether rich edit or not we make it be with the value as inner html or just raw text

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/memo-field.tsx
@@ -159,7 +159,7 @@ export default class MemoField extends React.Component<MemoFieldProps, MemoField
 
     //now we need the field
     let field;
-    let minRows = (this.props.content.rows != "" || this.props.content.rows != null || this.props.content.rows != undefined) ? parseInt(this.props.content.rows) : 3;
+    let minRows: number = this.props.content.rows && this.props.content.rows.trim() !== "" ? parseInt(this.props.content.rows) : 3;
     //if readonly
     if  (this.props.readOnly){
       //depending to whether rich edit or not we make it be with the value as inner html or just raw text


### PR DESCRIPTION
If memo field's row value is left empty then we set it to 3 by default to prevent 0 height field.

Closes #4973 