### PR TITLE
* Added basic entities escaping back

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/ckeditor.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/ckeditor.tsx
@@ -62,7 +62,6 @@ const extraConfig = (props: CKEditorProps) => ({
   entities_latin: false,
   entities_greek: false,
   entities: false,
-  basicEntities: false,
   toolbar: [
     { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat' ] },
     { name: 'links', items: [ 'Link' ] },


### PR DESCRIPTION
Closes #5266 

This brings back basic entities support for CKEditor so they are escaped properly.