### PR TITLE
Added scrollbars on TOC

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
@@ -531,6 +531,11 @@ $color-environment-navbar-item-menu-button: $color-default;
 $color-workspace-navbar-background: $color-workspace;
 $color-workspace-edit-mode-navbar-background: #000000;
 
+// scollbar
+
+$color-scrollbar-background: #f5f5f5;
+$color-scrollbar-handle: #555;
+
 // ICON LINKS
 $color-environment-link-icon-color: $color-default;
 $color-environment-link-icon-color-hover: $color-default;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -164,7 +164,6 @@
 }
 
 .content-panel__navigation-content {
-  @include no-scrollbars;
   @include prefix(transition, webkit moz o ms, right 0.3s);
   background-color: $color-application-panel-box-background;
   border: solid 1px $color-application-panel-box-border;
@@ -176,6 +175,20 @@
   right: 0;
   top: 0;
   width: 90%;
+  scrollbar-width: thin;
+  scrollbar-color: $color-scrollbar-handle $color-scrollbar-background;
+
+  &::-webkit-scrollbar {
+    width: 7.5px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $color-scrollbar-background; 
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: $color-scrollbar-handle;
+  }
 
   @include breakpoint($breakpoint-pad) {
     width: 70%;


### PR DESCRIPTION
Fixes #5061 

Adds very thin scrollbars to the TOC in the material view.

It affects the workspace help panel as well.

Checked them to work with webkit and FF browsers and kept consistency with them to look the same way in both browsers despite the distinct standard, but it does not work with IE (untested because I don't have Winblows right now as I have uninstalled it, hence no access to IE or Edge).

This should also technically work on Edge, as it's webkit based.