### PR TITLE
Fixed autocomplete overflowing over navbar

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/autocomplete.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/autocomplete.scss
@@ -6,7 +6,7 @@
   display: block;
   position: relative;
   width: 100%;
-  z-index: 99;
+  z-index: 98;
 }
 
 .autocomplete__input {


### PR DESCRIPTION
Fixed autocomplete overflowing over navbar by changes autocomplete container z-index value one step lower.

Resolves: #6094 