### PR TITLE
Deletes TravisCI build badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 muikku
 ======
-[![Build Status](https://travis-ci.org/otavanopisto/muikku.png?branch=devel)](https://travis-ci.org/otavanopisto/muikku)
 
 In English
 ---


### PR DESCRIPTION
Should be deleted since we don't use TravisCI anymore