### PR TITLE
6096-pdf-in-the-materials-changes:

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/binary/pdf.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/binary/pdf.tsx
@@ -20,12 +20,20 @@ export default function Pdf(props: {
         data={`/rest/materials/binary/${props.material.materialId}/content`}
       >
         <Link
+          className="link"
           href={`/rest/materials/binary/${props.material.materialId}/content`}
           openInNewTab={props.material.title}
         >
           {props.i18n.text.get("plugin.workspace.materials.binaryDownload")}
         </Link>
       </object>
+      <Link
+        className="link link--download-pdf"
+        href={`/rest/materials/binary/${props.material.materialId}/content`}
+        openInNewTab={props.material.title}
+      >
+        {props.i18n.text.get("plugin.workspace.materials.binaryDownload")}
+      </Link>
     </div>
   );
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/link.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/link.scss
@@ -451,3 +451,11 @@
   padding: 0 5px;
   text-decoration: underline;
 }
+
+.link--download-pdf {
+  display: block;
+
+  @include breakpoint($breakpoint-desktop) {
+    display: none;
+  }
+}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/link.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/link.scss
@@ -454,8 +454,10 @@
 
 .link--download-pdf {
   display: block;
+  padding: 20px;
 
   @include breakpoint($breakpoint-desktop) {
     display: none;
+    padding: 0;
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/material-page.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/material-page.scss
@@ -135,14 +135,12 @@
   padding: 0;
 
   object {
+    display: none;
     height: 520px;
     width: 100%;
 
-    @include breakpoint($breakpoint-pad) {
-      height: 966px;
-    }
-
     @include breakpoint($breakpoint-desktop) {
+      display: inline;
       height: 840px;
     }
 


### PR DESCRIPTION
- Pdf problem is fixed by using styling to hide/showing link only in mobile and pad views
- The actual problem was only with apples device that did only show picture of pdf first page
but clicking picture didn't active download link at all

Resolves: #6096 