### PR TITLE
Restricted materials behind login fix

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
@@ -45,6 +45,11 @@ interface ContentState {
   materials: MaterialContentNodeListType;
 }
 
+/**
+ * isScrolledIntoView
+ * @param el
+ * @returns
+ */
 function isScrolledIntoView(el: HTMLElement) {
   let rect = el.getBoundingClientRect();
   let elemTop = rect.top;
@@ -85,16 +90,31 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     this.onDropBetweenSubnodes = this.onDropBetweenSubnodes.bind(this);
     this.onDropBetweenSections = this.onDropBetweenSections.bind(this);
   }
+
+  /**
+   * componentDidUpdate
+   * @param prevProps
+   */
   componentDidUpdate(prevProps: ContentProps) {
     if (prevProps.activeNodeId !== this.props.activeNodeId) {
       this.refresh();
     }
   }
+
+  /**
+   * componentWillReceiveProps
+   * @param nextProps
+   */
   componentWillReceiveProps(nextProps: ContentProps) {
     this.setState({
       materials: nextProps.materials,
     });
   }
+
+  /**
+   * refresh
+   * @param props
+   */
   refresh(props: ContentProps = this.props) {
     const tocElement = this.refs[props.activeNodeId] as TocElement;
     if (tocElement) {
@@ -108,6 +128,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       }
     }
   }
+
+  /**
+   * hotInsertBeforeSection
+   * @param baseIndex
+   * @param targetBeforeIndex
+   */
   hotInsertBeforeSection(baseIndex: number, targetBeforeIndex: number) {
     const newMaterialState = [...this.state.materials];
     newMaterialState.splice(baseIndex, 1);
@@ -142,6 +168,14 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       });
     };
   }
+
+  /**
+   * hotInsertBeforeSubnode
+   * @param parentBaseIndex
+   * @param baseIndex
+   * @param parentTargetBeforeIndex
+   * @param targetBeforeIndex
+   */
   hotInsertBeforeSubnode(
     parentBaseIndex: number,
     baseIndex: number,
@@ -216,6 +250,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       });
     };
   }
+
+  /**
+   * onInteractionBetweenSections
+   * @param base
+   * @param target
+   */
   onInteractionBetweenSections(
     base: MaterialContentNodeType,
     target: MaterialContentNodeType
@@ -229,6 +269,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       )
     );
   }
+
+  /**
+   * onDropBetweenSections
+   * @param base
+   * @param target
+   */
   onDropBetweenSections(
     base: MaterialContentNodeType,
     target: MaterialContentNodeType
@@ -236,6 +282,13 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     this.storedLastUpdateServerExecution && this.storedLastUpdateServerExecution();
     delete this.storedLastUpdateServerExecution;
   }
+
+  /**
+   * onInteractionBetweenSubnodes
+   * @param base
+   * @param target
+   * @returns
+   */
   onInteractionBetweenSubnodes(
     base: MaterialContentNodeType,
     target: MaterialContentNodeType | number
@@ -270,6 +323,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       targetBeforeIndex
     );
   }
+
+  /**
+   * onDropBetweenSubnodes
+   * @param base
+   * @param target
+   */
   onDropBetweenSubnodes(
     base: MaterialContentNodeType,
     target: MaterialContentNodeType | number
@@ -277,6 +336,11 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     this.storedLastUpdateServerExecution && this.storedLastUpdateServerExecution();
     delete this.storedLastUpdateServerExecution;
   }
