### PR TITLE
5748 math editor stack

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -217,6 +217,7 @@
     max-width: 700px;
     min-width: 650px;
     order: 1;
+    z-index: 100;
   }
 
   @include breakpoint($breakpoint-desktop-xl) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -92,7 +92,7 @@
 
 .content-panel__content {
 
-  @include breakpoint($breakpoint-pad) {
+  @include breakpoint($breakpoint-desktop) {
     display: flex;
     flex-flow: row nowrap;
   }


### PR DESCRIPTION
Resolves #5748 

This PR fixes issue with math editors toolbar z-index stack. It use to open to the top of the page but stayed behind ToC in desktop modes. This PR fixes the z-index of content-panel__main-container in desktop resolution as in tablet/mobile the ToC is hidden and accessible via drawer functionality.

This PR also solves one issue with pad resolution with content-panel__content elements incorrect display property that caused material view not to render properly when it's contain was not contained within the view port. Usually tables that were too wide caused unwanted page overflow.