### PR TITLE
Fixes timed notifications not working properly

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/AssesmentRequestNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/AssesmentRequestNotificationController.java
@@ -29,10 +29,10 @@ public class AssesmentRequestNotificationController {
   @Inject
   private AssessmentRequestNotificationDAO assessmentRequestNotificationDAO;
   
-  public SearchResult searchActiveStudentIds(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore){
+  public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, null, null, false, true, true, 
-        firstResult, maxResults, Collections.singleton("id"), excludeSchoolDataIdentifiers, startedStudiesBefore);
+        firstResult, maxResults, null, excludeSchoolDataIdentifiers, startedStudiesBefore);
   }
   
   public AssesmentRequestNotification createAssesmentRequestNotification(SchoolDataIdentifier studentIdentifier){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NeverLoggedInNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NeverLoggedInNotificationController.java
@@ -29,10 +29,10 @@ public class NeverLoggedInNotificationController {
   @Inject
   private NeverLoggedInNotificationDAO neverLoggedInNotificationDAO;
   
-  public SearchResult searchActiveStudentIds(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date studiesStartedBefore){
+  public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date studiesStartedBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, 
-        null, null, false, true, true, firstResult, maxResults, Collections.singleton("id"), excludeSchoolDataIdentifiers, 
+        null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, 
         studiesStartedBefore, null);
   }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoPassedCoursesNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoPassedCoursesNotificationController.java
@@ -37,7 +37,7 @@ public class NoPassedCoursesNotificationController {
   @Inject
   private SchoolDataBridgeSessionController schoolDataBridgeSessionController;
   
-  public SearchResult searchActiveStudentIds(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore){
+  public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     
     return searchProvider.searchUsers(
@@ -53,7 +53,7 @@ public class NoPassedCoursesNotificationController {
         true,   // only default users 
         firstResult, 
         maxResults, 
-        Collections.singleton("id"), 
+        null, 
         excludeSchoolDataIdentifiers, 
         startedStudiesBefore);
   }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/RequestedAssessmentSupplementationsNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/RequestedAssessmentSupplementationsNotificationController.java
@@ -27,10 +27,10 @@ public class RequestedAssessmentSupplementationsNotificationController {
   @Inject
   private RequestedAssessmentSupplementationNotificationDAO requestedAssessmentSupplementationNotificationDAO;
   
-  public SearchResult searchActiveStudentIds(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults){
+  public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, null, null, false, true, false, 
-        firstResult, maxResults, Collections.singleton("id"));
+        firstResult, maxResults, null);
   }
   
   public RequestedAssessmentSupplementationNotification createRequestedAssessmentSupplementationNotification(SchoolDataIdentifier studentIdentifier, SchoolDataIdentifier workspaceIdentifier){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/StudyTimeLeftNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/StudyTimeLeftNotificationController.java
@@ -29,11 +29,10 @@ public class StudyTimeLeftNotificationController {
   @Inject
   private StudyTimeNotificationDAO studyTimeNotificationDAO;
   
-  public SearchResult searchActiveStudentIds(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date studyTimeEndsBefore){
+  public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date studyTimeEndsBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, 
-        null, null, false, true, true, firstResult, maxResults, Collections.singleton("id"), excludeSchoolDataIdentifiers, 
-        null, studyTimeEndsBefore);
+        null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, null, studyTimeEndsBefore);
   }
 
   public List<SchoolDataIdentifier> listNotifiedSchoolDataIdentifiersAfter(Date date){

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/AssessmentRequestNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/AssessmentRequestNotificationStrategy.java
@@ -93,7 +93,7 @@ public class AssessmentRequestNotificationStrategy extends AbstractTimedNotifica
     // Get a batch of students that have been studying for more than 60 days
     
     Date since = Date.from(OffsetDateTime.now().minusDays(NOTIFICATION_THRESHOLD_DAYS).toInstant());
-    SearchResult searchResult = assesmentRequestNotificationController.searchActiveStudentIds(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifiersAlreadyNotified, since);
+    SearchResult searchResult = assesmentRequestNotificationController.searchActiveStudents(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifiersAlreadyNotified, since);
     logger.log(Level.INFO, String.format("%s processing %d/%d", getClass().getSimpleName(), offset, searchResult.getTotalHitCount()));
 
     if ((offset + MAX_RESULTS) > searchResult.getTotalHitCount()) {

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/NeverLoggedInNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/NeverLoggedInNotificationStrategy.java
@@ -135,7 +135,7 @@ public class NeverLoggedInNotificationStrategy extends AbstractTimedNotification
 
     Date thresholdDate = Date.from(OffsetDateTime.now().minusDays(NOTIFICATION_THRESHOLD_DAYS).toInstant());
     List<SchoolDataIdentifier> studentIdentifierAlreadyNotified = neverLoggedInNotificationController.listNotifiedSchoolDataIdentifiersAfter(thresholdDate);
-    SearchResult searchResult = neverLoggedInNotificationController.searchActiveStudentIds(
+    SearchResult searchResult = neverLoggedInNotificationController.searchActiveStudents(
         getActiveOrganizations(),
         groups,
         FIRST_RESULT,

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/NoPassedCoursesNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/NoPassedCoursesNotificationStrategy.java
@@ -117,7 +117,7 @@ public class NoPassedCoursesNotificationStrategy extends AbstractTimedNotificati
     
     Date thresholdDate = Date.from(OffsetDateTime.now().minusDays(NOTIFICATION_THRESHOLD_DAYS).toInstant());
     List<SchoolDataIdentifier> studentIdentifierAlreadyNotified = noPassedCoursesNotificationController.listNotifiedSchoolDataIdentifiersAfter(thresholdDate);
-    SearchResult searchResult = noPassedCoursesNotificationController.searchActiveStudentIds(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifierAlreadyNotified, thresholdDate);
+    SearchResult searchResult = noPassedCoursesNotificationController.searchActiveStudents(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifierAlreadyNotified, thresholdDate);
     logger.log(Level.INFO, String.format("%s processing %d/%d", getClass().getSimpleName(), offset, searchResult.getTotalHitCount()));
     
     if ((offset + MAX_RESULTS) > searchResult.getTotalHitCount()) {

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/RequestedAssessmentSupplementationsNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/RequestedAssessmentSupplementationsNotificationStrategy.java
@@ -104,7 +104,7 @@ public class RequestedAssessmentSupplementationsNotificationStrategy extends Abs
     
     // Iterate through active students who belong to pre-configured groups (read: study programs)
     
-    SearchResult searchResult = requestedAssessmentSupplementationsNotificationController.searchActiveStudentIds(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS);
+    SearchResult searchResult = requestedAssessmentSupplementationsNotificationController.searchActiveStudents(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS);
     logger.log(Level.INFO, String.format("%s processing %d/%d", getClass().getSimpleName(), offset, searchResult.getTotalHitCount()));
     
     if ((offset + MAX_RESULTS) > searchResult.getTotalHitCount()) {

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/StudyTimeNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/StudyTimeNotificationStrategy.java
@@ -38,10 +38,10 @@ import fi.otavanopisto.muikku.users.UserEntityName;
 public class StudyTimeNotificationStrategy extends AbstractTimedNotificationStrategy {
 
   private static final int FIRST_RESULT = 0;
-  private static final int MAX_RESULTS = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.maxresults", "20"));
+  private static final int MAX_RESULTS = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.maxresults", "200"));
   private static final int DAYS_UNTIL_FIRST_NOTIFICATION = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.daysuntilfirstnotification", "60"));
   private static final int NOTIFICATION_THRESHOLD_DAYS_LEFT = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.notificationthreshold", "30"));
-  private static final long NOTIFICATION_CHECK_FREQ = NumberUtils.createLong(System.getProperty("muikku.timednotifications.studytime.checkfreq", "1800000"));
+  private static final long NOTIFICATION_CHECK_FREQ = NumberUtils.createLong(System.getProperty("muikku.timednotifications.studytime.checkfreq", "15000"));//"1800000"));
   
   @Inject
   private StudyTimeLeftNotificationController studyTimeLeftNotificationController;
@@ -86,7 +86,7 @@ public class StudyTimeNotificationStrategy extends AbstractTimedNotificationStra
     Date studyTimeEnds = Date.from(studyTimeEndsOdt.toInstant());
     Date lastNotifiedThresholdDate = Date.from(OffsetDateTime.now().minusDays(NOTIFICATION_THRESHOLD_DAYS_LEFT + 1).toInstant());
     List<SchoolDataIdentifier> studentIdentifierAlreadyNotified = studyTimeLeftNotificationController.listNotifiedSchoolDataIdentifiersAfter(lastNotifiedThresholdDate);
-    SearchResult searchResult = studyTimeLeftNotificationController.searchActiveStudentIds(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifierAlreadyNotified, studyTimeEnds);
+    SearchResult searchResult = studyTimeLeftNotificationController.searchActiveStudents(getActiveOrganizations(), groups, FIRST_RESULT + offset, MAX_RESULTS, studentIdentifierAlreadyNotified, studyTimeEnds);
     logger.log(Level.INFO, String.format("%s processing %d/%d", getClass().getSimpleName(), offset, searchResult.getTotalHitCount()));
     
     if ((offset + MAX_RESULTS) > searchResult.getTotalHitCount()) {

--- a/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/StudyTimeNotificationStrategy.java
+++ b/muikku-timed-notifications-plugin/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/strategies/StudyTimeNotificationStrategy.java
@@ -38,10 +38,10 @@ import fi.otavanopisto.muikku.users.UserEntityName;
 public class StudyTimeNotificationStrategy extends AbstractTimedNotificationStrategy {
 
   private static final int FIRST_RESULT = 0;
-  private static final int MAX_RESULTS = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.maxresults", "200"));
+  private static final int MAX_RESULTS = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.maxresults", "20"));
   private static final int DAYS_UNTIL_FIRST_NOTIFICATION = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.daysuntilfirstnotification", "60"));
   private static final int NOTIFICATION_THRESHOLD_DAYS_LEFT = NumberUtils.createInteger(System.getProperty("muikku.timednotifications.studytime.notificationthreshold", "30"));
-  private static final long NOTIFICATION_CHECK_FREQ = NumberUtils.createLong(System.getProperty("muikku.timednotifications.studytime.checkfreq", "15000"));//"1800000"));
+  private static final long NOTIFICATION_CHECK_FREQ = NumberUtils.createLong(System.getProperty("muikku.timednotifications.studytime.checkfreq", "1800000"));
   
   @Inject
   private StudyTimeLeftNotificationController studyTimeLeftNotificationController;


### PR DESCRIPTION
- fixes #5933

Notifications asked for Elastic fields that weren't included in the search results. Fixed by returning all fields rather than just id field.