### PR TITLE
Deduplication of edits in worklist

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/profile.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/profile.ts
@@ -637,7 +637,7 @@ const editProfileWorklistItem: EditProfileWorklistItemTriggerType = function del
         });
 
         if (itemWithMoreIndex === -1) {
-          newItems = [...newSummary.items, newWorklistItem];
+          newItems = [...newItems, newWorklistItem];
         } else {
           newItems.splice(itemWithMoreIndex, 0, newWorklistItem);
         }


### PR DESCRIPTION
Somehow the wrong original variable without the removing the obsolete value was being used resulting in duplication with items of the same id.

This most likely went through the gaps because the error only occurred if the modification was on the last element.

This is the fix.

Fixes #5695 