### PR TITLE
Showing correct answers with examples to students regardles of the answers state

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/select-field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/select-field.tsx
@@ -152,14 +152,13 @@ export default class SelectField extends React.Component<SelectFieldProps, Selec
 
     //Select field is able to mark what were meant to be the correct answers in the field itself
     let markcorrectAnswers = false;
+
     //It also has a summary component of what the correct answers were meant to be
     let correctAnswersummaryComponent = null;
-    //the classic variable
-    let answerIsCheckedAndItisCorrect = this.props.checkAnswers && this.state.answerState === "PASS"
 
     //So we only care about this logic if we didn't get the answer right and we are asking for show the right thing
     //Note that a state of UNKNOWN also goes through here, but not a state of PASS
-    if (this.props.displayCorrectAnswers && !answerIsCheckedAndItisCorrect){
+    if (this.props.displayCorrectAnswers){
       //find the correct answers from the list
       let correctAnswersFound = this.props.content.options.filter(a=>a.correct);
       //if we have some correct answers


### PR DESCRIPTION
Resolves #5221 

Idea is to show exercises correct answers regardless whether the answer state is PASS or FAIL. Previously we showed the correct answers with examples only when the answer was incorrect.