### PR TITLE
Removed nesting that caused images not to load properly

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/base/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/base/index.tsx
@@ -124,6 +124,12 @@ function preprocessor($html: any): any{
     }
   });
 
+  $html.find("a figure").each(function(){
+    // removing old style images wrapped in a link
+    // they get processed as link and thus don't work
+    $(this).parent("a").replaceWith(this);
+  });
+
   const $newHTML = $html.map(function() {
     if (this.tagName === "TABLE") {
       let elem = document.createElement("div");


### PR DESCRIPTION
Fixes #4992 

Nested relative sources are non-standard according to how materials work and as such I decided to normalize these fields.

The way it's done is that.

1. As default every image must be inside a figure element
2. When there's a link on top of a figure element the link is removed.

Let's be careful with side effects but I checked this and everything seems normal after the change.

With the introduction of the zooming element it should be unecessary to have all this extra nesting.