### PR TITLE
Removed study program selection 

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/organization/dialogs/edit-student.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/organization/dialogs/edit-student.tsx
@@ -194,6 +194,8 @@ class OrganizationUser extends React.Component<
         <DialogRow modifiers="new-user">
           {/* This is a mandatory field in creation, it's a very rigid validation and the backend does not provide it, so for no, it is commented from this dialog
           <SSNFormElement value={this.} modifiers="new-user" label={this.props.i18n.text.get('plugin.organization.users.addUser.label.SSN')} updateField={this.updateField} /> */}
+
+          {/* Removed for now as study programe change is more complex in Pyramus than this dropdown sets it to be.
           <SelectFormElement
             id="editStudent"
             valid={this.state.studyProgrammeIdentifierValid}
@@ -217,7 +219,7 @@ class OrganizationUser extends React.Component<
                   </option>
                 );
               })}
-          </SelectFormElement>
+            </SelectFormElement>*/}
         </DialogRow>
       </div>
     );


### PR DESCRIPTION
Resolves #5721

This removes study program selection from edit student dialog at organization management as the operation the select field was meant to provide is way more complex to be done merely by selecting different study program.

Branch name is misleading as the scope of the issue was changed after branch creation.