### PR TITLE
* Added permission checks for products and students orders

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/CeeposPermissions.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/CeeposPermissions.java
@@ -16,7 +16,7 @@ import fi.otavanopisto.security.Scope;
 public class CeeposPermissions  extends AbstractMuikkuPermissionCollection implements MuikkuPermissionCollection {
 
   @Scope (PermissionScope.ENVIRONMENT)
-  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER } )
+  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER } )
   public static final String CREATE_ORDER = "CREATE_ORDER";
 
   @Scope (PermissionScope.ENVIRONMENT)
@@ -32,15 +32,15 @@ public class CeeposPermissions  extends AbstractMuikkuPermissionCollection imple
   public static final String PAY_ORDER = "PAY_ORDER";
   
   @Scope (PermissionScope.ENVIRONMENT)
-  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER } )
+  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER } )
   public static final String LIST_PRODUCTS = "LIST_PRODUCTS";
 
   @Scope (PermissionScope.ENVIRONMENT)
-  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER } )
+  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER } )
   public static final String FIND_ORDER = "FIND_ORDER";
 
   @Scope (PermissionScope.ENVIRONMENT)
-  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER, EnvironmentRoleArchetype.TEACHER } )
+  @DefaultEnvironmentPermissionRoles ( { EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER } )
   public static final String LIST_USER_ORDERS = "LIST_USER_ORDERS";
 
   @Override

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/rest/CeeposRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/rest/CeeposRESTService.java
@@ -617,8 +617,7 @@ public class CeeposRESTService {
    * DESCRIPTION:
    * 
    * Forces the completion of an order in progress. The order may NOT be in state
-   * COMPLETE. Forced order completion is only available for admins or the staff
-   * member who originally created the order.
+   * COMPLETE. Forced order completion is only available for admins.
    * 
    * @param orderId Order id  
    * 
@@ -626,7 +625,7 @@ public class CeeposRESTService {
    */
   @Path("/manualCompletion/{ORDERID}")
   @POST
-  @RESTPermit(handling = Handling.INLINE, requireLoggedIn = true)
+  @RESTPermit(CeeposPermissions.COMPLETE_ORDER)
   public Response completeOrder(@PathParam("ORDERID") Long orderId) {
 
     // Validate payload
@@ -641,16 +640,6 @@ public class CeeposRESTService {
     if (order == null) {
       logger.warning(String.format("Ceepos order %d: Not found", orderId));
       return Response.status(Status.NOT_FOUND).build();
-    }
-    
-    // Ensure order ownership
-
-    if (!sessionController.hasEnvironmentPermission(CeeposPermissions.COMPLETE_ORDER)) {
-      if (!order.getCreatorId().equals(sessionController.getLoggedUserEntity().getId())) {
-        logger.severe(String.format("Ceepos order %d: User %s access revoked", order.getId(), sessionController.getLoggedUser().toId()));
-        return Response.status(Status.FORBIDDEN).build();
-        
-      }
     }
     
     // Ensure order sate

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/base/status.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/base/status.ts
@@ -39,6 +39,13 @@ async function loadWhoAMI(dispatch: (arg: AnyActionType) => any, whoAmIReadyCb: 
         GUIDER_VIEW: whoAmI.permissions.includes("GUIDER_VIEW"),
         ORGANIZATION_VIEW: whoAmI.permissions.includes("ORGANIZATION_VIEW"),
         TRANSCRIPT_OF_RECORDS_VIEW: whoAmI.permissions.includes("TRANSCRIPT_OF_RECORDS_VIEW"),
+        LIST_USER_ORDERS: whoAmI.permissions.includes("LIST_USER_ORDERS"),
+        FIND_ORDER: whoAmI.permissions.includes("FIND_ORDER"),
+        REMOVE_ORDER: whoAmI.permissions.includes("REMOVE_ORDER"),
+        CREATE_ORDER: whoAmI.permissions.includes("CREATE_ORDER"),
+        PAY_ORDER: whoAmI.permissions.includes("PAY_ORDER"),
+        LIST_PRODUCTS: whoAmI.permissions.includes("LIST_PRODUCTS"),
+        COMPLETE_ORDER: whoAmI.permissions.includes("COMPLETE_ORDER")
       },
       profile: {
         addresses: (whoAmI.addresses && JSON.parse(whoAmI.addresses)) || [],

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/guider/index.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/guider/index.ts
@@ -223,6 +223,8 @@ let loadStudent: LoadStudentTriggerType = function loadStudent(id) {
     try {
       let currentUserSchoolDataIdentifier = getState().status.userSchoolDataIdentifier;
 
+      const canListUserOrders = getState().status.permissions.LIST_USER_ORDERS;
+
       dispatch({
         type: "LOCK_TOOLBAR",
         payload: null
@@ -264,13 +266,6 @@ let loadStudent: LoadStudentTriggerType = function loadStudent(id) {
           .then((files: Array<UserFileType>) => {
             dispatch({ type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: { property: "files", value: files } })
           }),
-        // Removed until it works correctly
-        // VOPS disabled until studies view redesign
-
-        //        promisify(mApi().records.vops.read(id), 'callback')()
-        //          .then((vops:VOPSDataType)=>{
-        //            dispatch({type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: {property: "vops", value: vops}})
-        //          }),
         promisify(mApi().records.hops.read(id), 'callback')()
           .then((hops: HOPSDataType) => {
             dispatch({ type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: { property: "hops", value: hops } })
@@ -309,9 +304,11 @@ let loadStudent: LoadStudentTriggerType = function loadStudent(id) {
           .then((activityLogs:ActivityLogType[])=>{
             dispatch({type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: {property: "activityLogs", value: activityLogs}});
         }),
-        promisify(mApi().ceepos.user.orders.read(id), "callback")().then((pOrders: PurchaseType[]) => {
-          dispatch({type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: {property: "purchases", value: pOrders}})
-        }),
+
+        (canListUserOrders &&
+          promisify(mApi().ceepos.user.orders.read(id), "callback")().then((pOrders: PurchaseType[]) => {
+            dispatch({type: "SET_CURRENT_GUIDER_STUDENT_PROP", payload: {property: "purchases", value: pOrders}})
+          })),
       ]);
 
       dispatch({

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application/current-student.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application/current-student.tsx
@@ -11,16 +11,15 @@ import '~/sass/elements/application-sub-panel.scss';
 import '~/sass/elements/avatar.scss';
 import '~/sass/elements/workspace-activity.scss';
 import { getUserImageUrl, getName } from '~/util/modifiers';
-import Vops from '~/components/base/vops';
 import Hops from '~/components/base/hops_readable';
 import FileDeleteDialog from '../../dialogs/file-delete';
 import Workspaces from './current-student/workspaces';
 import Ceepos from "./current-student/ceepos";
+import { StatusType } from "~/reducers/base/status";
 import FileUploader from '~/components/general/file-uploader';
 import MainChart from '~/components/general/graph/main-chart'
 import {
-  AddFileToCurrentStudentTriggerType, RemoveFileFromCurrentStudentTriggerType,
-  addFileToCurrentStudent
+  AddFileToCurrentStudentTriggerType, addFileToCurrentStudent
 } from '~/actions/main-function/guider';
 import { displayNotification, DisplayNotificationTriggerType } from '~/actions/base/notifications';
 import { UserFileType } from '~/reducers/user-index';
@@ -30,6 +29,7 @@ import { GuiderType, GuiderStudentUserProfileLabelType } from '~/reducers/main-f
 interface CurrentStudentProps {
   i18n: i18nType,
   guider: GuiderType,
+  status: StatusType,
   addFileToCurrentStudent: AddFileToCurrentStudentTriggerType,
   displayNotification: DisplayNotificationTriggerType
 }
@@ -205,7 +205,7 @@ class CurrentStudent extends React.Component<CurrentStudentProps, CurrentStudent
       <div className="application-sub-panel">
         {studentBasicInfo}
       </div>
-      {this.props.guider.currentStudent.basic && IsStudentPartOfProperStudyProgram(this.props.guider.currentStudent.basic.studyProgrammeName) ?
+      {this.props.guider.currentStudent.basic && IsStudentPartOfProperStudyProgram(this.props.guider.currentStudent.basic.studyProgrammeName) && this.props.status.permissions.LIST_USER_ORDERS ?
         <div className="application-sub-panel">
           <h3 className="application-sub-panel__header">{this.props.i18n.text.get("plugin.guider.user.details.purchases")}</h3>
           <div className="application-sub-panel__body">
@@ -242,7 +242,8 @@ class CurrentStudent extends React.Component<CurrentStudentProps, CurrentStudent
 function mapStateToProps(state: StateType) {
   return {
     i18n: state.i18n,
-    guider: state.guider
+    guider: state.guider,
+    status: state.status
   }
 };
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application/current-student/ceepos.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application/current-student/ceepos.tsx
@@ -314,20 +314,23 @@ class Ceepos extends React.Component<CeeposProps, CeeposState> {
         {this.props.guider.availablePurchaseProducts && this.props.guider.availablePurchaseProducts.length ?
           <>
             <div className="application-sub-panel__description">{this.props.i18n.text.get("plugin.guider.createStudentOrder.description")}</div>
-            <Dropdown modifier="guider-products-selection" items={this.props.guider.availablePurchaseProducts.map((p) => {
-              return (closeDropdown: () => any) => {
-                return <Link className="link link--full link--purchasable-product-dropdown" onClick={this.beginOrderCreationProcess.bind(this, p, closeDropdown)}>
-                  <span className="link__icon icon-plus"></span>
-                  <span>{p.Description}</span>
-                </Link>
-              }
-            })}>
-              <Button
-                icon="cart-plus"
-                buttonModifiers={["create-student-order", "info"]}
-                disabled={IsOrderCreationDisabled}
-              >{this.props.i18n.text.get("plugin.guider.createStudentOrder.buttonLabel")}</Button>
-            </Dropdown>
+            {this.props.status.permissions.CREATE_ORDER ?
+              <Dropdown modifier="guider-products-selection" items={this.props.guider.availablePurchaseProducts.map((p) => {
+                return (closeDropdown: () => any) => {
+                  return <Link className="link link--full link--purchasable-product-dropdown" onClick={this.beginOrderCreationProcess.bind(this, p, closeDropdown)}>
+                    <span className="link__icon icon-plus"></span>
+                    <span>{p.Description}</span>
+                  </Link>
+                }
+              })}>
+                <Button
+                  icon="cart-plus"
+                  buttonModifiers={["create-student-order", "info"]}
+                  disabled={IsOrderCreationDisabled}
+                >{this.props.i18n.text.get("plugin.guider.createStudentOrder.buttonLabel")}</Button>
+              </Dropdown>
+            : null}
+
           </> : <div className="empty">
             <span>{this.props.i18n.text.get("plugin.guider.noPurchasableProducts")}</span>
           </div>
@@ -355,8 +358,8 @@ class Ceepos extends React.Component<CeeposProps, CeeposState> {
                   {p.state !== "COMPLETE" ?
                     <span className="application-list__header-primary-actions">
 
-                      {/* We show "Delete" button only if logged in user is ADMINISTRATOR or logged in user userEntityId is the same as purchase creator userId */}
-                      {this.props.status.role === "ADMINISTRATOR" || p.creator.userEntityId === this.props.status.userId ?
+                      {/* We show "Delete" button only if logged in user has REMOVE_ORDER permission or logged in user's userEntityId is the same as purchase creator userId */}
+                      {this.props.status.permissions.REMOVE_ORDER || p.creator.userEntityId === this.props.status.userId ?
                         <Button
                           onClick={this.beginOrderDeleteProcess.bind(this, p)}
                           disabled={IsOrderDeletionDisabled(p.state)}
@@ -365,7 +368,7 @@ class Ceepos extends React.Component<CeeposProps, CeeposState> {
                           >{this.props.i18n.text.get("plugin.guider.purchase.deleteOrderLink")}</Button>
                       : null}
 
-                      {/* We show "Complete order" button only if logged in user is ADMINISTRATOR */}
+                      {/* We show "Complete order" button only if logged in user has COMPLETE_ORDER permission */}
                       {this.props.status.role === "ADMINISTRATOR" ?
                         <Button
                           onClick={this.beginOrderManualCompleteProcess.bind(this, p)}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/main-function.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/main-function.tsx
@@ -592,7 +592,12 @@ export default class MainFunction extends React.Component<MainFunctionProps, {}>
       this.props.store.dispatch(titleActions.updateTitle(this.props.store.getState().i18n.text.get('plugin.guider.guider')));
       this.props.store.dispatch(updateLabelFilters() as Action);
       this.props.store.dispatch(updateWorkspaceFilters() as Action);
-      this.props.store.dispatch(updateAvailablePurchaseProducts() as Action);
+
+      // If user has LIST_USER_ORDERS permission then dispatchin is possible
+      if (this.props.store.getState().status.permissions.LIST_USER_ORDERS) {
+        this.props.store.dispatch(updateAvailablePurchaseProducts() as Action);
+      }
+
       this.props.store.dispatch(updateUserGroupFilters() as Action);
 
       this.loadGuiderData();


### PR DESCRIPTION
Closes #5982 

Added following permission mappings related to webstore functionality:
LIST_USER_ORDERS, FIND_ORDER, REMOVE_ORDER, CREATE_ORDER, PAY_ORDER, LIST_PRODUCTS, COMPLETE_ORDER

Order removal is no dependent on REMOVE_ORDER permission. Order completion still remain ad admin only feature.

Order creation is now dependent on CREATE_ORDER permission, also available purchases rely on the same permission.

LIST_USER_ORDERS permission is used to check whether we render <Ceepos> component inside Guider view. Also loadStudent function has check for the said permission so we don't try to load data logged-in user should not have access to.