### PR TITLE
Fixes to student visibility in Guider

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/chat/ChatSyncController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/chat/ChatSyncController.java
@@ -486,7 +486,8 @@ public class ChatSyncController {
         false,                    // includeHidden
         true,                     // onlyDefaultUsers
         0, 
-        Integer.MAX_VALUE);
+        Integer.MAX_VALUE,
+        false);                   // join groups and workspaces
     List<Map<String, Object>> results = result.getResults();
     for (Map<String, Object> o : results) {
       Long userEntityId = Long.valueOf(o.get("userEntityId").toString());

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRecipientsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRecipientsRESTService.java
@@ -174,7 +174,8 @@ public class CommunicatorRecipientsRESTService extends PluginRESTService {
           false,
           onlyDefaultUsers,
           firstResult, 
-          maxResults);
+          maxResults,
+          false);
       
       List<Map<String, Object>> results = result.getResults();
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
@@ -224,7 +224,7 @@ public class GuiderRESTService extends PluginRESTService {
     Set<Long> workspaceFilters = null;
 
     // #4585: By default, teachers should only see their own students
-    // #6170: Teachers used to see only their own workspaces' students. They shoud also see their own groups' students
+    // #6170: Teachers used to see only their own workspaces' students. They should also see their own groups' students
     
     boolean joinGroupsAndWorkspaces = false;
     EnvironmentRoleEntity roleEntity = userSchoolDataIdentifierController.findUserSchoolDataIdentifierRole(sessionController.getLoggedUser());

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
@@ -224,7 +224,7 @@ public class GuiderRESTService extends PluginRESTService {
     Set<Long> workspaceFilters = null;
 
     // #4585: By default, teachers should only see their own students
-    // #6170: Teachers should only be able to see their own students (either via workspace or usergroup)
+    // #6170: Teachers used to see only their own workspaces' students. They shoud also see their own groups' students
     
     boolean joinGroupsAndWorkspaces = false;
     EnvironmentRoleEntity roleEntity = userSchoolDataIdentifierController.findUserSchoolDataIdentifierRole(sessionController.getLoggedUser());

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
@@ -270,6 +270,8 @@ public class GuiderRESTService extends PluginRESTService {
       } else {
         userGroupFilters.addAll(accessibleUserGroupEntityIds);
       }
+      // Study guiders only have access to their groups' students, so even if group and workspace filters would
+      // be in effect, they are used to create an intersection result rather than a join result 
       joinGroupsAndWorkspaces = false;
     }
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
@@ -224,14 +224,14 @@ public class GuiderRESTService extends PluginRESTService {
     Set<Long> workspaceFilters = null;
 
     // #4585: By default, teachers should only see their own students
-    // #6170: Teachers and managers should only be able to see their own students (either via workspace or usergroup)
+    // #6170: Teachers should only be able to see their own students (either via workspace or usergroup)
     
     boolean joinGroupsAndWorkspaces = false;
     EnvironmentRoleEntity roleEntity = userSchoolDataIdentifierController.findUserSchoolDataIdentifierRole(sessionController.getLoggedUser());
     if (roleEntity == null) {
       return Response.status(Status.BAD_REQUEST).entity("Unknown role").build();
     }
-    if (roleEntity.getArchetype() == EnvironmentRoleArchetype.TEACHER || roleEntity.getArchetype() == EnvironmentRoleArchetype.MANAGER) {
+    if (roleEntity.getArchetype() == EnvironmentRoleArchetype.TEACHER) {
       myUserGroups = CollectionUtils.isEmpty(userGroupIds) && CollectionUtils.isEmpty(workspaceIds);
       myWorkspaces = CollectionUtils.isEmpty(userGroupIds) && CollectionUtils.isEmpty(workspaceIds);
       joinGroupsAndWorkspaces = myUserGroups && myWorkspaces;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/organizationmanagement/rest/OrganizationUserManagementRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/organizationmanagement/rest/OrganizationUserManagementRESTService.java
@@ -139,7 +139,8 @@ public class OrganizationUserManagementRESTService {
         false,             // includeHidden
         true,              // onlyDefaultUsers
         firstResult, 
-        maxResults);
+        maxResults,
+        false);            // join groups and workspaces
       
     List<Map<String, Object>> results = result.getResults();
 
@@ -250,7 +251,8 @@ public class OrganizationUserManagementRESTService {
         false,                                                // includeHidden
         true,                                                 // onlyDefaultUsers
         firstResult,
-        maxResults);
+        maxResults,
+        false);                                               // join groups and workspaces
 
     List<Map<String, Object>> results = result.getResults();
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/AssesmentRequestNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/AssesmentRequestNotificationController.java
@@ -32,7 +32,7 @@ public class AssesmentRequestNotificationController {
   public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, null, null, false, true, true, 
-        firstResult, maxResults, null, excludeSchoolDataIdentifiers, startedStudiesBefore);
+        firstResult, maxResults, null, excludeSchoolDataIdentifiers, startedStudiesBefore, false);
   }
   
   public AssesmentRequestNotification createAssesmentRequestNotification(SchoolDataIdentifier studentIdentifier){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NeverLoggedInNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NeverLoggedInNotificationController.java
@@ -33,7 +33,7 @@ public class NeverLoggedInNotificationController {
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, 
         null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, 
-        studiesStartedBefore, null);
+        studiesStartedBefore, null, false);
   }
 
   public List<SchoolDataIdentifier> listNotifiedSchoolDataIdentifiersAfter(Date date){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoLoggedInForTwoMonthsNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoLoggedInForTwoMonthsNotificationController.java
@@ -33,7 +33,7 @@ public class NoLoggedInForTwoMonthsNotificationController {
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, 
         null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, 
-        studiesStartedBefore, null);
+        studiesStartedBefore, null, false);
   }
 
   public List<SchoolDataIdentifier> listNotifiedSchoolDataIdentifiersAfter(Date date){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoPassedCoursesNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/NoPassedCoursesNotificationController.java
@@ -55,7 +55,8 @@ public class NoPassedCoursesNotificationController {
         maxResults, 
         null, 
         excludeSchoolDataIdentifiers, 
-        startedStudiesBefore);
+        startedStudiesBefore,
+        false); // join groups and workspaces
   }
   
   public Long countPassedCoursesByStudentIdentifierSince(SchoolDataIdentifier studentIdentifier, Date since) {

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/RequestedAssessmentSupplementationsNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/RequestedAssessmentSupplementationsNotificationController.java
@@ -30,7 +30,7 @@ public class RequestedAssessmentSupplementationsNotificationController {
   public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, null, null, false, true, false, 
-        firstResult, maxResults, null);
+        firstResult, maxResults, null, false);
   }
   
   public RequestedAssessmentSupplementationNotification createRequestedAssessmentSupplementationNotification(SchoolDataIdentifier studentIdentifier, SchoolDataIdentifier workspaceIdentifier){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/StudyTimeLeftNotificationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/timed/notifications/StudyTimeLeftNotificationController.java
@@ -32,7 +32,7 @@ public class StudyTimeLeftNotificationController {
   public SearchResult searchActiveStudents(List<OrganizationEntity> activeOrganizations, Collection<Long> groups, int firstResult, int maxResults, List<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date studyTimeEndsBefore){
     SearchProvider searchProvider = getProvider("elastic-search");
     return searchProvider.searchUsers(activeOrganizations, null, null, Collections.singleton(EnvironmentRoleArchetype.STUDENT), groups, 
-        null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, null, studyTimeEndsBefore);
+        null, null, false, true, true, firstResult, maxResults, null, excludeSchoolDataIdentifiers, null, studyTimeEndsBefore, false);
   }
 
   public List<SchoolDataIdentifier> listNotifiedSchoolDataIdentifiersAfter(Date date){

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -1196,7 +1196,7 @@ public class WorkspaceRESTService extends PluginRESTService {
         false,                                                    // only default users
         firstResult,                                              // first result
         maxResults,                                               // max results
-        false);                                                   // join gruops and workspaces
+        false);                                                   // join groups and workspaces
 
     List<Map<String, Object>> elasticUsers = searchResult.getResults();
 

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -1195,7 +1195,8 @@ public class WorkspaceRESTService extends PluginRESTService {
         true,                                                     // include hidden
         false,                                                    // only default users
         firstResult,                                              // first result
-        maxResults);                                              // max results
+        maxResults,                                               // max results
+        false);                                                   // join gruops and workspaces
 
     List<Map<String, Object>> elasticUsers = searchResult.getResults();
 
