### PR TITLE
Indexing clarifications

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/SchoolDataSearchReindexListener.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/SchoolDataSearchReindexListener.java
@@ -24,12 +24,9 @@ import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
 import fi.otavanopisto.muikku.plugins.communicator.CommunicatorController;
 import fi.otavanopisto.muikku.plugins.communicator.model.CommunicatorMessage;
 import fi.otavanopisto.muikku.schooldata.WorkspaceEntityController;
-import fi.otavanopisto.muikku.schooldata.entity.UserGroup;
-import fi.otavanopisto.muikku.search.SearchIndexer;
 import fi.otavanopisto.muikku.search.SearchReindexEvent;
 import fi.otavanopisto.muikku.search.SearchReindexEvent.Task;
 import fi.otavanopisto.muikku.users.UserEntityController;
-import fi.otavanopisto.muikku.users.UserGroupController;
 import fi.otavanopisto.muikku.users.UserGroupEntityController;
 
 @ApplicationScoped
@@ -46,9 +43,6 @@ public class SchoolDataSearchReindexListener {
   private UserEntityController userEntityController;
 
   @Inject
-  private UserGroupController userGroupController;
-
-  @Inject
   private UserGroupEntityController userGroupEntityController;
 
   @Inject
@@ -58,17 +52,17 @@ public class SchoolDataSearchReindexListener {
   private CommunicatorController communicatorController;
 
   @Inject
-  private SearchIndexer indexer;
-
-  @Inject
   private UserIndexer userIndexer;
 
+  @Inject
+  private UserGroupIndexer userGroupIndexer;
+  
   @Inject
   private WorkspaceIndexer workspaceIndexer;
 
   @Inject
   private CommunicatorMessageIndexer communicatorMessageIndexer;
-
+  
   @Resource
   private TimerService timerService;
 
@@ -211,7 +205,7 @@ public class SchoolDataSearchReindexListener {
 
   private boolean reindexUserGroups() {
     try {
-      List<UserGroupEntity> userGroups = userGroupEntityController.listUserGroupEntities();
+      List<UserGroupEntity> userGroups = userGroupEntityController.listAllUserGroupEntities();
       int groupIndex = getOffset("groupIndex");
 
       if (groupIndex < userGroups.size()) {
@@ -219,14 +213,11 @@ public class SchoolDataSearchReindexListener {
 
         for (int i = groupIndex; i < last; i++) {
           UserGroupEntity groupEntity = userGroups.get(i);
-
-          UserGroup userGroup = userGroupController.findUserGroup(groupEntity.getSchoolDataSource(), groupEntity.getIdentifier());
-
           try {
-            indexer.index(UserGroup.class.getSimpleName(), userGroup);
+            userGroupIndexer.indexUserGroup(groupEntity);
           }
           catch (Exception e) {
-            logger.log(Level.WARNING, "could not index UserGroup #" + groupEntity.getSchoolDataSource() + '/' + groupEntity.getIdentifier(), e);
+            logger.log(Level.WARNING, "could not index UserGroup " + groupEntity.schoolDataIdentifier().toString(), e);
           }
         }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserGroupIndexer.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserGroupIndexer.java
@@ -1,0 +1,58 @@
+package fi.otavanopisto.muikku.plugins.search;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
+import fi.otavanopisto.muikku.model.users.UserGroupEntity;
+import fi.otavanopisto.muikku.schooldata.SchoolDataBridgeSessionController;
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
+import fi.otavanopisto.muikku.schooldata.entity.UserGroup;
+import fi.otavanopisto.muikku.search.SearchIndexer;
+import fi.otavanopisto.muikku.users.UserGroupController;
+
+public class UserGroupIndexer {
+  
+  @Inject
+  private Logger logger;
+  
+  @Inject
+  private SchoolDataBridgeSessionController schoolDataBridgeSessionController;
+
+  @Inject
+  private UserGroupController userGroupController;
+  
+  @Inject
+  private SearchIndexer indexer;
+  
+  public void indexUserGroup(UserGroupEntity userGroupEntity) {
+    indexUserGroup(userGroupEntity.schoolDataIdentifier());
+  }
+  
+  public void indexUserGroup(SchoolDataIdentifier userGroupIdentifier) {
+    schoolDataBridgeSessionController.startSystemSession();
+    try {
+      UserGroup userGroup = userGroupController.findUserGroup(userGroupIdentifier);
+      if (userGroup != null) {
+        indexer.index(UserGroup.class.getSimpleName(), userGroup);
+      } else {
+        logger.info(String.format("Removing user group %s from index", userGroupIdentifier.getIdentifier(), userGroupIdentifier.getDataSource()));
+        removeUserGroup(userGroupIdentifier);
+      }
+    } catch (Exception ex) {
+      logger.log(Level.SEVERE, "Indexing of user group identifier " + userGroupIdentifier.getIdentifier() + " failed.", ex);
+    } finally {
+      schoolDataBridgeSessionController.endSystemSession();
+    } 
+  }
+
+  public void removeUserGroup(SchoolDataIdentifier userGroupIdentifier) {
+    try {
+      indexer.remove(UserGroup.class.getSimpleName(), String.format("%s/%s", userGroupIdentifier.getIdentifier(), userGroupIdentifier.getDataSource()));
+    } catch (Exception ex) {
+      logger.log(Level.SEVERE, String.format("Removal of user %s/%s from index failed", userGroupIdentifier.getDataSource(), userGroupIdentifier.getIdentifier()), ex);
+    } 
+  }
+
+}

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserGroupIndexer.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserGroupIndexer.java
@@ -27,7 +27,11 @@ public class UserGroupIndexer {
   private SearchIndexer indexer;
   
   public void indexUserGroup(UserGroupEntity userGroupEntity) {
-    indexUserGroup(userGroupEntity.schoolDataIdentifier());
+    if (!userGroupEntity.getArchived()) {
+      indexUserGroup(userGroupEntity.schoolDataIdentifier());
+    } else {
+      removeUserGroup(userGroupEntity.schoolDataIdentifier());
+    }
   }
   
   public void indexUserGroup(SchoolDataIdentifier userGroupIdentifier) {
@@ -37,7 +41,7 @@ public class UserGroupIndexer {
       if (userGroup != null) {
         indexer.index(UserGroup.class.getSimpleName(), userGroup);
       } else {
-        logger.info(String.format("Removing user group %s from index", userGroupIdentifier.getIdentifier(), userGroupIdentifier.getDataSource()));
+        logger.info(String.format("Removing user group %s from index (not found from school data source)", userGroupIdentifier));
         removeUserGroup(userGroupIdentifier);
       }
     } catch (Exception ex) {

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedCommunicatorMessage.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedCommunicatorMessage.java
@@ -8,48 +8,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import fi.otavanopisto.muikku.search.annotations.IndexId;
 import fi.otavanopisto.muikku.search.annotations.Indexable;
-import fi.otavanopisto.muikku.search.annotations.IndexableFieldOption;
 
-@Indexable (
-  name = "IndexedCommunicatorMessage",
-    options = {
-      @IndexableFieldOption (
-        name = "communicatorMessageThreadId",
-        type = "Long",
-        index = "not_analyzed"
-      ),
-      @IndexableFieldOption (
-        name = "senderId",
-        type = "long",
-        index = "not_analyzed"
-      ),
-      @IndexableFieldOption (
-        name = "sender",
-        type = "IndexedCommunicatorMessageSender",
-        index = "not_analyzed"
-      ),
-      @IndexableFieldOption (
-        name = "recipients",
-        type = "List<IndexedCommunicatorMessageRecipient>",
-        index = "not_analyzed"
-      ),
-      @IndexableFieldOption (
-          name = "groupRecipients",
-          type = "List<IndexedCommunicatorMessageGroupRecipient>",
-          index = "not_analyzed"
-        ),
-      @IndexableFieldOption (
-        name = "searchId",
-        type = "Long",
-        index = "not_analyzed"
-      ),
-      @IndexableFieldOption (
-        name = "created",
-        type = "Date",
-        index = "not_analyzed"
-     )
-   }
-)
+@Indexable (name = "IndexedCommunicatorMessage")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IndexedCommunicatorMessage {
   

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/users/UserGroupEntityController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/users/UserGroupEntityController.java
@@ -156,6 +156,10 @@ public class UserGroupEntityController {
     return userGroupEntityDAO.listByUserIdentifierExcludeArchived(userSchoolDataIdentifier);
   }
   
+  public List<UserGroupEntity> listAllUserGroupEntities() {
+    return userGroupEntityDAO.listAll();
+  }
+  
   public List<UserGroupEntity> listUserGroupEntities() {
     List<UserGroupEntity> userGroups = userGroupEntityDAO.listByArchived(Boolean.FALSE);
     if (!organizationEntityController.canCurrentUserAccessAllOrganizations()) {


### PR DESCRIPTION
- Removed definitions from indexed communicator messages where the defined types were not supported by the indexing mechanism
- Changed User Group indexing to have the same layout as other indexers also fixing an issue with permissions within