### PR TITLE
Removed arrow down on non-list tooltips

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/dropdown.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/dropdown.tsx
@@ -155,7 +155,7 @@ export default class Dropdown extends React.Component<DropdownProps, DropdownSta
     (this.refs["portal"] as Portal).closePortal();
   }
   onKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Tab") {
+    if (e.key === "Tab" || !this.props.items) {
       return;
     }
 


### PR DESCRIPTION
It does a very simple thing disables the arrow down catching functionality when the content of a tooltip is not a list.

Fixes #5433 