+
+  /**
+   * render
+   * @returns
+   */
   render() {
     if (!this.props.materials || !this.props.materials.length) {
       return null;
@@ -293,17 +357,21 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
         {this.state.materials.map((node, nodeIndex) => {
           const isSectionViewRestricted =
             node.viewRestrict === "LOGGED_IN" && !this.props.isLoggedIn;
+
           const isSectionViewRestrictedVisible =
             node.viewRestrict === "LOGGED_IN" && !this.props.isStudent;
-          let icon: string = isSectionViewRestrictedVisible
+
+          const iconTopic: string = isSectionViewRestrictedVisible
             ? "restriction"
             : null;
-          let iconTitle: string = isSectionViewRestrictedVisible
+
+          const iconTitleTopic: string = isSectionViewRestrictedVisible
             ? this.props.i18n.text.get(
                 "plugin.workspace.materialViewRestricted"
               )
             : null;
-          let className: string = isSectionViewRestrictedVisible
+
+          const classNameTopic: string = isSectionViewRestrictedVisible
             ? "toc__section-container--view-restricted"
             : "toc__section-container";
 
@@ -317,47 +385,42 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
                   ? null
                   : "s-" + node.workspaceMaterialId
               }
-              className={className}
-              iconAfter={icon}
-              iconAfterTitle={iconTitle}
+              className={classNameTopic}
+              iconAfter={iconTopic}
+              iconAfterTitle={iconTitleTopic}
             >
               {node.children
                 .map((subnode) => {
                   if (isSectionViewRestricted) {
                     return null;
                   }
+
                   const isViewRestrictedVisible =
                     subnode.viewRestrict === "LOGGED_IN" &&
                     !this.props.isStudent;
 
-                  let isAssignment = subnode.assignmentType === "EVALUATED";
-                  let isExercise = subnode.assignmentType === "EXERCISE";
+                  const isAssignment = subnode.assignmentType === "EVALUATED";
+                  const isExercise = subnode.assignmentType === "EXERCISE";
 
                   //this modifier will add the --assignment or --exercise to the list so you can add the border style with it
-                  let modifier = isAssignment
+                  const modifier = isAssignment
                     ? "assignment"
                     : isExercise
                     ? "exercise"
                     : null;
-                  let icon: string = isViewRestrictedVisible
-                    ? "restriction"
-                    : null;
-                  let iconTitle: string = isViewRestrictedVisible
-                    ? this.props.i18n.text.get(
-                        "plugin.workspace.materialViewRestricted"
-                      )
-                    : null;
-                  let className: string = isViewRestrictedVisible
-                    ? "toc__item--view-restricted"
-                    : null;
 
-                  let compositeReplies =
+                  let icon: string | null = null;
+                  let iconTitle: string | null = null;
+                  let className: string | null = null;
+
+                  const compositeReplies =
                     this.props.materialReplies &&
                     this.props.materialReplies.find(
                       (reply) =>
                         reply.workspaceMaterialId ===
                         subnode.workspaceMaterialId
                     );
+
                   if (compositeReplies) {
                     switch (compositeReplies.state) {
                       case "ANSWERED":
@@ -406,6 +469,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
                       default:
                         break;
                     }
+                  }
+
+                  if(isViewRestrictedVisible) {
+                    icon = "restriction";
+                    className = "toc__item--view-restricted";
+                    iconTitle = this.props.i18n.text.get("plugin.workspace.materialViewRestricted")
                   }
 
                   const pageElement = (
@@ -507,6 +576,11 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
   }
 }
 
+/**
+ * mapStateToProps
+ * @param state
+ * @returns
+ */
 function mapStateToProps(state: StateType) {
   return {
     i18n: state.i18n,
@@ -520,6 +594,11 @@ function mapStateToProps(state: StateType) {
   };
 }
 
+/**
+ * mapDispatchToProps
+ * @param dispatch
+ * @returns
+ */
 function mapDispatchToProps(dispatch: Dispatch<any>) {
   return bindActionCreators(
     { updateWorkspaceMaterialContentNode, setWholeWorkspaceMaterials },


### PR DESCRIPTION
- Restricted materials behind login now correctly prioritizes rectricted
  icon for logged admin users over checked icon if excercise is done also
- Contains some minor code cleaning
- content.tsx (workspace materials)

Resolves #5519 