### PR TITLE
H5P support

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/static/iframe.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/static/iframe.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { prepareH5POn } from "~/lib/h5p";
 import { i18nType } from "~/reducers/base/i18n";
 import { HTMLtoReactComponent } from "~/util/modifiers";
 
@@ -14,8 +15,31 @@ interface IframeProps {
 }
 
 export default class Iframe extends React.Component<IframeProps, {}>{
+  private mainParentRef: React.RefObject<HTMLDivElement>;
+  private loadedH5P: boolean = false;
   constructor(props: IframeProps){
     super(props);
+
+    this.mainParentRef = React.createRef();
+
+    this.loadH5PIfNecessary = this.loadH5PIfNecessary.bind(this);
+  }
+  componentDidMount() {
+    this.loadH5PIfNecessary();
+  }
+  componentDidUpdate() {
+    this.loadH5PIfNecessary();
+  }
+  loadH5PIfNecessary() {
+    if (!this.loadedH5P) {
+      const iframe = this.mainParentRef.current && this.mainParentRef.current.querySelector("iframe");
+      if (iframe) {
+        iframe.addEventListener("load", () => {
+          prepareH5POn(iframe);
+        });
+        this.loadedH5P = true;
+      }
+    }
   }
   render (){
     return HTMLtoReactComponent(this.props.element, (Tag: string, elementProps: any, children: Array<any>, element: HTMLElement)=>{

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
@@ -64,6 +64,10 @@ actionHandlers.prepareResize = (iframe: HTMLIFrameElement, data: any, respond: F
 actionHandlers.resize = (iframe: HTMLIFrameElement, data: any) => {
     // Resize iframe so all content is visible. Use scrollHeight to make sure we get everything
     iframe.style.height = data.scrollHeight + 'px';
+
+    if (iframe.parentElement && iframe.parentElement.classList.contains("material-page__iframe-wrapper")) {
+        iframe.parentElement.style.height = data.scrollHeight + 'px';
+    }
 };
 
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
@@ -18,7 +18,7 @@ actionHandlers.hello = (iframe: HTMLIFrameElement, data: any, respond: Function)
     iframe.getBoundingClientRect();
 
     // Tell iframe that it needs to resize when our window resizes
-    var resize = function () {
+    const resize = function () {
         if (iframe.contentWindow) {
             // Limit resize calls to avoid flickering
             respond('resize');
@@ -78,8 +78,8 @@ window.addEventListener('message', (event) => {
     }
 
     // Find out who sent the message
-    var iframe, iframes = document.getElementsByTagName('iframe');
-    for (var i = 0; i < iframes.length; i++) {
+    let iframe, iframes = document.getElementsByTagName('iframe');
+    for (let i = 0; i < iframes.length; i++) {
         if (iframes[i].contentWindow === event.source) {
             iframe = iframes[i];
             break;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
@@ -1,0 +1,111 @@
+// Map actions to handlers
+const actionHandlers: any = {};
+
+/**
+ * Prepare iframe resize.
+ *
+ * @private
+ * @param {Object} iframe Element
+ * @param {Object} data Payload
+ * @param {Function} respond Send a response to the iframe
+ */
+actionHandlers.hello = (iframe: HTMLIFrameElement, data: any, respond: Function) => {
+    // Make iframe responsive
+    iframe.style.width = '100%';
+
+    // Bugfix for Chrome: Force update of iframe width. If this is not done the
+    // document size may not be updated before the content resizes.
+    iframe.getBoundingClientRect();
+
+    // Tell iframe that it needs to resize when our window resizes
+    var resize = function () {
+        if (iframe.contentWindow) {
+            // Limit resize calls to avoid flickering
+            respond('resize');
+        }
+        else {
+            // Frame is gone, unregister.
+            window.removeEventListener('resize', resize);
+        }
+    };
+    window.addEventListener('resize', resize, false);
+
+    // Respond to let the iframe know we can resize it
+    respond('hello');
+};
+
+/**
+ * Prepare iframe resize.
+ *
+ * @private
+ * @param {Object} iframe Element
+ * @param {Object} data Payload
+ * @param {Function} respond Send a response to the iframe
+ */
+actionHandlers.prepareResize = (iframe: HTMLIFrameElement, data: any, respond: Function) => {
+    // Do not resize unless page and scrolling differs
+    if (iframe.clientHeight !== data.scrollHeight ||
+        data.scrollHeight !== data.clientHeight) {
+
+        // Reset iframe height, in case content has shrinked.
+        iframe.style.height = data.clientHeight + 'px';
+        respond('resizePrepared');
+    }
+};
+
+/**
+ * Resize parent and iframe to desired height.
+ *
+ * @private
+ * @param {Object} iframe Element
+ * @param {Object} data Payload
+ * @param {Function} respond Send a response to the iframe
+ */
+actionHandlers.resize = (iframe: HTMLIFrameElement, data: any) => {
+    // Resize iframe so all content is visible. Use scrollHeight to make sure we get everything
+    iframe.style.height = data.scrollHeight + 'px';
+};
+
+
+// Listen for messages from iframes
+window.addEventListener('message', (event) => {
+    if (event.data.context !== 'h5p') {
+        return; // Only handle h5p requests.
+    }
+
+    // Find out who sent the message
+    var iframe, iframes = document.getElementsByTagName('iframe');
+    for (var i = 0; i < iframes.length; i++) {
+        if (iframes[i].contentWindow === event.source) {
+            iframe = iframes[i];
+            break;
+        }
+    }
+
+    if (!iframe) {
+        return; // Cannot find sender
+    }
+
+    // Find action handler handler
+    if (actionHandlers[event.data.action]) {
+        actionHandlers[event.data.action](iframe, event.data, (action: string, data: any) => {
+            if (data === undefined) {
+                data = {};
+            }
+            data.action = action;
+            data.context = 'h5p';
+            (event.source.postMessage as any)(data, event.origin);
+        });
+    }
+}, false);
+
+// Let h5p iframes know we're ready!
+export function prepareH5POn(iframe: HTMLIFrameElement) {
+    const ready = {
+        context: 'h5p',
+        action: 'ready'
+    };
+    if (iframe.src.indexOf('h5p') !== -1) {
+        iframe.contentWindow.postMessage(ready, '*');
+    }
+}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/h5p.ts
@@ -70,7 +70,6 @@ actionHandlers.resize = (iframe: HTMLIFrameElement, data: any) => {
     }
 };
 
-
 // Listen for messages from iframes
 window.addEventListener('message', (event) => {
     if (event.data.context !== 'h5p') {


### PR DESCRIPTION
Addds H5P resizing supports to the materials dinamically

It is able to combine it with the lazy loader and the fact scripts are blocked by using its own custom h5p resizer based on the original wordpress based one that has been rewritten into typescript with some tweaks to make it dynamic and speak the H5P protocol.

The original H5P resizer was designed for a static website.

Fixes #5130 