### PR TITLE
* Removed unnecesary his.props.openInNewTab conditional from profile …

### DIFF
--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/tor/ToRTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/tor/ToRTestsBase.java
@@ -325,7 +325,7 @@ public class ToRTestsBase extends AbstractUITest {
         findElementOrReloadAndFind(".item-list--student-councelors .item-list__user-name", 5, 5000);
         assertTextIgnoreCase(".item-list--student-councelors .item-list__user-name", "Admin User");
         assertTextIgnoreCase(".item-list--student-councelors .item-list__user-email", "admin@example.com");
-        assertTextIgnoreCase(".button--contact-student-councelor", "Lähetä viesti");
+        assertPresent(".item-list--student-councelors .button-pill--new-message");
         
         waitForPresent(".application-sub-panel__card-header--summary-evaluated");
         assertTextIgnoreCase(".application-sub-panel__card-header--summary-evaluated", "Kurssisuoritukset");

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/link.tsx
@@ -237,6 +237,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
     delete elementProps["disableScroll"];
     delete elementProps["as"];
     delete elementProps["disableSmoothScroll"];
+    delete elementProps["i18n"];
 
     if (
       (elementProps.href == null &&

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/profile-item.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/navbar/profile-item.tsx
@@ -79,18 +79,6 @@ class ProfileItem extends React.Component<ProfileItemProps, ProfileItemState> {
           >
             <span className={`link__icon icon-${item.icon}`}></span>
             <span>{this.props.i18n.text.get(item.text)}</span>
-
-            {item.openInNewTab && (
-              <>
-                <span className="visually-hidden">
-                  {this.props.i18n.text.get("plugin.wcag.externalLink.label")}
-                </span>
-                <span
-                  role="presentation"
-                  className="external-link-indicator icon-external-link"
-                />
-              </>
-            )}
           </Link>
         ))}
       >

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/whatsapp-link.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/whatsapp-link.tsx
@@ -81,6 +81,9 @@ export const WhatsappButtonLink: React.FC<WhatsappLinkProps> = (props) => {
 
   return (
     <ButtonPill
+      aria-label={i18n.text.get(
+        "plugin.profile.whatsappIntegration.button.label"
+      )}
       icon="whatsapp"
       title={i18n.text.get("plugin.profile.whatsappIntegration.button.label")}
       buttonModifiers="whatsapp-me"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/records/body/application/summary.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/records/body/application/summary.tsx
@@ -16,6 +16,7 @@ import { StateType } from "~/reducers";
 import MainChart from "~/components/general/graph/main-chart";
 import CommunicatorNewMessage from "~/components/communicator/dialogs/new-message";
 import Button from "~/components/general/button";
+import { ButtonPill } from "~/components/general/button";
 import moment from "~/lib/moment";
 import { StatusType } from "~/reducers/base/status";
 import Avatar from "~/components/general/avatar";
@@ -28,7 +29,7 @@ import {
 import { AnyActionType } from "~/actions";
 import { bindActionCreators } from "redux";
 import Notes from "~/components/general/notes/notes";
-import { WhatsappLink } from "~/components/general/whatsapp-link";
+import { WhatsappButtonLink } from "~/components/general/whatsapp-link";
 
 /**
  * SummaryProps
@@ -198,20 +199,20 @@ class Summary extends React.Component<SummaryProps, SummaryState> {
                                   },
                                 ]}
                               >
-                                <Button
-                                  buttonModifiers={[
-                                    "info",
-                                    "contact-student-councelor",
-                                  ]}
-                                >
-                                  {this.props.i18n.text.get(
+                                <ButtonPill
+                                  icon="envelope"
+                                  aria-label={this.props.i18n.text.get(
                                     "plugin.records.contactStudentCouncelor.message.label"
                                   )}
-                                </Button>
+                                  title={this.props.i18n.text.get(
+                                    "plugin.records.contactStudentCouncelor.message.label"
+                                  )}
+                                  buttonModifiers="new-message"
+                                ></ButtonPill>
                               </CommunicatorNewMessage>
                               {councelor.properties["profile-phone"] &&
                               councelor.properties["profile-whatsapp"] ? (
-                                <WhatsappLink
+                                <WhatsappButtonLink
                                   i18n={this.props.i18n}
                                   mobileNumber={
                                     councelor.properties["profile-phone"]
@@ -221,22 +222,22 @@ class Summary extends React.Component<SummaryProps, SummaryState> {
                               {councelor.properties[
                                 "profile-appointmentCalendar"
                               ] ? (
-                                <Button
+                                <ButtonPill
+                                  aria-label={this.props.i18n.text.get(
+                                    "plugin.records.contactStudentCouncelor.appointmentCalendar.label"
+                                  )}
+                                  title={this.props.i18n.text.get(
+                                    "plugin.records.contactStudentCouncelor.appointmentCalendar.label"
+                                  )}
+                                  icon="clock"
+                                  buttonModifiers="appointment-calendar"
+                                  openInNewTab="_blank"
                                   href={
                                     councelor.properties[
                                       "profile-appointmentCalendar"
                                     ]
                                   }
-                                  openInNewTab="_blank"
-                                  buttonModifiers={[
-                                    "info",
-                                    "appointment-calendar",
-                                  ]}
-                                >
-                                  {this.props.i18n.text.get(
-                                    "plugin.records.contactStudentCouncelor.appointmentCalendar.label"
-                                  )}
-                                </Button>
+                                />
                               ) : null}
                             </div>
                           </div>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHome/teachers.tsx
@@ -161,6 +161,9 @@ class WorkspaceTeachers extends React.Component<
                           )}
                         >
                           <ButtonPill
+                            aria-label={this.props.i18n.text.get(
+                              "plugin.workspace.index.newMessage.label"
+                            )}
                             icon="envelope"
                             title={this.props.i18n.text.get(
                               "plugin.workspace.index.newMessage.label"
@@ -182,6 +185,9 @@ class WorkspaceTeachers extends React.Component<
                           teacher.properties["profile-appointmentCalendar"] !==
                             null && (
                             <ButtonPill
+                              aria-label={this.props.i18n.text.get(
+                                "plugin.workspace.index.appointmentCalendar.label"
+                              )}
                               title={this.props.i18n.text.get(
                                 "plugin.workspace.index.appointmentCalendar.label"
                               )}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
@@ -1950,12 +1950,12 @@
 
   &:hover,
   &.hover {
-    background: darken($color-whatsapp-dark, 10%);
+    background: darken($color-info, 10%);
   }
 
   &:active,
   &.active {
-    background: darken($color-whatsapp-dark, 10%);
+    background: darken($color-info, 10%);
   }
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
@@ -815,6 +815,14 @@
     width: 100%;
   }
 
+  // This needs to be added here as we place external-link-indicator
+  // automatically to every button and anchor element that opens up a new tab/window.
+  // This way we only hide the indicator in button-pill element and avoid making
+  // unnecessary conditional to the button and/or link component.
+  .external-link-indicator {
+    display: none;
+  }
+
   @include breakpoint($breakpoint-pad) {
     font-size: $button-pill-desktop-font-size;
     height: $button-pill-desktop-size;
@@ -952,7 +960,6 @@
 .button-pill--restore,
 .button-pill--edit,
 .button-pill--create-contact-log-entry,
-.button-pill--new-message,
 .button-pill--filter,
 .button-pill--add-note {
   background-color: $color-main-function-button-pill-delete-background;
@@ -1934,9 +1941,30 @@
   }
 }
 
+.button-pill--new-message {
+  background: $color-info;
+  color: $color-default;
+  font-size: 1.125rem;
+  height: 2rem;
+  width: 2rem;
+
+  &:hover,
+  &.hover {
+    background: darken($color-whatsapp-dark, 10%);
+  }
+
+  &:active,
+  &.active {
+    background: darken($color-whatsapp-dark, 10%);
+  }
+}
+
 .button-pill--whatsapp-me {
   background: $color-whatsapp-dark;
   color: $color-default;
+  font-size: 1.25rem;
+  height: 2rem;
+  width: 2rem;
 
   &:hover,
   &.hover {
@@ -1952,6 +1980,9 @@
 .button-pill--appointment-calendar {
   background: $color-appointment-calendar-button-background;
   color: $color-default;
+  font-size: 1.25rem;
+  height: 2rem;
+  width: 2rem;
 
   &:hover,
   &.hover {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
@@ -2094,7 +2094,6 @@
 .button--whatsapp-me {
   background: linear-gradient($color-whatsapp-light, $color-whatsapp-dark);
   color: $color-default;
-  font-size: 0.75rem;
   margin: 0 0 0 10px;
 }
 


### PR DESCRIPTION
Closes #6207 

After adding external link icon handling to <Link> component we forgot to remove the same conditional from profile menu and this caused menu to have double icons if link was meant to open in new tab/window.

This PR contains few other ninja fixes also regarding buttons and external link icon.