@@ -1296,7 +1297,8 @@ public class WorkspaceRESTService extends PluginRESTService {
         false,                                                    // include hidden
         false,                                                    // only default users
         0,                                                        // first result
-        Integer.MAX_VALUE);                                       // max results
+        Integer.MAX_VALUE,                                        // max results
+        false);                                                   // join groups and workspaces
     List<Map<String, Object>> elasticUsers = searchResult.getResults();
 
     List<WorkspaceUserRestModel> workspaceStaffMembers = new ArrayList<WorkspaceUserRestModel>();
@@ -2829,7 +2831,8 @@ public class WorkspaceRESTService extends PluginRESTService {
         true,                                                     // include hidden
         false,                                                    // only default users
         0,                                                        // first result
-        1);                                                       // max results
+        1,                                                        // max results
+        false);                                                   // join groups and workspaces
     List<Map<String, Object>> elasticUsers = searchResult.getResults();
     if (elasticUsers.isEmpty()) {
       return Response.status(Status.NOT_FOUND).build();

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/search/SearchProvider.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/search/SearchProvider.java
@@ -34,19 +34,19 @@ public interface SearchProvider {
   public SearchResult findUser(SchoolDataIdentifier identifier, boolean includeInactive);
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes, Collection<Long> groups,
       Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers, Boolean includeInactiveStudents, Boolean includeHidden,
-      Boolean onlyDefaultUsers, int start, int maxResults);
+      Boolean onlyDefaultUsers, int start, int maxResults, boolean joinGroupsAndWorkspaces);
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes, Collection<Long> groups,
       Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers, Boolean includeInactiveStudents, Boolean includeHidden,
