### PR TITLE
Added database index on WorkspaceJournalEntry

### DIFF
--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceJournalEntry.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceJournalEntry.java
@@ -7,12 +7,19 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
 @Entity
+@Table (
+    indexes = {
+        @Index ( columnList = "workspaceEntityId, userEntityId, archived, created DESC" )
+    }
+)
 public class WorkspaceJournalEntry {
 
   public Long getWorkspaceEntityId() {

--- a/updates/1.116/220310_workspacejournalentry_index.xml
+++ b/updates/1.116/220310_workspacejournalentry_index.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<update xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ofw.fi/xml/2011/java-xmldb-updater/UpdaterSchema.xsd">
+  
+  <sql>create index IDX44j9b3afxovb09ytt0754h98u on WorkspaceJournalEntry (workspaceEntityId, userEntityId, archived, created);</sql>
+
+</update>


### PR DESCRIPTION
Index helps the queries in WorkspaceJournalEntryDAO that use workspaceEntityId, userEntityId, archived, created fields or a subset of them.