### PR TITLE
Fixes filenames with exotic characters that break http header

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2016,7 +2017,6 @@ public class WorkspaceRESTService extends PluginRESTService {
         return Response.status(Status.FORBIDDEN).build();
       }
     }
-    
     byte[] content = answerFile.getContent();
     if (content == null) {
       Long userEntityId = workspaceMaterialReply.getUserEntityId();
@@ -2038,15 +2038,17 @@ public class WorkspaceRESTService extends PluginRESTService {
     if (content == null) {
       return Response.status(Status.NOT_FOUND).build();
     }
+    
+    String filename = new String(answerFile.getFileName().getBytes(Charset.forName("US-ASCII")));
     if (StringUtils.isEmpty(answerFile.getContentType())) {
       return Response.ok(content)
-        .header("Content-Disposition", "attachment; filename=\"" + answerFile.getFileName().replaceAll("\"", "\\\"") + "\"")
+        .header("Content-Disposition", "attachment; filename=\"" + filename.replaceAll("\"", "\\\"") + "\"")
         .build();
     }
     else {
       return Response.ok(content)
         .type(answerFile.getContentType())
-        .header("Content-Disposition", "attachment; filename=\"" + answerFile.getFileName().replaceAll("\"", "\\\"") + "\"")
+        .header("Content-Disposition", "attachment; filename=\"" + filename.replaceAll("\"", "\\\"") + "\"")
         .build();
     }
   }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -5,6 +5,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -2038,18 +2040,23 @@ public class WorkspaceRESTService extends PluginRESTService {
     if (content == null) {
       return Response.status(Status.NOT_FOUND).build();
     }
-    
-    String filename = new String(answerFile.getFileName().getBytes(Charset.forName("US-ASCII")));
-    if (StringUtils.isEmpty(answerFile.getContentType())) {
-      return Response.ok(content)
-        .header("Content-Disposition", "attachment; filename=\"" + filename.replaceAll("\"", "\\\"") + "\"")
-        .build();
-    }
-    else {
-      return Response.ok(content)
-        .type(answerFile.getContentType())
-        .header("Content-Disposition", "attachment; filename=\"" + filename.replaceAll("\"", "\\\"") + "\"")
-        .build();
+    String filename = new String(answerFile.getFileName().getBytes(Charset.forName("US-ASCII"))).replaceAll("\"", "\\\"");
+    try {
+      String encFilename = URLEncoder.encode(answerFile.getFileName(), "utf-8").replaceAll("\\+", "%20").replaceAll("\"", "\\\"");
+      if (StringUtils.isEmpty(answerFile.getContentType())) {
+        return Response.ok(content)
+          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"; filename*=utf-8\"" + encFilename + "\"")
+          .build();
+      }
+      else {
+        return Response.ok(content)
+          .type(answerFile.getContentType())
+          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"; filename*=utf-8''\"" + encFilename + "\"")
+          .build();
+      }
+    } catch (UnsupportedEncodingException e) {
+      logger.warning("Unsupported character encoding: " + e.getMessage());
+      return Response.status(Status.INTERNAL_SERVER_ERROR).build();
     }
   }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -2045,7 +2045,7 @@ public class WorkspaceRESTService extends PluginRESTService {
       String encFilename = URLEncoder.encode(answerFile.getFileName(), "utf-8").replaceAll("\\+", "%20").replaceAll("\"", "\\\"");
       if (StringUtils.isEmpty(answerFile.getContentType())) {
         return Response.ok(content)
-          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"; filename*=utf-8\"" + encFilename + "\"")
+          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"; filename*=utf-8''\"" + encFilename + "\"")
           .build();
       }
       else {

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -2040,8 +2040,8 @@ public class WorkspaceRESTService extends PluginRESTService {
     if (content == null) {
       return Response.status(Status.NOT_FOUND).build();
     }
-    String filename = new String(answerFile.getFileName().getBytes(Charset.forName("US-ASCII"))).replaceAll("\"", "\\\"");
     try {
+      String filename = new String(answerFile.getFileName().getBytes(Charset.forName("US-ASCII"))).replaceAll("\"", "\\\"");
       String encFilename = URLEncoder.encode(answerFile.getFileName(), "utf-8").replaceAll("\\+", "%20").replaceAll("\"", "\\\"");
       if (StringUtils.isEmpty(answerFile.getContentType())) {
         return Response.ok(content)


### PR DESCRIPTION
Resolves #5852  

- Converts filename into US-ASCII encoded string as other encodings are not really fully supported in header filename in all browsers