### PR TITLE
Fixed calculation of the material from the source

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
@@ -221,8 +221,15 @@ class ContentComponent extends React.Component<ContentProps, ContentState> {
     const materialFromState = materialParentFromState.children[baseIndex];
     const workspaceId = materialFromState.workspaceMaterialId;
 
-    const materialParent = this.originalMaterials.find((cn) => cn.workspaceMaterialId === materialParentFromState.workspaceMaterialId);
-    const material = materialParent.children.find((cn) => cn.workspaceMaterialId === materialFromState.workspaceMaterialId);
+    let material: MaterialContentNodeType;
+    this.originalMaterials.forEach((cn) => {
+      cn.children.forEach((ccn) => {
+        if (ccn.workspaceMaterialId === materialFromState.workspaceMaterialId) {
+          material = ccn;
+        }
+      });
+    });
+
     const update = repariedNodes[parentTargetBeforeIndex].children.find(
       (cn: MaterialContentNodeType) =>
         cn.workspaceMaterialId === material.workspaceMaterialId


### PR DESCRIPTION
Fixes the calculation of the material from the source of original materials that caused it to be unable to find the original material from the list.

Now it is capable of switching subnodes in sections.