-      Boolean onlyDefaultUsers, int start, int maxResults, Collection<String> fields);
+      Boolean onlyDefaultUsers, int start, int maxResults, Collection<String> fields, boolean joinGroupsAndWorkspaces);
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes, Collection<Long> groups,
       Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers, Boolean includeInactiveStudents, Boolean includeHidden,
       Boolean onlyDefaultUsers, int start, int maxResults, Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers,
-      Date startedStudiesBefore);
+      Date startedStudiesBefore, boolean joinGroupsAndWorkspaces);
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes,
       Collection<Long> groups, Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers,
       Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults,
       Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore,
-      Date studyTimeEndsBefore);
+      Date studyTimeEndsBefore, boolean joinGroupsAndWorkspaces);
 
   public SearchResult findUserGroup(SchoolDataIdentifier identifier);
   public SearchResult searchUserGroups(String searchTerm, String archetype, List<OrganizationEntity> organizations, int start, int maxResults);

--- a/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
+++ b/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
@@ -209,7 +209,7 @@ public class ElasticSearchProvider implements SearchProvider {
       Collection<Long> groups, Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers,
       Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults,
       Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers,
-      Date startedStudiesBefore, Date studyTimeEndsBefore) {
+      Date startedStudiesBefore, Date studyTimeEndsBefore, boolean joinGroupsAndWorkspaces) {
     try {
       long now = OffsetDateTime.now().toEpochSecond();
 
@@ -276,12 +276,23 @@ public class ElasticSearchProvider implements SearchProvider {
         query.must(termsQuery("organizationIdentifier.untouched", organizationIdentifiers.toArray()));
       }
 
-      if (groups != null) {
-        query.must(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))));
+      // #6170: If both group and workspace filters have been provided, possibly treat them as a join rather than an intersection
+      
+      if (groups != null && workspaces != null && joinGroupsAndWorkspaces) {
+        query.must(
+            boolQuery()
+            .should(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))))
+            .should(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))))
+          );
       }
