### PR TITLE
5134 Make link components work with keyboard

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/main-function/navbar.tsx
@@ -133,7 +133,7 @@ class MainFunctionNavbar extends React.Component<MainFunctionNavbarProps, MainFu
       if (!item.condition){
         return null;
       }
-      return <Link openInNewTab={item.openInNewTab} href={item.href} className={`link link--full link--menu ${this.props.activeTrail === item.trail ? 'active' : ''}`} aria-label={this.props.i18n.text.get(item.text)} role="menuitem">
+      return <Link openInNewTab={item.openInNewTab} to={item.to ? item.href : null} href={item.href} className={`link link--full link--menu ${this.props.activeTrail === item.trail ? 'active' : ''}`} aria-label={this.props.i18n.text.get(item.text)} role="menuitem">
         <span className={`link__icon icon-${item.icon}`}/>
         {item.badge ? <span className="indicator indicator--main-function">{(item.badge >= 100 ? "99+" : item.badge)}</span> : null}
         <span className="link--menu__text">{this.props.i18n.text.get(item.text)}</span>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
@@ -39,6 +39,7 @@ export default class Link extends React.Component<LinkProps, LinkState> {
     this.onTouchStart = this.onTouchStart.bind(this);
     this.onTouchEnd = this.onTouchEnd.bind(this);
     this.onTouchMove = this.onTouchMove.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
 
     this.state = {
       active: false,
@@ -124,6 +125,11 @@ export default class Link extends React.Component<LinkProps, LinkState> {
       this.props.onTouchEnd(e);
     }
   }
+  onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "enter") {
+      this.onClick(e as any);
+    }
+  }
   render(){
     if (this.state.redirect){
       return <Redirect push to={this.props.to}/>
@@ -140,7 +146,11 @@ export default class Link extends React.Component<LinkProps, LinkState> {
     delete elementProps["disableScroll"];
     delete elementProps["as"];
 
-    return <Element ref="element" {...elementProps}
+    if (Element !== "a") {
+      elementProps.tabIndex = 1;
+    }
+
+    return <Element ref="element" {...elementProps} onKeyDown={this.onKeyDown}
       className={(this.props.className || "") + (this.state.active ? " active" : "") + (this.props.disabled ? " disabled" : "")}
       onClick={this.onClick} onTouchStart={this.onTouchStart} onTouchEnd={this.onTouchEnd} onTouchMove={this.onTouchMove}/>
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
@@ -147,7 +147,7 @@ export default class Link extends React.Component<LinkProps, LinkState> {
     delete elementProps["as"];
 
     if (Element !== "a") {
-      elementProps.tabIndex = 1;
+      elementProps.tabIndex = elementProps.tabIndex || 1;
     }
 
     return <Element ref="element" {...elementProps} onKeyDown={this.onKeyDown}


### PR DESCRIPTION
Fixes #5134 by adding a keyboard listener to the link

Also fixes the menu links not working because they were disabled.