### PR TITLE
Fixes media recorder icon always being visible after click

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/audio-field/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/audio-field/index.tsx
@@ -124,7 +124,7 @@ export default class AudioField extends React.Component<AudioFieldProps, AudioFi
   async start(){
     //we create it
     try {
-      this.stream = await navigator.mediaDevices.getUserMedia({
+      this.stream = this.stream || await navigator.mediaDevices.getUserMedia({
         audio: true
       });
     } catch (err){
@@ -181,6 +181,7 @@ export default class AudioField extends React.Component<AudioFieldProps, AudioFi
     clearInterval(this.interval);
     //stop the recorder, this should trigger the dataavailable event
     this.recorder.stop();
+    this.stream.getTracks().forEach((t) => t.stop());
 
     //delet stuff
     delete this["recorder"];


### PR DESCRIPTION
Fixes #5008 

I recommend merging soon as this is a likely memory leak of a track that remained open and never closed, and then started to stack with each recording as the memory wasn't cleaned, but I am not sure, not very well versed on the MediaRecorder API.