### PR TITLE
5025 - Fixed selection task field's rendering.

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/select-field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/select-field.tsx
@@ -205,7 +205,7 @@ export default class SelectField extends React.Component<SelectFieldProps, Selec
           value={this.state.value} onChange={this.onSelectChange} disabled={this.props.readOnly}>
           {this.props.content.listType === "dropdown" ? <option value=""/> : null}
           {this.props.content.options.map(o=>{
-            return <option className="material-page__selectfield-item-container" key={o.name} value={o.name}><StrMathJAX>{o.text}</StrMathJAX></option>
+            return <option className="material-page__selectfield-item-container" key={o.name} value={o.name}>{o.text}</option>
           })}
         </select>
         {correctAnswersummaryComponent}


### PR DESCRIPTION
Closes #5025 

When MathJax rendering support were added to every task field it was also enabled to selection field's dropdowns and lists causing them to render [Object object] values for option elements instead of correct value. This happened because StrMathJAX component was added to those fields also which was a mistake.

It's not feasible to add MathJax support for select field's option elements as they cannot contain math formulas provided by MathJax.