+      else {
+        if (groups != null) {
+          query.must(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))));
+        }
 
-      if (workspaces != null) {
-        query.must(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))));
+        if (workspaces != null) {
+          query.must(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))));
+        }
       }
 
       if (userIdentifiers != null) {
@@ -385,25 +396,26 @@ public class ElasticSearchProvider implements SearchProvider {
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes,
       Collection<Long> groups, Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers,
       Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults,
-      Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore) {
+      Collection<String> fields, Collection<SchoolDataIdentifier> excludeSchoolDataIdentifiers, Date startedStudiesBefore, boolean joinGroupsAndWorkspaces) {
     return searchUsers(organizations, text, textFields, archetypes, groups, workspaces, userIdentifiers, includeInactiveStudents, includeHidden,
-        onlyDefaultUsers, start, maxResults, fields, excludeSchoolDataIdentifiers, startedStudiesBefore, null);
+        onlyDefaultUsers, start, maxResults, fields, excludeSchoolDataIdentifiers, startedStudiesBefore, null, joinGroupsAndWorkspaces);
   }
 
   @Override
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes,
       Collection<Long> groups, Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers,
-      Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults) {
+      Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults, boolean joinGroupsAndWorkspaces) {
     return searchUsers(organizations, text, textFields, archetypes, groups, workspaces, userIdentifiers, includeInactiveStudents, includeHidden,
-        onlyDefaultUsers, start, maxResults, null, null, null);
+        onlyDefaultUsers, start, maxResults, null, null, null, joinGroupsAndWorkspaces);
   }
 
   @Override
   public SearchResult searchUsers(List<OrganizationEntity> organizations, String text, String[] textFields, Collection<EnvironmentRoleArchetype> archetypes,
       Collection<Long> groups, Collection<Long> workspaces, Collection<SchoolDataIdentifier> userIdentifiers,
-      Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults, Collection<String> fields) {
+      Boolean includeInactiveStudents, Boolean includeHidden, Boolean onlyDefaultUsers, int start, int maxResults, Collection<String> fields,
+      boolean joinGroupsAndWorkspaces) {
     return searchUsers(organizations, text, textFields, archetypes, groups, workspaces, userIdentifiers, includeInactiveStudents, includeHidden,
-        onlyDefaultUsers, start, maxResults, fields, null, null);
+        onlyDefaultUsers, start, maxResults, fields, null, null, joinGroupsAndWorkspaces);
   }
 
   private Set<Long> getActiveWorkspaces() {

--- a/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
+++ b/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
@@ -443,7 +443,7 @@ public class UserRESTService extends AbstractRESTService {
       OrganizationEntity organization = userSchoolDataIdentifier.getOrganization();
       
       SearchResult result = elasticSearchProvider.searchUsers(Arrays.asList(organization), searchString, fields, Arrays.asList(EnvironmentRoleArchetype.STUDENT), 
-          userGroupFilters, workspaceFilters, userIdentifiers, includeInactiveStudents, true, false, firstResult, maxResults);
+          userGroupFilters, workspaceFilters, userIdentifiers, includeInactiveStudents, true, false, firstResult, maxResults, false);
       
       List<Map<String, Object>> results = result.getResults();
 
@@ -1317,7 +1317,8 @@ public class UserRESTService extends AbstractRESTService {
           false,
           onlyDefaultUsers,
           firstResult, 
-          maxResults);
+          maxResults,
+          false);
       
       List<Map<String, Object>> results = result.getResults();
 
@@ -1837,7 +1838,8 @@ public class UserRESTService extends AbstractRESTService {
           false,
           false,
           firstResult, 
-          maxResults);
+          maxResults,
+          false);
       
       List<Map<String, Object>> results = result.getResults();
 


### PR DESCRIPTION
- fixed a bug in which teachers could only see students of their own workspaces but not of their own groups
- fixed a bug in which study guiders could click their own workspace in Guider but the view would crash if that workspace had any students that were not in the groups of the study guider
- fixed a bug which caused lag due to an unnecessary Pyramus call for each student shown in Guider
- resolves #6170