### PR TITLE
5092 - Place ToC before material content 

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
@@ -136,7 +136,11 @@ export default class ContentPanel extends React.Component<ContentPanelProps, Con
 
         <div className="content-panel__body" ref="body">
           <div className="content-panel__content">
-            <div className={`content-panel__main-container loader-empty`}>{this.props.children}</div>
+
+            {/* Rendering the handle arrow for opening the ToC */}
+            {this.props.navigation && <div className="content-panel__navigation-open" onClick={this.openNavigation}><span className="icon-arrow-left"></span></div>}
+
+            {/* Rendering the ToC */}
             {this.props.navigation && <nav ref="menu-overlay"
              className={`content-panel__navigation ${this.state.displayed ? "displayed" : ""} ${this.state.visible ? "visible" : ""} ${this.state.dragging ? "dragging" : ""}`}
              onClick={this.closeNavigationByOverlay} onTouchStart={this.onTouchStart} onTouchMove={this.onTouchMove} onTouchEnd={this.onTouchEnd}>
@@ -145,7 +149,8 @@ export default class ContentPanel extends React.Component<ContentPanelProps, Con
               }</div>
             </nav>}
 
-            {this.props.navigation && <div className="content-panel__navigation-open" onClick={this.openNavigation}><span className="icon-arrow-left"></span></div>}
+            {/* Rendering the content */}
+            <div className={`content-panel__main-container loader-empty`}>{this.props.children}</div>
           </div>
         </div>
       </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -200,7 +200,7 @@
     margin: 0 50px 10px 0;
     max-width: 700px;
     min-width: 650px;
-    order :1;
+    order: 1;
   }
 
   @include breakpoint($breakpoint-desktop-xl) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -141,6 +141,7 @@
     flex-shrink: 1;
     height: calc(100vh - (#{$navbar-desktop-height} * 1.25 + (3 * #{$panel-header-title-margin}) + #{$panel-header-title-height-desktop}));
     margin: 0;
+    order: 2;
     // scss-lint:disable VendorPrefix
     position: -webkit-sticky; // Safari 7-12 support
     // scss-lint:enable VendorPrefix
@@ -199,6 +200,7 @@
     margin: 0 50px 10px 0;
     max-width: 700px;
     min-width: 650px;
+    order :1;
   }
 
   @include breakpoint($breakpoint-desktop-xl) {
@@ -270,7 +272,7 @@
   justify-content: center;
   position: fixed;
   right: -1px;
-  top: 65px;
+  top: 70px;
   width: 2rem;
   z-index: 10;
 


### PR DESCRIPTION
Closes #5092 

This will change the html element order of ToC and Material Content so we will serve the ToC first. ToC is still displayed in the right side of the screen via flexbox order property.