### PR TITLE
fixed drag and drop

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
@@ -66,6 +66,7 @@ function isScrolledIntoView(el: HTMLElement) {
 
 class ContentComponent extends React.Component<ContentProps, ContentState> {
   private storedLastUpdateServerExecution: Function;
+  private originalMaterials: MaterialContentNodeListType;
 
   constructor(props: ContentProps) {
     super(props);
@@ -73,6 +74,8 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     this.state = {
       materials: props.materials,
     };
+
+    this.originalMaterials = props.materials;
 
     this.hotInsertBeforeSection = this.hotInsertBeforeSection.bind(this);
     this.hotInsertBeforeSubnode = this.hotInsertBeforeSubnode.bind(this);
@@ -118,7 +121,8 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     );
     const contentNodesRepaired = repairContentNodes(newMaterialState);
 
-    const material = this.state.materials[baseIndex];
+    const materialFromState = this.state.materials[baseIndex];
+    const material = this.originalMaterials.find((cn) => cn.workspaceMaterialId === materialFromState.workspaceMaterialId);
     const update = contentNodesRepaired.find(
       (cn) => cn.workspaceMaterialId === material.workspaceMaterialId
     );
@@ -137,6 +141,7 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
         },
         success: () => {
           this.props.setWholeWorkspaceMaterials(contentNodesRepaired);
+          this.originalMaterials = contentNodesRepaired;
         },
         dontTriggerReducerActions: true,
       });
@@ -182,7 +187,8 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
       baseIndex
     ].workspaceMaterialId;
 
-    const material = this.state.materials[parentBaseIndex].children[baseIndex];
+    const materialFromState = this.state.materials[baseIndex];
+    const material = this.originalMaterials.find((cn) => cn.workspaceMaterialId === materialFromState.workspaceMaterialId);
     const update = repariedNodes[parentTargetBeforeIndex].children.find(
       (cn: MaterialContentNodeType) =>
         cn.workspaceMaterialId === material.workspaceMaterialId
@@ -211,6 +217,7 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
         },
         success: () => {
           this.props.setWholeWorkspaceMaterials(repariedNodes);
+          this.originalMaterials = repariedNodes;
         },
         dontTriggerReducerActions: true,
       });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
@@ -183,12 +183,12 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     }
 
     const repariedNodes = repairContentNodes(newMaterialState);
-    const workspaceId = this.state.materials[parentBaseIndex].children[
-      baseIndex
-    ].workspaceMaterialId;
+    const materialParentFromState = this.state.materials[parentBaseIndex];
+    const materialFromState = materialParentFromState.children[baseIndex];
+    const workspaceId = materialFromState.workspaceMaterialId;
 
-    const materialFromState = this.state.materials[baseIndex];
-    const material = this.originalMaterials.find((cn) => cn.workspaceMaterialId === materialFromState.workspaceMaterialId);
+    const materialParent = this.originalMaterials.find((cn) => cn.workspaceMaterialId === materialParentFromState.workspaceMaterialId);
+    const material = materialParent.children.find((cn) => cn.workspaceMaterialId === materialFromState.workspaceMaterialId);
     const update = repariedNodes[parentTargetBeforeIndex].children.find(
       (cn: MaterialContentNodeType) =>
         cn.workspaceMaterialId === material.workspaceMaterialId


### PR DESCRIPTION
The drag and drop event triggers twice, the computer is too fast when debugger is not open so react has no time to re-render and the drag function catches twice.

This update stores the original material state into a variable rather than relying on the react state which might be off-sync.