### PR TITLE
Fixed potentially mobile issues with evaluation modal's overflowing buttons

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/dialog.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/dialog.scss
@@ -405,7 +405,7 @@
   }
 
   .dialog__content {
-    height: calc(100vh - 100px);
+    height: 100%;
     padding: 0;
   }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/evaluation.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/evaluation.scss
@@ -9,7 +9,7 @@
   background: $color-evaluation-modal-background;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 55px);
+  height: calc(100% - 55px);
   margin: 55px 0 0;
   overflow: auto;
   padding: 0 0 40px;
@@ -89,7 +89,7 @@
 
 .evaluation-modal__content-wrapper {
   @include breakpoint($breakpoint-desktop) {
-    height: calc(100vh - 55px);
+    height: calc(100% - 55px);
     overflow-y: scroll;
   }
 }
@@ -516,7 +516,7 @@
   display: flex;
   justify-content: space-between;
   min-height: 30px;
-  padding: 10px 0;
+  padding: 12px 0;
   position: relative;
   white-space: nowrap;
   width: 100%;
@@ -573,7 +573,7 @@
 }
 
 .evaluation-modal__evaluate-drawer-content {
-  height: calc(100vh - 55px);
+  height: calc(100% - 55px);
   overflow: auto;
   overscroll-behavior: contain;
   padding: 10px;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/voice-recorder.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/voice-recorder.scss
@@ -144,6 +144,7 @@
   flex-shrink: 1;
   height: 1.75rem;
   max-width: 100%;
+  min-width: 0; // This overrides browser's min-width value for <audio> tags. Without it, download and delete recording icons would overflow browser's viewport with narrow screens
 }
 
 .voice-recorder__file--recording,


### PR DESCRIPTION
Closes #5827 

Main requirement for mobile devices full screen usage is not to use vh values with height property. When mobile device renders something full screen within the browser and url address bar and possible browser buttons reserves some of thatt browsers viewport area. 

If using `height: 100vh` browsers does not adjust their reported viewport height when pulling up the url address bar and/or button bar, therefore small portion of the page will overflow the screen and is inaccessible. Using height: 100% instead fixes this.

It also seems that using height 100% i evaluation modal views everything works perfectly fine with desktop browsers also.