### PR TITLE
5135 front page wcag support

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/login-button.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/login-button.tsx
@@ -28,7 +28,7 @@ class LoginButton extends React.Component<LoginButtonProps, LoginButtonState> {
     window.location.replace($("#login").attr("href"));
   }
   render(){
-    return (<Link className={`button button--login ${this.props.modifier ? "button--" + this.props.modifier : ""}`} onClick={this.login}>
+    return (<Link tabIndex={0} className={`button button--login ${this.props.modifier ? "button--" + this.props.modifier : ""}`} onClick={this.login}>
       <span>{this.props.i18n.text.get('plugin.login.buttonLabel')}</span>
     </Link>);
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
@@ -22,7 +22,7 @@ interface ItemDataElement {
   icon: string,
   condition?: boolean,
   badge?: number,
-  openInNewTab?: string
+  openInNewTab?: string,
 }
 
 interface MainFunctionNavbarProps {
@@ -46,9 +46,9 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       text: 'plugin.home.home',
       href: "/",
       icon: "home",
-      //Go to frontpage if not logged in
+      // Go to frontpage if not logged in
       to: this.props.status.loggedIn,
-      condition: true
+      condition: true,
     }, {
       modifier: "coursepicker",
       trail: "coursepicker",
@@ -56,7 +56,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       href: "/coursepicker",
       icon: "books",
       to: true,
-      condition: true
+      condition: true,
     }, {
       modifier: "communicator",
       trail: "communicator",
@@ -65,7 +65,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       icon: "envelope",
       condition: this.props.status.isActiveUser && this.props.status.loggedIn,
       to: true,
-      badge: this.props.messageCount
+      badge: this.props.messageCount,
     }, {
       modifier: "discussion",
       trail: "discussion",
@@ -73,7 +73,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       href: "/discussion",
       icon: "bubbles",
       to: true,
-      condition: this.props.status.isActiveUser && this.props.status.loggedIn && this.props.status.permissions.FORUM_ACCESSENVIRONMENTFORUM
+      condition: this.props.status.isActiveUser && this.props.status.loggedIn && this.props.status.permissions.FORUM_ACCESSENVIRONMENTFORUM,
     }, {
       modifier: "guider",
       trail: "guider",
@@ -81,16 +81,16 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       href: "/guider",
       icon: "users",
       to: true,
-      condition: this.props.status.permissions.GUIDER_VIEW
+      condition: this.props.status.permissions.GUIDER_VIEW,
     }, {
-      //Transcript of records is way too heavy and crazy to be its own thing, let it be here until it is refactored
+      // Transcript of records is way too heavy and crazy to be its own thing, let it be here until it is refactored
       modifier: "records",
       trail: "records",
       text: 'plugin.records.records',
       href: "/records",
       icon: "profile",
       to: true,
-      condition: this.props.status.permissions.TRANSCRIPT_OF_RECORDS_VIEW
+      condition: this.props.status.permissions.TRANSCRIPT_OF_RECORDS_VIEW,
     },{
       modifier: "announcer",
       trail: "announcer",
@@ -98,7 +98,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       href: "/announcer",
       icon: "paper-plane",
       to: true,
-      condition: this.props.status.permissions.ANNOUNCER_TOOL
+      condition: this.props.status.permissions.ANNOUNCER_TOOL,
     },{
       //Evaluation is also an external
       modifier: "evaluation",
@@ -107,7 +107,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       href: "/evaluation2",
       icon: "evaluate",
       condition: this.props.status.permissions.EVALUATION_VIEW_INDEX,
-      openInNewTab: "_blank"
+      openInNewTab: "_blank",
     }];
 
     return <Navbar mobileTitle={this.props.title} isProfileContainedInThisApp={true}
@@ -115,25 +115,25 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       if (!item.condition){
         return null;
       }
-      return {
+        return {
         modifier: item.modifier,
         item: (<Dropdown openByHover key={item.text} content={this.props.i18n.text.get(item.text)}>
-          <Link openInNewTab={item.openInNewTab} href={this.props.activeTrail !== item.trail ? item.href : null} to={item.to && this.props.activeTrail !== item.trail ? item.href : null} className={`link link--icon link--full link--main-function-navbar ${this.props.activeTrail === item.trail ? 'active' : ''}`}
-          aria-label={this.props.i18n.text.get(item.text)}>
+          <Link openInNewTab={item.openInNewTab} tabIndex={this.props.activeTrail == item.trail ? 0 : null} as={this.props.activeTrail == item.trail ? "span" : null} href={this.props.activeTrail !== item.trail ? item.href : null} to={item.to && this.props.activeTrail !== item.trail ? item.href : null} className={`link link--icon link--full link--main-function-navbar ${this.props.activeTrail === item.trail ? 'active' : ''}`}
+            aria-label={this.props.activeTrail == item.trail ? this.props.i18n.text.get("plugin.wcag.mainNavigation.currentPage.aria.label") + " " + this.props.i18n.text.get(item.text) : this.props.i18n.text.get(item.text)} role="menuitem">
           <span className={`link__icon icon-${item.icon}`}/>
           {item.badge ? <span className="indicator indicator--main-function">{(item.badge >= 100 ? "99+" : item.badge)}</span> : null}
         </Link></Dropdown>)
       }
     })} defaultOptions={this.props.status.loggedIn ? null : [
       (<LoginButton modifier="login-main-function" key="0"/>),
-      (<ForgotPasswordDialog key="1"><Link className="link link--forgot-password link--forgot-password-main-function">
+      (<ForgotPasswordDialog key="1"><Link className="link link--forgot-password link--forgot-password-main-function" aria-label={this.props.i18n.text.get('plugin.forgotpassword.forgotLink')} role="menuitem">
         <span>{this.props.i18n.text.get('plugin.forgotpassword.forgotLink')}</span>
       </Link></ForgotPasswordDialog>)
     ]} menuItems={itemData.map((item: ItemDataElement)=>{
       if (!item.condition){
         return null;
       }
-      return <Link openInNewTab={item.openInNewTab} href={item.href} className={`link link--full link--menu ${this.props.activeTrail === item.trail ? 'active' : ''}`} aria-label={this.props.i18n.text.get(item.text)}>
+      return <Link openInNewTab={item.openInNewTab} href={item.href} className={`link link--full link--menu ${this.props.activeTrail === item.trail ? 'active' : ''}`} aria-label={this.props.i18n.text.get(item.text)} role="menuitem">
         <span className={`link__icon icon-${item.icon}`}/>
         {item.badge ? <span className="indicator indicator--main-function">{(item.badge >= 100 ? "99+" : item.badge)}</span> : null}
         <span className="link--menu__text">{this.props.i18n.text.get(item.text)}</span>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/workspace/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/workspace/navbar.tsx
@@ -232,10 +232,9 @@ class WorkspaceNavbar extends React.Component<WorkspaceNavbarProps, WorkspaceNav
   let assessmentRequestItem = this.props.currentWorkspace &&
     this.props.status.permissions.WORKSPACE_REQUEST_WORKSPACE_ASSESSMENT ? {
     modifier: "assessment-request",
-
     item: (<Dropdown openByHover key="assessment-request" modifier="assessment"
         content={getTextForAssessmentState(this.props.currentWorkspace.studentAssessments.assessmentState, this.props.i18n)}>
-      <Link onClick={this.onRequestEvaluationOrCancel.bind(this, this.props.currentWorkspace.studentAssessments.assessmentState)} aria-label={getTextForAssessmentState(this.props.currentWorkspace.studentAssessments.assessmentState, this.props.i18n)}
+      <Link tabIndex={0} as="span" onClick={this.onRequestEvaluationOrCancel.bind(this, this.props.currentWorkspace.studentAssessments.assessmentState)} aria-label={getTextForAssessmentState(this.props.currentWorkspace.studentAssessments.assessmentState, this.props.i18n)}
         className={`link link--icon link--workspace-assessment link--workspace-assessment-${getClassNameForAssessmentState(this.props.currentWorkspace.studentAssessments.assessmentState)} link--workspace-navbar icon-assessment-${getIconForAssessmentState(this.props.currentWorkspace.studentAssessments.assessmentState)}`}></Link>
     </Dropdown>)
   } : null;
@@ -264,7 +263,6 @@ class WorkspaceNavbar extends React.Component<WorkspaceNavbarProps, WorkspaceNav
   return <Navbar mobileTitle={this.props.title} isProfileContainedInThisApp={false}
     modifier={navbarModifiers} navigation={trueNavigation} navbarItems={[
       assessmentRequestItem,
-      //managementItem
     ].concat(itemData.map((item)=>{
     if (!item.condition){
       return null;
@@ -272,8 +270,8 @@ class WorkspaceNavbar extends React.Component<WorkspaceNavbarProps, WorkspaceNav
     return {
       modifier: item.modifier,
       item: (<Dropdown openByHover key={item.text} content={this.props.i18n.text.get(item.text)}>
-        <Link openInNewTab={item.openInNewTab} href={this.props.activeTrail !== item.trail ? item.href : null} to={item.to && this.props.activeTrail !== item.trail ? item.href : null} className={`link link--icon link--full link--workspace-navbar ${this.props.activeTrail === item.trail ? 'active' : ''}`}
-        aria-label={this.props.i18n.text.get(item.text)}>
+        <Link tabIndex={this.props.activeTrail == item.trail ? 0 : null} as={this.props.activeTrail == item.trail ? "span" : null} openInNewTab={item.openInNewTab} href={this.props.activeTrail !== item.trail ? item.href : null} to={item.to && this.props.activeTrail !== item.trail ? item.href : null} className={`link link--icon link--full link--workspace-navbar ${this.props.activeTrail === item.trail ? 'active' : ''}`}
+          aria-label={this.props.activeTrail == item.trail ? this.props.i18n.text.get("plugin.wcag.mainNavigation.currentPage.aria.label") + " " + this.props.i18n.text.get(item.text) : this.props.i18n.text.get(item.text)} role="menuitem">
         <span className={`link__icon icon-${item.icon}`}/>
         {item.badge ? <span className="indicator indicator--workspace">{(item.badge >= 100 ? "99+" : item.badge)}</span> : null}
       </Link></Dropdown>)

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body.tsx
@@ -35,7 +35,7 @@ class FrontpageBody extends React.Component<FrontpageBodyProps, FrontpageBodySta
       <FrontpageHero i18n={this.props.i18n}/>
       <ScreenContainer viewModifiers="frontpage">
         <FrontpageStudying i18n={this.props.i18n}/>
-        <FrontpageVideos/>
+        <FrontpageVideos i18n={this.props.i18n}/>
         <FrontpageNews i18n={this.props.i18n}/>
         <FrontpageInstagram i18n={this.props.i18n}/>
         <FrontpageOrganization i18n={this.props.i18n}/>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/footer.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/footer.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { i18nType } from "~/reducers/base/i18n";
 
 import '~/sass/elements/footer.scss';
+import '~/sass/elements/wcag.scss';
 
 
 interface FrontpageFooterProps {
@@ -34,7 +35,9 @@ export default class FrontpageFooter extends React.Component<FrontpageFooterProp
             <span>info@otavia.fi</span>
           </p>
           <p className="footer__subitem footer__subitem--privacy-policy">
-            <a href="https://otavia.fi/opiskelija-ja-opintotietorekisterin-tietosuojaseloste/" target="_blank" className="link link--privacy-policy">{this.props.i18n.text.get('plugin.footer.ooPrivacyPolicy.label')}</a>
+            <a href="https://otavia.fi/opiskelija-ja-opintotietorekisterin-tietosuojaseloste/" target="_blank" className="link link--privacy-policy">
+              <span className="visually-hidden">Otavia </span>{this.props.i18n.text.get('plugin.footer.ooPrivacyPolicy.label')}
+            </a>
           </p>
           <p className="footer__subitem footer__subitem--accessibility-statement">
             <a href="https://docs.google.com/document/d/1EXS3TroGTNAq9N8bV1pK6W2byKntZpHudBHH3NBGgXY/edit?usp=sharing" target="_blank" className="link link--accessibility-statement">{this.props.i18n.text.get('plugin.footer.accesibilityStatement.text')}</a>
@@ -47,7 +50,9 @@ export default class FrontpageFooter extends React.Component<FrontpageFooterProp
       </div>
       <div className="footer__container--plagscan">
         <div className="footer__item footer__item--plagscan">
-          <a href="https://www.plagscan.com" className="link link--plagscan-logo" target="_blank"><img src="/gfx/plagscan-logo-white.png" alt="" title=""/></a> <span className="footer__item--plagscan-text">{this.props.i18n.text.get('plugin.footer.plagscan.text')}</span> <a href="https://otavia.fi/plagscan_tietosuojaseloste/" target="_blank" className="link link--plagscan-privacy-policy">({this.props.i18n.text.get('plugin.footer.plagScanPrivacyPolicy.label')}).</a>
+          <a href="https://www.plagscan.com" className="link link--plagscan-logo" target="_blank"><img src="/gfx/plagscan-logo-white.png" alt="Plagscan logo"/></a>
+          <span className="footer__item--plagscan-text">{this.props.i18n.text.get('plugin.footer.plagscan.text')}</span>
+          <a href="https://otavia.fi/plagscan_tietosuojaseloste/" target="_blank" className="link link--plagscan-privacy-policy">(<span className="visually-hidden">Plagscan </span>{this.props.i18n.text.get('plugin.footer.plagScanPrivacyPolicy.label')}).</a>
         </div>
       </div>
     </footer>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/header.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/header.tsx
@@ -29,9 +29,9 @@ export default class FrontpageHero extends React.Component<FrontpageHeroProps, F
         </div>
         <div className="hero__item hero__item--frontpage">
           <div className="hero__item-logo-container">
-            <img className="logo logo--muikku" src="/gfx/oo-branded-site-logo.png"></img>
+            <img className="logo logo--muikku" src="/gfx/oo-branded-site-logo.png" alt="Muikku logo"></img>
             <div className="hero__header-container">
-              <div className="hero__header hero__header--frontpage-muikku">MUIKKU</div>
+              <h1 className="hero__header hero__header--frontpage-muikku">{this.props.i18n.text.get("plugin.site.title")}</h1>
             </div>
           </div>
           <div className="hero__description">{this.props.i18n.text.get( 'plugin.header.site.description' )}</div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/instagram.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/instagram.tsx
@@ -4,6 +4,7 @@ import { i18nType } from "~/reducers/base/i18n";
 
 import '~/sass/elements/ordered-container.scss';
 import '~/sass/elements/card.scss';
+import '~/sass/elements/wcag.scss';
 
 interface FrontpageInstagramProps {
   i18n: i18nType
@@ -19,8 +20,8 @@ export default class FrontpageInstagram extends React.Component<FrontpageInstagr
     const THUMBNAIL_WIDTH = 640;
     const PHOTO_COUNT = 12;
 
-    return <section id="news" className="screen-container__section">
-      <h2 className="screen-container__header">{this.props.i18n.text.get( 'plugin.sectionTitle.instagram' )}</h2>
+    return <section id="instagram" className="screen-container__section">
+      <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.instagram")}</h2>
       <div className="ordered-container ordered-container--frontpage-instagram">
 
         <div className="ordered-container__item ordered-container__item--frontpage-instagram">
@@ -28,10 +29,18 @@ export default class FrontpageInstagram extends React.Component<FrontpageInstagr
             <div className="card__content">
               <div className="card__meta">
                 <div className="card__meta-aside">
-                  <a href="https://www.instagram.com/muikkuofficial/" target="_blank"><span className="card__meta-aside-logo icon-instagram"></span></a>
+                  <a href="https://www.instagram.com/muikkuofficial/" target="_blank">
+                    <span className="card__meta-aside-logo icon-instagram">
+                      <span className="visually-hidden">Instagram muikkuofficial</span>
+                    </span>
+                  </a>
                 </div>
                 <div className="card__meta-body">
-                  <div className="card__meta-body-title"><a className="card__meta-body-link card__meta-body-link--instagram" href="https://www.instagram.com/muikkuofficial/" target="_blank">muikkuofficial</a></div>
+                  <div className="card__meta-body-title">
+                    <a className="card__meta-body-link card__meta-body-link--instagram" href="https://www.instagram.com/muikkuofficial/" target="_blank">
+                      <span className="visually-hidden">Instagram </span>muikkuofficial
+                    </a>
+                  </div>
                   <div className="card__meta-body-description">{this.props.i18n.text.get('plugin.studying.nettilukio.title')} / {this.props.i18n.text.get('plugin.studying.nettiperuskoulu.title')}</div>
                 </div>
               </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/instagram.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/instagram.tsx
@@ -20,7 +20,7 @@ export default class FrontpageInstagram extends React.Component<FrontpageInstagr
     const THUMBNAIL_WIDTH = 640;
     const PHOTO_COUNT = 12;
 
-    return <section id="instagram" className="screen-container__section">
+    return <section id="instagram" className="screen-container__section" aria-label={this.props.i18n.text.get("plugin.wcag.frontPageSectionInstagramLabel")}>
       <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.instagram")}</h2>
       <div className="ordered-container ordered-container--frontpage-instagram">
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/navbar.tsx
@@ -15,7 +15,7 @@ interface FrontpageNavbarProps {
 }
 
 interface FrontpageNavbarState {
-  
+
 }
 
 class FrontpageNavbar extends React.Component<FrontpageNavbarProps, FrontpageNavbarState> {
@@ -46,7 +46,7 @@ class FrontpageNavbar extends React.Component<FrontpageNavbarProps, FrontpageNav
       }
     ]} defaultOptions={[
       (<LoginButton key="0"/>),
-      (<ForgotPasswordDialog key="1"><Link className="link link--forgot-password">
+      (<ForgotPasswordDialog key="1"><Link tabIndex={0} className="link link--forgot-password">
          <span>{this.props.i18n.text.get('plugin.forgotpassword.forgotLink')}</span>
        </Link></ForgotPasswordDialog>)
     ]} menuItems={[

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/news.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/news.tsx
@@ -15,8 +15,8 @@ interface FrontpageNewsState {
 
 export default class FrontpageNews extends React.Component<FrontpageNewsProps, FrontpageNewsState> {
   render() {
-    return <section id="news" className="screen-container__section">
-      <h2 className="screen-container__header">{this.props.i18n.text.get( 'plugin.sectionTitle.news' )}</h2>
+    return <section id="news" role="feed" className="screen-container__section">
+      <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.news")}</h2>
       <div className="ordered-container ordered-container--frontpage-news">
 
         <div className="ordered-container__item ordered-container__item--frontpage-news">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/news.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/news.tsx
@@ -15,7 +15,7 @@ interface FrontpageNewsState {
 
 export default class FrontpageNews extends React.Component<FrontpageNewsProps, FrontpageNewsState> {
   render() {
-    return <section id="news" role="feed" className="screen-container__section">
+    return <section id="news" role="feed" className="screen-container__section" aria-label={this.props.i18n.text.get("plugin.wcag.frontPageSectionNewsLabel")}>
       <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.news")}</h2>
       <div className="ordered-container ordered-container--frontpage-news">
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/organization.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/organization.tsx
@@ -18,7 +18,7 @@ interface FrontpageOrganizationState {
 
 export default class FrontpageOrganization extends React.Component<FrontpageOrganizationProps, FrontpageOrganizationState> {
   render() {
-    return <section id="organization" className="screen-container__section">
+    return <section id="organization" className="screen-container__section" aria-label={this.props.i18n.text.get('plugin.wcag.frontPageSectionOrganizationLabel')}>
 
       <div className="card card--frontpage-organization">
         <div className="ordered-container ordered-container--frontpage-organization-info">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/organization.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/organization.tsx
@@ -6,6 +6,7 @@ import '~/sass/elements/ordered-container.scss';
 import '~/sass/elements/logo.scss';
 import '~/sass/elements/buttons.scss';
 import '~/sass/elements/rich-text.scss';
+import '~/sass/elements/wcag.scss';
 
 interface FrontpageOrganizationProps {
   i18n: i18nType
@@ -32,8 +33,8 @@ export default class FrontpageOrganization extends React.Component<FrontpageOrga
               <h2 className="ordered-container__subcontainer-header--social-media">
                 {this.props.i18n.text.get( 'plugin.organization.some.title' )}
               </h2>
-              <ButtonSocial openInNewTab="_blank" className="icon-twitter" href="https://twitter.com/OtavanOpisto"/>
-              <ButtonSocial openInNewTab="_blank" className="icon-linkedin" href="https://www.linkedin.com/company/106028"/>
+              <ButtonSocial openInNewTab="_blank" className="icon-twitter" href="https://twitter.com/otaviafi"><span className="visually-hidden">Twitter Otavia</span></ButtonSocial>
+              <ButtonSocial openInNewTab="_blank" className="icon-linkedin" href="https://www.linkedin.com/company/106028"><span className="visually-hidden">Linkedin Otavia</span></ButtonSocial>
             </div>
           </div>
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
@@ -21,7 +21,7 @@ export default class FrontpageStudying extends React.Component<FrontpageStudying
       <div className="ordered-container ordered-container--frontpage-studying">
         <div className="ordered-container__item ordered-container__item--upper-secondary-school">
           <div className="card">
-            <img className="card__image" src="/gfx/kuva_nettilukio.png" alt="" title="" />
+            <img className="card__image" src="/gfx/kuva_nettilukio.png" alt="" role="presentation" />
             <div className="card__content">
               <div className="card__title card__title--frontpage-upper-secondary-school">{this.props.i18n.text.get('plugin.studying.nettilukio.title')}</div>
               <div className="card__text">{this.props.i18n.text.get('plugin.studying.nettilukio.description')}</div>
@@ -35,7 +35,7 @@ export default class FrontpageStudying extends React.Component<FrontpageStudying
         </div>
         <div className="ordered-container__item ordered-container__item--secondary-school">
           <div className="card">
-            <img className="card__image" src="/gfx/kuva_nettiperuskoulu.png" alt="" title="" />
+            <img className="card__image" src="/gfx/kuva_nettiperuskoulu.png" alt="" role="presentation"/>
             <div className="card__content">
               <div className="card__title card__title--frontpage-secondary-school">{this.props.i18n.text.get('plugin.studying.nettiperuskoulu.title')}</div>
               <div className="card__text">{this.props.i18n.text.get('plugin.studying.nettiperuskoulu.description')}</div>
@@ -49,7 +49,7 @@ export default class FrontpageStudying extends React.Component<FrontpageStudying
         </div>
         <div className="ordered-container__item ordered-container__item--open-materials">
           <div className="card">
-            <img className="card__image" src="/gfx/kuva_aineopiskelu.png" alt="" title="" />
+            <img className="card__image" src="/gfx/kuva_aineopiskelu.png" alt="" role="presentation"/>
             <div className="card__content">
               <div className="card__title card__title--frontpage-open-materials">{this.props.i18n.text.get('plugin.studying.aineopiskelu.title')}</div>
               <div className="card__text">{this.props.i18n.text.get('plugin.studying.aineopiskelu.description')}</div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
@@ -16,7 +16,7 @@ interface FrontpageStudyingState {
 
 export default class FrontpageStudying extends React.Component<FrontpageStudyingProps, FrontpageStudyingState> {
   render() {
-    return <section id="studying" className="screen-container__section">
+    return <section id="studying" className="screen-container__section" aria-label={this.props.i18n.text.get("plugin.wcag.frontPageSectionStudyingLabel")}>
       <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.studying")}</h2>
       <div className="ordered-container ordered-container--frontpage-studying">
         <div className="ordered-container__item ordered-container__item--upper-secondary-school">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/studying.tsx
@@ -17,7 +17,7 @@ interface FrontpageStudyingState {
 export default class FrontpageStudying extends React.Component<FrontpageStudyingProps, FrontpageStudyingState> {
   render() {
     return <section id="studying" className="screen-container__section">
-      <h2 className="screen-container__header">{this.props.i18n.text.get( 'plugin.sectionTitle.studying' )}</h2>
+      <h2 className="screen-container__header">{this.props.i18n.text.get("plugin.sectionTitle.studying")}</h2>
       <div className="ordered-container ordered-container--frontpage-studying">
         <div className="ordered-container__item ordered-container__item--upper-secondary-school">
           <div className="card">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/videos.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/videos.tsx
@@ -17,19 +17,22 @@ export default class FrontpageVideos extends React.Component<FrontpageVideosProp
           <iframe width="1280" height="720"
             src="https://www.youtube.com/embed/IvP595DJ5fM?rel=0&amp;showinfo=0"
             style={{ border: 0 }}
-            allowFullScreen={true}></iframe>
+            allowFullScreen={true}
+            title="Nettilukio.fi - Treenien rinnalla | Robert Ven"></iframe>
         </CarouselVideoItem>
         <CarouselVideoItem>
           <iframe width="1280" height="720"
             src="https://www.youtube.com/embed/CJcpWZD0VT8?rel=0&amp;showinfo=0"
             style={{ border: 0 }}
-            allowFullScreen={true}></iframe>
+            allowFullScreen={true}
+            title="Nettilukiolaisten ajatuksia"></iframe>
         </CarouselVideoItem>
         <CarouselVideoItem>
           <iframe width="1280" height="720"
             src="https://www.youtube.com/embed/iOKUoAAQ7Uk?rel=0&amp;showinfo=0"
             style={{ border: 0 }}
-            allowFullScreen={true}></iframe>
+            allowFullScreen={true}
+            title="Nettilukio: helppoa ja kätevää?"></iframe>
         </CarouselVideoItem>
       </Carousel>
     </section>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/videos.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/frontpage/body/videos.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import Carousel, { CarouselVideoItem } from "~/components/general/carousel";
+import { i18nType } from "~/reducers/base/i18n";
 
 interface FrontpageVideosProps {
-
+  i18n: i18nType
 }
 
 interface FrontpageVideosState {
@@ -11,7 +12,7 @@ interface FrontpageVideosState {
 
 export default class FrontpageVideos extends React.Component<FrontpageVideosProps, FrontpageVideosState> {
   render() {
-    return <section id="videos" className="screen-container__section">
+    return <section id="videos" className="screen-container__section" aria-label={this.props.i18n.text.get("plugin.wcag.frontPageSectionVideosLabel")}>
       <Carousel>
         <CarouselVideoItem>
           <iframe width="1280" height="720"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel.tsx
@@ -171,19 +171,17 @@ export default class ApplicationPanel extends React.Component<ApplicationPanelPr
     this.setRemainingHeight(isSticky);
   }
   render(){
-
-
     return (
-      <div className={`application-panel application-panel--${this.props.modifier}`} ref="panel">
+      <main className={`application-panel application-panel--${this.props.modifier}`} ref="panel">
         <div className="application-panel__container">
-          <div className="application-panel__header">
+          <h1 className="application-panel__header">
           {this.props.title ?
-            <div className="application-panel__header-title">{this.props.title}</div>
+            <span className="application-panel__header-title">{this.props.title}</span>
           : null}
           {this.props.icon ?
-            <div className="application-panel__header-actions">{this.props.icon}</div>
+            <span className="application-panel__header-actions">{this.props.icon}</span>
           : null}
-          </div>
+          </h1>
           {this.props.panelTabs ? <Tabs tabs={this.props.panelTabs} onTabChange={this.props.onTabChange} activeTab={this.props.activeTab} /> :
             <div className="application-panel__body" ref="body">
               <div style={{display: this.state.sticky ? "block" : "none", height: this.state.stickyHeight}}></div>
@@ -211,7 +209,7 @@ export default class ApplicationPanel extends React.Component<ApplicationPanelPr
             </div>
           }
         </div>
-      </div>
+      </main>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/application-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/application-panel.tsx
@@ -33,23 +33,23 @@ export default class ApplicationPanel extends React.Component<ApplicationPanelPr
 
   render(){
     return (
-      <div className={`application-panel application-panel--${this.props.modifier}`} ref="panel">
+      <main className={`application-panel application-panel--${this.props.modifier}`} ref="panel">
         <div className="application-panel__container">
-          <div className="application-panel__header">
+          <h1 className="application-panel__header">
           {this.props.title ?
-            <div className="application-panel__header-title">{this.props.title}</div>
+            <span className="application-panel__header-title">{this.props.title}</span>
           : null}
           {this.props.icon ?
-            <div className="application-panel__header-actions">{this.props.icon}</div>
+            <span className="application-panel__header-actions">{this.props.icon}</span>
           : null}
-          </div>
+          </h1>
           {this.props.panelTabs ? <Tabs modifier="application-panel" tabs={this.props.panelTabs} onTabChange={this.props.onTabChange} activeTab={this.props.activeTab} /> :
             <ApplicationPanelBody modifier={this.props.modifier? this.props.modifier : ""} toolbar={this.props.toolbar} primaryOption={this.props.primaryOption} asideAfter={this.props.asideAfter} asideBefore={this.props.asideBefore} disableStickyScrolling={this.props.disableStickyScrolling}>
               {this.props.children}
             </ApplicationPanelBody>
           }
         </div>
-      </div>
+      </main>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/feed.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/feed.tsx
@@ -29,12 +29,10 @@ class Feed extends React.Component<FeedProps, FeedState> {
       {this.props.entries.map((entry, index)=>{
         return <li className="feed__item" key={entry.link}>
           <div className="feed__item-aside">
-            <a href={entry.link} target="_blank">
-              {entry.image ? <img className="feed__item-image" src={entry.image} alt={entry.title}/> :
+              {entry.image ? <img className="feed__item-image" src={entry.image} alt="" role="presentation"/> :
               entry.feed === "nettilukio" ? <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettilukio-feed.png"/> :
-              <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettiperuskoulu-feed.png" alt={entry.title}/>
+                <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettiperuskoulu-feed.png" alt="" role="presentation"/>
             }
-            </a>
           </div>
           <div className="feed__item-body">
             {entry.feed === "nettilukio" ? <a className="feed__item-title feed__item-title--nettilukio" href={entry.link} target="_blank">{entry.title}</a> :

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/feed.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/feed.tsx
@@ -29,16 +29,16 @@ class Feed extends React.Component<FeedProps, FeedState> {
       {this.props.entries.map((entry, index)=>{
         return <li className="feed__item" key={entry.link}>
           <div className="feed__item-aside">
-          <a href={entry.link} target="_blank">
-            {entry.image ? <img className="feed__item-image" src={entry.image}/> :
+            <a href={entry.link} target="_blank">
+              {entry.image ? <img className="feed__item-image" src={entry.image} alt={entry.title}/> :
               entry.feed === "nettilukio" ? <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettilukio-feed.png"/> :
-              <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettiperuskoulu-feed.png"/>
+              <img className="feed__item-image feed__item-image--empty" src="/gfx/kuva_nettiperuskoulu-feed.png" alt={entry.title}/>
             }
             </a>
           </div>
           <div className="feed__item-body">
             {entry.feed === "nettilukio" ? <a className="feed__item-title feed__item-title--nettilukio" href={entry.link} target="_blank">{entry.title}</a> :
-              <a className="feed__item-title feed__item-title--nettiperuskoulu" href={entry.link} target="_blank">{entry.title}</a>}
+            <a className="feed__item-title feed__item-title--nettiperuskoulu" href={entry.link} target="_blank">{entry.title}</a>}
             <div className="feed__item-description" dangerouslySetInnerHTML={{__html: entry.description}}/>
             <div className="feed__item-meta"><span className="feed__item-date">{this.props.i18n.time.format(entry.publicationDate)}</span> - {entry.feed === "nettilukio" ? <a href="https://nettilukio.fi" target="_blank" className="feed__item-label feed__item-label--nettilukio">nettilukio.fi</a> : <a href="https://nettiperuskoulu.fi" target="_blank" className="feed__item-label feed__item-label--nettiperuskoulu">nettiperuskoulu.fi</a>}</div>
           </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/instagram-feed.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/instagram-feed.tsx
@@ -58,9 +58,9 @@ export default class InstagramFeed extends React.Component<InstagramFeedProps, I
   render() {
     return (
       <div className="instagram-feed">
-        {this.state.photos && this.state.photos.map(({ src, url }) => (
+        {this.state.photos && this.state.photos.map(({ src, url, caption }) => (
           <a href={url} target="_blank" key={src}>
-            <img className="instagram-feed__item" src={src} />
+            <img className="instagram-feed__item" src={src} alt={caption}/>
           </a>
         ))}
       </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
@@ -138,6 +138,7 @@ export default class Link extends React.Component<LinkProps, LinkState> {
     delete elementProps["openInNewTab"];
     delete elementProps["scrollPadding"];
     delete elementProps["disableScroll"];
+    delete elementProps["as"];
 
     return <Element ref="element" {...elementProps}
       className={(this.props.className || "") + (this.state.active ? " active" : "") + (this.props.disabled ? " disabled" : "")}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar.tsx
@@ -50,34 +50,34 @@ class Navbar extends React.Component<NavbarProps, NavbarState> {
   render(){
     return (
       <div>
-        <nav className={`navbar ${this.props.modifier ? 'navbar--' + this.props.modifier : ''}`} id="stick">
+        <nav className={`navbar ${this.props.modifier ? 'navbar--' + this.props.modifier : ''}`} id="stick" aria-label={this.props.i18n.text.get("plugin.wcag.mainNavigation.aria.label")}>
           <div className="navbar__wrapper">
             <div className="navbar__logo">
               <Dropdown openByHover key="frontpage" content={this.props.i18n.text.get("plugin.home.home")}>
                 <a href="/" className="navbar__logo-link"><img src={`${this.props.modifier == "frontpage" ? '/gfx/oo-branded-site-logo-text.png' : '/gfx/oo-branded-site-logo-text-white.png'}`} width="175" alt={this.props.i18n.text.get("plugin.site.logo.linkBackToFrontPage")}/></a>
               </Dropdown>
             </div>
-            <ul className="navbar__items">
-              <li className={`navbar__item navbar__item--menu-button`}>
-                <a className={`link link--icon link--full ${this.props.modifier ? 'link--' + this.props.modifier : ''}`} onClick={this.openMenu}>
+            <ul className="navbar__items" role="menubar" aria-label={this.props.i18n.text.get("plugin.wcag.mainNavigation.aria.label")}>
+              <li className={`navbar__item navbar__item--menu-button`} role="none">
+                <span className={`link link--icon link--full ${this.props.modifier ? 'link--' + this.props.modifier : ''}`} onClick={this.openMenu} role="menuitem" aria-hidden="true">
                   <span className="link__icon icon-navicon"></span>
-                </a>
+                </span>
               </li>
               {this.props.navbarItems.map((item, index)=>{
                 if (!item){
                   return null;
                 }
-                return (<li key={index} className={`navbar__item navbar__item--${item.modifier}`}>
+                return (<li key={index} className={`navbar__item navbar__item--${item.modifier}`} role="none">
                   {item.item}
                 </li>);
               }).filter(item=>!!item)}
             </ul>
-            {this.props.mobileTitle ? <div className="navbar__mobile-title">{this.props.mobileTitle}</div> : null}
-            <div className="navbar__default-options">
+            {this.props.mobileTitle ? <div className="navbar__mobile-title" aria-hidden="true">{this.props.mobileTitle}</div> : null}
+            <ul className="navbar__default-options" role="menubar" aria-label={this.props.i18n.text.get("plugin.wcag.alternateNavigation.aria.label")}>
               {this.props.defaultOptions}
-              <ProfileItem modifier={this.props.modifier} isProfileContainedInThisApp={this.props.isProfileContainedInThisApp}/>
-              <LanguagePicker />
-            </div>
+              <li role="none"><ProfileItem modifier={this.props.modifier} isProfileContainedInThisApp={this.props.isProfileContainedInThisApp} /></li>
+              <li role="none"><LanguagePicker /></li>
+            </ul>
           </div>
         </nav>
         <Menu open={this.state.isMenuOpen} onClose={this.closeMenu}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/language-picker.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/language-picker.tsx
@@ -3,6 +3,7 @@ import Dropdown from '~/components/general/dropdown';
 import * as React from 'react';
 import {connect, Dispatch} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import { i18nType } from '~/reducers/base/i18n';
 import Link from '~/components/general/link';
 import {LocaleListType} from '~/reducers/base/locales';
 import {StateType} from '~/reducers';
@@ -13,6 +14,7 @@ import '~/sass/elements/buttons.scss';
 
 interface LanguagePickerProps {
   locales: LocaleListType,
+  i18n: i18nType,
   setLocale: SetLocaleTriggerType
 }
 
@@ -23,11 +25,11 @@ interface LanguagePickerState {
 class LanguagePicker extends React.Component<LanguagePickerProps, LanguagePickerState> {
   render(){
     return <Dropdown modifier="language-picker" items={this.props.locales.available.map((locale)=>{
-      return (<Link className={`link link--full link--language-picker-dropdown`} onClick={this.props.setLocale.bind(this, locale.locale)}>
+      return (<Link className={`link link--full link--language-picker-dropdown`} onClick={this.props.setLocale.bind(this, locale.locale)} role="menuitem">
         <span className={`link__locale link__locale--${locale.locale}`}>{locale.name}</span>
       </Link>);
     })}>
-      <Link className={`button-pill button-pill--current-language`}>
+      <Link className={`button-pill button-pill--current-language`} role="menuitem" tabIndex={0} aria-haspopup="true" aria-label={this.props.i18n.text.get("plugin.wcag.localeMenu.aria.label")}>
         <span className={`button-pill__current-locale button-pill__current-locale--${this.props.locales.current}`}>{this.props.locales.current}</span>
       </Link>
     </Dropdown>
@@ -36,6 +38,7 @@ class LanguagePicker extends React.Component<LanguagePickerProps, LanguagePicker
 
 function mapStateToProps(state: StateType){
   return {
+    i18n: state.i18n,
     locales: state.locales
   }
 };

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/menu.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/menu.tsx
@@ -140,7 +140,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
   }
   render(){
     return (<div className={`menu menu--${this.props.modifier} ${this.state.displayed ? "displayed" : ""} ${this.state.visible ? "visible" : ""} ${this.state.dragging ? "dragging" : ""}`}
-      onClick={this.closeByOverlay} onTouchStart={this.onTouchStart} onTouchMove={this.onTouchMove} onTouchEnd={this.onTouchEnd} ref="menu">
+      onClick={this.closeByOverlay} onTouchStart={this.onTouchStart} onTouchMove={this.onTouchMove} onTouchEnd={this.onTouchEnd} ref="menu" aria-hidden="true">
       <div className="menu__container" ref="menuContainer" style={{left: this.state.drag}}>
         <div className="menu__header">
           <div className="menu__logo">
@@ -162,11 +162,10 @@ class Menu extends React.Component<MenuProps, MenuState> {
             {this.props.status.loggedIn ? <li className="menu__item menu__item--space"></li> : null}
             {this.props.status.loggedIn ? <li className="menu__item">
               <Link className="link link--full link--menu link--menu-profile" href="/profile">
-                <object className="button-image"
-                  data={getUserImageUrl(this.props.status.userId)}
-                  type="image/jpeg">
+                {this.props.status.hasImage ?
+                  <img src={getUserImageUrl(this.props.status.userId, null, this.props.status.imgVersion)} className="button-image" /> :
                   <span className="link__icon icon-user"></span>
-                </object>
+                }
                 <span className="link--menu__text">{this.props.i18n.text.get('plugin.profileBadge.links.personalInfo')}</span>
               </Link>
             </li> : null}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/profile-item.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/profile-item.tsx
@@ -62,11 +62,11 @@ class ProfileItem extends React.Component<ProfileItemProps, ProfileItemState> {
           <span>{this.props.i18n.text.get(item.text)}</span>
         </Link>}
       })}>
-      <Link className="button-pill button-pill--profile">
+      <Link className="button-pill button-pill--profile" role="menuitem" tabIndex={0} aria-haspopup="true" aria-label={this.props.i18n.text.get("plugin.wcag.profileMenu.aria.label")}>
         {
           this.props.status.hasImage ?
-            <img src={getUserImageUrl(this.props.status.userId, null, this.props.status.imgVersion)} className="button-image"/> :
-              <div className="button-image"><span className="button-pill__icon icon-user"/></div>
+            <img alt={this.props.i18n.text.get("plugin.profileBadge.links.profileImageAtl")} src={getUserImageUrl(this.props.status.userId, null, this.props.status.imgVersion)} className="button-image"/> :
+              <span className="button-image"><span className="button-pill__icon icon-user"/></span>
         }
       </Link>
     </Dropdown>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/screen-container.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/screen-container.tsx
@@ -8,7 +8,7 @@ interface ScreenContainerProps {
 }
 
 interface ScreenContainerState {
-  
+
 }
 
 export default class ScreenContainer extends React.Component<ScreenContainerProps, ScreenContainerState> {
@@ -17,7 +17,8 @@ export default class ScreenContainer extends React.Component<ScreenContainerProp
   }
   render(){
     let modifiers:Array<string> = typeof this.props.viewModifiers === "string" ? [this.props.viewModifiers] : this.props.viewModifiers;
-    return <div className="screen-container">
-    <div className={`screen-container__wrapper ${(modifiers || []).map(s=>`screen-container__wrapper--${s}`).join(" ")}`}>{this.props.children}</div></div>
+    return <main className="screen-container">
+      <div className={`screen-container__wrapper ${(modifiers || []).map(s=>`screen-container__wrapper--${s}`).join(" ")}`}>{this.props.children}</div>
+    </main>
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body.tsx
@@ -6,6 +6,7 @@ import ContinueStudiesPanel from './body/continue-studies-panel';
 import ImportantPanel from './body/important-panel';
 import LastMessagesPanel from './body/latest-messages-panel';
 import WorkspacesPanel from './body/workspaces-panel';
+import { i18nType } from '~/reducers/base/i18n';
 
 import * as React from 'react';
 
@@ -16,21 +17,25 @@ import StudiesEnded from './body/studies-ended';
 
 import CheckContactInfoDialog from '~/components/base/check-contact-info-dialog';
 
+import '~/sass/elements/wcag.scss';
+
 //TODO css get rid of ordered container
 class IndexBody extends React.Component<{
-  status: StatusType
+  status: StatusType,
+  i18n: i18nType,
 },{}> {
   render(){
     return (<div>
       <MainFunctionNavbar activeTrail="index"/>
         {this.props.status.isActiveUser ? <ScreenContainer viewModifiers="index">
-          <div className="panel-group panel-group--studies">
-            <ContinueStudiesPanel/>
-            <WorkspacesPanel/>
-          </div>
-          <LastMessagesPanel/>
-          <ImportantPanel/>
-          <AnnouncementsPanel/></ScreenContainer> : <ScreenContainer viewModifiers="index"><StudiesEnded/></ScreenContainer>}
+        <h1 className="visually-hidden">{this.props.i18n.text.get('plugin.wcag.indexViewHeader')}</h1>
+        <div className="panel-group panel-group--studies">
+          <ContinueStudiesPanel/>
+          <WorkspacesPanel/>
+        </div>
+        <LastMessagesPanel/>
+        <ImportantPanel/>
+        <AnnouncementsPanel/></ScreenContainer> : <ScreenContainer viewModifiers="index"><StudiesEnded/></ScreenContainer>}
       <CheckContactInfoDialog/>
     </div>);
   }
@@ -38,6 +43,7 @@ class IndexBody extends React.Component<{
 
 function mapStateToProps(state: StateType){
   return {
+    i18n: state.i18n,
     status: state.status
   }
 };

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
@@ -22,10 +22,10 @@ interface AnnouncementsPanelState {
 
 class AnnouncementsPanel extends React.Component<AnnouncementsPanelProps, AnnouncementsPanelState> {
   render(){
-    return (<div className="panel panel--announcements">
+    return (<div className="panel panel--announcements" aria-label={this.props.i18n.text.get('plugin.frontPage.announcements.title')}>
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--announcements icon-paper-plane"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.announcements.title')}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.announcements.title')}</h2>
       </div>
       {this.props.announcements.length ? (
         <div className="panel__body">
@@ -33,7 +33,7 @@ class AnnouncementsPanel extends React.Component<AnnouncementsPanelProps, Announ
             {this.props.announcements.map((announcement: AnnouncementType)=>{
               let extraWorkspaces = announcement.workspaces && announcement.workspaces.length ? announcement.workspaces.length - 1 : 0;
               return <Link key={announcement.id} className={`item-list__item item-list__item--announcements ${announcement.workspaces.length ? "item-list__item--has-workspaces" : ""}`}
-                to={`/announcements#${announcement.id}`}>
+                href={`/announcements#${announcement.id}`} to={`/announcements#${announcement.id}`}>
                 <span className="item-list__icon item-list__icon--announcements icon-paper-plane"></span>
                 <span className="item-list__text-body item-list__text-body--multiline">
                   <span className="item-list__announcement-caption">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/announcements-panel.tsx
@@ -22,7 +22,7 @@ interface AnnouncementsPanelState {
 
 class AnnouncementsPanel extends React.Component<AnnouncementsPanelProps, AnnouncementsPanelState> {
   render(){
-    return (<div className="panel panel--announcements" aria-label={this.props.i18n.text.get('plugin.frontPage.announcements.title')}>
+    return (<div className="panel panel--announcements">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--announcements icon-paper-plane"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.announcements.title')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/continue-studies-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/continue-studies-panel.tsx
@@ -29,7 +29,7 @@ class ContinueStudiesPanel extends React.Component<ContinueStudiesPanelProps, Co
     } else if (!this.props.status.isStudent) {
       return null;
     }
-    return (<div className="panel panel--continue-studies" aria-label={this.props.i18n.text.get('plugin.frontPage.latestWorkspace.title')}>
+    return (<div className="panel panel--continue-studies">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--continue-studies icon-forward"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestWorkspace.title')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/continue-studies-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/continue-studies-panel.tsx
@@ -29,10 +29,10 @@ class ContinueStudiesPanel extends React.Component<ContinueStudiesPanelProps, Co
     } else if (!this.props.status.isStudent) {
       return null;
     }
-    return (<div className="panel panel--continue-studies">
+    return (<div className="panel panel--continue-studies" aria-label={this.props.i18n.text.get('plugin.frontPage.latestWorkspace.title')}>
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--continue-studies icon-forward"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestWorkspace.title')}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestWorkspace.title')}</h2>
       </div>
       <div className="panel__body">
         <div className="panel__body-title">{this.props.lastWorkspace.workspaceName}</div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/latest-messages-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/latest-messages-panel.tsx
@@ -18,7 +18,7 @@ interface LastMessagesPanelState {
 
 class LastMessagesPanel extends React.Component<LastMessagesPanelProps, LastMessagesPanelState> {
   render(){
-    return (<div className="panel panel--latest-messages" aria-label={this.props.i18n.text.get('plugin.frontPage.latestMessages.title')}>
+    return (<div className="panel panel--latest-messages">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--latest-messages icon-envelope"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestMessages.title')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/latest-messages-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/latest-messages-panel.tsx
@@ -18,17 +18,17 @@ interface LastMessagesPanelState {
 
 class LastMessagesPanel extends React.Component<LastMessagesPanelProps, LastMessagesPanelState> {
   render(){
-    return (<div className="panel panel--latest-messages">
+    return (<div className="panel panel--latest-messages" aria-label={this.props.i18n.text.get('plugin.frontPage.latestMessages.title')}>
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--latest-messages icon-envelope"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestMessages.title')}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.latestMessages.title')}</h2>
       </div>
       {this.props.lastThreads.length ? (
         <div className="panel__body">
           <div className="item-list item-list--panel-latest-messages">
             {this.props.lastThreads.map((thread)=>{
               return (<Link key={thread.id} className={`item-list__item item-list__item--latest-messages ${thread.unreadMessagesInThread ? "item-list__item--unread" : ""}`}
-                      to={`/communicator#inbox/${thread.communicatorMessageId}?f`}>
+                href={`/communicator#inbox/${thread.communicatorMessageId}?f`} to={`/communicator#inbox/${thread.communicatorMessageId}?f`}>
                 <span className={`item-list__icon item-list__icon--latest-messages icon-${thread.unreadMessagesInThread ? "envelope-alt" : "envelope-open"}`}></span>
                 <span className="item-list__text-body item-list__text-body--multiline">
                   <span className="item-list__latest-message-caption">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/studies-ended.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/studies-ended.tsx
@@ -18,7 +18,7 @@ class StudiesEnded extends React.Component<StudiesEndedProps, StudiesEndedState>
     return <div className="panel panel--studies-ended">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--studies-ended icon-blocked"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get("plugin.frontpage.inactiveStudent.messageTitle")}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get("plugin.frontpage.inactiveStudent.messageTitle")}</h2>
       </div>
       <div className="panel__body panel__body--studies-ended" dangerouslySetInnerHTML={{ __html: this.props.i18n.text.get('plugin.frontpage.inactiveStudent.messageContent')}}></div>
     </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/workspaces-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/workspaces-panel.tsx
@@ -22,10 +22,10 @@ interface WorkspacesPanelState {
 
 class WorkspacesPanel extends React.Component<WorkspacesPanelProps, WorkspacesPanelState> {
   render(){
-    return (<div className="panel panel--workspaces">
+    return (<div className="panel panel--workspaces" aria-label={this.props.i18n.text.get('plugin.frontPage.workspaces.title')}>
         <div className="panel__header">
           <div className="panel__header-icon panel__header-icon--workspaces icon-books"></div>
-          <div className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.workspaces.title')}</div>
+          <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.workspaces.title')}</h2>
         </div>
         {this.props.workspaces.length ? (
           <div className="panel__body">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/workspaces-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/index/body/workspaces-panel.tsx
@@ -22,7 +22,7 @@ interface WorkspacesPanelState {
 
 class WorkspacesPanel extends React.Component<WorkspacesPanelProps, WorkspacesPanelState> {
   render(){
-    return (<div className="panel panel--workspaces" aria-label={this.props.i18n.text.get('plugin.frontPage.workspaces.title')}>
+    return (<div className="panel panel--workspaces">
         <div className="panel__header">
           <div className="panel__header-icon panel__header-icon--workspaces icon-books"></div>
           <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.frontPage.workspaces.title')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
@@ -25,7 +25,7 @@ class WorkspaceAnnouncements extends React.Component<WorkspaceAnnouncementsProps
   render(){
     if (this.props.status.loggedIn && this.props.status.isActiveUser &&
         this.props.status.permissions.WORKSPACE_LIST_WORKSPACE_ANNOUNCEMENTS){
-      return <div className="panel panel--workspace-announcements" aria-label={this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}>
+      return <div className="panel panel--workspace-announcements">
         <div className="panel__header">
           <div className="panel__header-icon panel__header-icon--workspace-announcements icon-paper-plane"></div>
           <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
@@ -28,7 +28,7 @@ class WorkspaceAnnouncements extends React.Component<WorkspaceAnnouncementsProps
       return <div className="panel panel--workspace-announcements">
         <div className="panel__header">
           <div className="panel__header-icon panel__header-icon--workspace-announcements icon-paper-plane"></div>
-          <div className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}</div>
+          <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}</h2>
         </div>
         {this.props.announcements.length && this.props.workspace ? (
           <div className="panel__body">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/announcements.tsx
@@ -25,7 +25,7 @@ class WorkspaceAnnouncements extends React.Component<WorkspaceAnnouncementsProps
   render(){
     if (this.props.status.loggedIn && this.props.status.isActiveUser &&
         this.props.status.permissions.WORKSPACE_LIST_WORKSPACE_ANNOUNCEMENTS){
-      return <div className="panel panel--workspace-announcements">
+      return <div className="panel panel--workspace-announcements" aria-label={this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}>
         <div className="panel__header">
           <div className="panel__header-icon panel__header-icon--workspace-announcements icon-paper-plane"></div>
           <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.announcementsTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
@@ -29,7 +29,7 @@ interface DescriptionPanelState {
 class DescriptionPanel extends React.Component<DescriptionPanelProps, DescriptionPanelState> {
   render(){
 
-    return <div className="panel panel--workspace-description" aria-label={this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}>
+    return <div className="panel panel--workspace-description">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-description icon-books"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
@@ -29,7 +29,7 @@ interface DescriptionPanelState {
 class DescriptionPanel extends React.Component<DescriptionPanelProps, DescriptionPanelState> {
   render(){
 
-    return <div className="panel panel--workspace-description">
+    return <div className="panel panel--workspace-description" aria-label={this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}>
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-description icon-books"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/description.tsx
@@ -32,7 +32,7 @@ class DescriptionPanel extends React.Component<DescriptionPanelProps, Descriptio
     return <div className="panel panel--workspace-description">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-description icon-books"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.descriptionTitle')}</h2>
       </div>
       <div className="panel__body">
         {this.props.workspace && <MaterialLoader editable={this.props.workspaceEditMode.active}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
@@ -52,7 +52,7 @@ class WorkspaceTeachers extends React.Component<WorkspaceTeachersProps, Workspac
     if (!this.props.status.loggedIn){
       return null;
     }
-    return <div className="panel panel--workspace-teachers" aria-label={this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}>
+    return <div className="panel panel--workspace-teachers">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-teachers icon-user"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
@@ -55,7 +55,7 @@ class WorkspaceTeachers extends React.Component<WorkspaceTeachersProps, Workspac
     return <div className="panel panel--workspace-teachers">
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-teachers icon-user"></div>
-        <div className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}</div>
+        <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}</h2>
       </div>
       {this.props.workspace && this.props.workspace.staffMembers && this.props.workspace.staffMembers.length ? (
         <div className="panel__body">

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
@@ -52,7 +52,7 @@ class WorkspaceTeachers extends React.Component<WorkspaceTeachersProps, Workspac
     if (!this.props.status.loggedIn){
       return null;
     }
-    return <div className="panel panel--workspace-teachers">
+    return <div className="panel panel--workspace-teachers" aria-label={this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}>
       <div className="panel__header">
         <div className="panel__header-icon panel__header-icon--workspace-teachers icon-user"></div>
         <h2 className="panel__header-title">{this.props.i18n.text.get('plugin.workspace.index.teachersTitle')}</h2>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/index.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors/index.scss
@@ -13,7 +13,7 @@ $color-index-item-list-item-panel-workspaces-icon: $color-index-text-for-panels-
 $color-index-item-list-item-panel-latest-messages-icon: #aaa;
 $color-index-item-list-item-panel-latest-messages-unread-icon: $color-index-text-for-panels-title-latest-messages-icon-background;
 $color-index-item-list-item-panel-announcements-unread-icon: $color-index-text-for-panels-title-announcements-icon-background;
-$color-index-text-panels-date-color: #868686;
+$color-index-text-panels-date-color: #565656;
 $color-index-item-list-item-panel-announcements-icon: $color-index-text-for-panels-title-announcements-icon-background;
 $color-index-item-list-item-panel-announcements-has-workspaces-icon: #2fd4af;
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
@@ -17,7 +17,6 @@
   font-family: $button-font-family;
   font-size: $button-mobile-font-size;
   justify-content: center;
-  outline: none;
   overflow: hidden;
   padding: 5px 10px;
   text-decoration: none;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/feed.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/feed.scss
@@ -56,13 +56,6 @@
   overflow: hidden;
   transition: opacity 0.3s ease-in-out;
 
-  &:hover,
-  &:active,
-  &.hover,
-  &.active {
-    opacity: 0.7;
-  }
-
   img {
     border: 0;
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
@@ -4,9 +4,9 @@
 @import "../base/breakpoints";
 
 .visually-hidden {
-  position: absolute;
-  left: -10000px;
-  width: 1px;
   height: 1px;
+  left: -10000px;
   overflow: hidden;
+  position: absolute;
+  width: 1px;
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
@@ -1,0 +1,12 @@
+@import "../base/colors";
+@import "../base/mixins";
+@import "../base/vars";
+@import "../base/breakpoints";
+
+.visually-hidden {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
@@ -112,5 +112,5 @@ plugin.wcag.mainNavigation.aria.label = Main Navigation of Muikku
 plugin.wcag.alternateNavigation.aria.label = Navigation for User Profile and Language selection of Muikku
 plugin.wcag.mainNavigation.currentPage.aria.label = Current Page is
 plugin.wcag.profileMenu.aria.label = User Profile Menu of Muikku
-plugin.wcag.localeMenu.aria.label = User Interface menu of Muikku
+plugin.wcag.localeMenu.aria.label = User Interface Language selection menu of Muikku
 

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
@@ -96,6 +96,7 @@ plugin.evaluation.evaluation = Evaluation
 plugin.announcer.announcer = Announcer
 plugin.records.records = Studies
 
+plugin.profileBadge.links.profileImageAtl = Profile image
 plugin.profileBadge.links.personalInfo = My Information
 plugin.profileBadge.links.userGuide = Guides for Muikku
 plugin.profileBadge.links.helpdesk = Helpdesk
@@ -105,3 +106,11 @@ plugin.footer.plagscan.text = We are using online plagiarism checking system
 plugin.footer.plagScanPrivacyPolicy.label = Privacy Policy
 
 plugin.footer.accesibilityStatement.text = Accessibility Statement
+
+plugin.wcag.indexViewHeader = Muikun etusivu
+plugin.wcag.mainNavigation.aria.label = Main Navigation of Muikku
+plugin.wcag.alternateNavigation.aria.label = Navigation for User Profile and Language selection of Muikku
+plugin.wcag.mainNavigation.currentPage.aria.label = Current Page is
+plugin.wcag.profileMenu.aria.label = User Profile Menu of Muikku
+plugin.wcag.localeMenu.aria.label = User Interface menu of Muikku
+

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_en.properties
@@ -107,6 +107,11 @@ plugin.footer.plagScanPrivacyPolicy.label = Privacy Policy
 
 plugin.footer.accesibilityStatement.text = Accessibility Statement
 
+plugin.wcag.frontPageSectionStudyingLabel = Different ways to study in Otavia
+plugin.wcag.frontPageSectionVideosLabel = Presentation Videos of Otavia
+plugin.wcag.frontPageSectionInstagramLabel = Muikkuofficial Instagram Feed
+plugin.wcag.frontPageSectionNewsLabel = News Feed from Otavia Organization
+plugin.wcag.frontPageSectionOrganizationLabel = Description of Otavia Organization
 plugin.wcag.indexViewHeader = Muikun etusivu
 plugin.wcag.mainNavigation.aria.label = Main Navigation of Muikku
 plugin.wcag.alternateNavigation.aria.label = Navigation for User Profile and Language selection of Muikku

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_fi.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_fi.properties
@@ -107,6 +107,11 @@ plugin.footer.plagScanPrivacyPolicy.label = tietosuojaseloste
 
 plugin.footer.accesibilityStatement.text = Saavutettavuusseloste
 
+plugin.wcag.frontPageSectionStudyingLabel = Opiskeluvaihtoehdot Otaviassa
+plugin.wcag.frontPageSectionVideosLabel = Otavian esittely videoita 
+plugin.wcag.frontPageSectionInstagramLabel = Muikkuofficial Instagram julkaisut
+plugin.wcag.frontPageSectionNewsLabel = Otavia organisaation uutisia
+plugin.wcag.frontPageSectionOrganizationLabel = Otavia organisaation kuvaus
 plugin.wcag.indexViewHeader = Front Page of Muikku
 plugin.wcag.mainNavigation.aria.label = Muikun p‰‰navigaatio
 plugin.wcag.alternateNavigation.aria.label = Muikun k‰ytt‰j‰profiilin ja kielivalinnan navigaatio

--- a/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_fi.properties
+++ b/muikku-core-plugins/src/main/resources/fi/otavanopisto/muikku/plugins/frontpage/FrontPageJsPluginMessages_fi.properties
@@ -96,6 +96,7 @@ plugin.evaluation.evaluation = Arviointi
 plugin.announcer.announcer = Tiedotin
 plugin.records.records = Opinnot
 
+plugin.profileBadge.links.profileImageAtl = Profiilin kuva
 plugin.profileBadge.links.personalInfo = Omat tiedot
 plugin.profileBadge.links.userGuide = Muikun ohjeet
 plugin.profileBadge.links.helpdesk = Helpdesk
@@ -105,3 +106,10 @@ plugin.footer.plagscan.text = Meillä on käytössä PlagScan -plagiaatintunnistusjä
 plugin.footer.plagScanPrivacyPolicy.label = tietosuojaseloste
 
 plugin.footer.accesibilityStatement.text = Saavutettavuusseloste
+
+plugin.wcag.indexViewHeader = Front Page of Muikku
+plugin.wcag.mainNavigation.aria.label = Muikun päänavigaatio
+plugin.wcag.alternateNavigation.aria.label = Muikun käyttäjäprofiilin ja kielivalinnan navigaatio
+plugin.wcag.mainNavigation.currentPage.aria.label = Olet sivulla
+plugin.wcag.profileMenu.aria.label = Muikun käyttäjäprofiilin valikko
+plugin.wcag.localeMenu.aria.label = Muikun käyttöliittymän kielivalikko

--- a/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -3,7 +3,9 @@
   xmlns:h="http://java.sun.com/jsf/html"
   xmlns:f="http://java.sun.com/jsf/core"
   xmlns:jsf="http://xmlns.jcp.org/jsf"
-  xmlns:ui="http://java.sun.com/jsf/facelets">
+  xmlns:ui="http://java.sun.com/jsf/facelets"
+  xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+  lang="fi">
 
 <!-- Base takes no parameters -->
 <!-- Base takes four defines, styles, scripts, body and title, where title is not required -->
@@ -136,18 +138,18 @@
   <div id="app"></div>
 
   <!-- TODO: please lets find a way to do this with a rest endpoint -->
-  <h:form id="language-picker" style="display:none">
+  <h:form id="language-picker" style="display:none" pt:aria-hidden="true">
     <ui:repeat value="#{i18n.languages}" var="locale">
       <a jsf:action="#{languageWidgetBackingBean.setLanguage(locale)}" data-locale="#{locale}">
         #{i18n.text['plugin.navigation.language.' .concat(locale)]}
       </a>
     </ui:repeat>
   </h:form>
-  <h:form style="display:none">
+  <h:form style="display:none" pt:aria-hidden="true">
     <a jsf:action="#{logoutWidgetBackingBean.logout}" id="logout"></a>
   </h:form>
-  <a id="locale" style="display:none">#{languageWidgetBackingBean.language}</a>
-  <a id="login" style="display:none" jsf:outcome="/login.jsf?authSource=loginWidgetBackingBean.credentialessAuthSources[0]"></a>
+  <a id="locale" style="display:none" aria-hidden="true">#{languageWidgetBackingBean.language}</a>
+  <a id="login" style="display:none" jsf:outcome="/login.jsf?authSource=loginWidgetBackingBean.credentialessAuthSources[0]" aria-hidden="true"></a>
 
   <!-- Google Analytics -->
   <script>


### PR DESCRIPTION
Closes #5135 

Currently Chrome extension aXe does not pass front page with flying colors, this is mainly because slick carousel and youtube embedded videos does not follow ARIA guidelines perfectly.

Slick carousel needs to be replaced with different library. One candidate might be https://github.com/express-labs/pure-react-carousel#readme for slick replacemenṭas slick has not been under active development for a long time. 