### PR TITLE
Communicator message open bug resolved

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/main-function/messages.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/main-function/messages.ts
@@ -430,10 +430,6 @@ export default function messages(
       selectedThreadsIds: state.selectedThreadsIds.concat([
         newThread.communicatorMessageId,
       ]),
-      toggleSelectAllMessageItemsActive:
-        state.selectedThreads.length === state.threads.length - 1
-          ? true
-          : false,
     });
   } else if (action.type === "REMOVE_FROM_MESSAGES_SELECTED_THREADS") {
     return Object.assign({}, state, {
@@ -573,19 +569,28 @@ export default function messages(
       currentThread: newCurrent,
     });
   } else if (action.type === "DELETE_MESSAGE_THREAD") {
+    const updatedThreads = state.threads.filter(
+      (thread: MessageThreadType) =>
+        thread.communicatorMessageId !== action.payload.communicatorMessageId
+    );
+
+    const updatedSelectedThreads = state.selectedThreads.filter(
+      (selectedThread: MessageThreadType) =>
+        selectedThread.communicatorMessageId !==
+        action.payload.communicatorMessageId
+    );
+
+    const updatedSelectedThreadsIds = state.selectedThreadsIds.filter(
+      (id: number) => id !== action.payload.communicatorMessageId
+    );
+
     return Object.assign({}, state, {
-      selectedThreads: state.selectedThreads.filter(
-        (selectedThread: MessageThreadType) =>
-          selectedThread.communicatorMessageId !==
-          action.payload.communicatorMessageId
-      ),
-      threads: state.threads.filter(
-        (thread: MessageThreadType) =>
-          thread.communicatorMessageId !== action.payload.communicatorMessageId
-      ),
-      selectedThreadsIds: state.selectedThreadsIds.filter(
-        (id: number) => id !== action.payload.communicatorMessageId
-      ),
+      threads: updatedThreads,
+      selectedThreads: updatedSelectedThreads,
+      selectedThreadsIds: updatedSelectedThreadsIds,
+      toggleSelectAllMessageItemsActive: state.toggleSelectAllMessageItemsActive
+        ? updatedThreads.length > 0
+        : false,
     });
   } else if (action.type === "SET_CURRENT_MESSAGE_THREAD") {
     return Object.assign({}, state, {


### PR DESCRIPTION
Communicator message open bug resolved. It was caused by toggleAllThreads property which didn't go off if there was 0 messages after deleting last one and with that said there were situations where active toggleAllThreads affect other functionalities which lead to this original bug.

Resolves: #6176 