### PR TITLE
Workspace users data loads data again between page changes

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/workspace.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/workspace.tsx
@@ -140,6 +140,7 @@ export default class Workspace extends React.Component<
       this.loadWorkspaceAnnouncerData.bind(this);
     this.loadWorkspaceMaterialsData =
       this.loadWorkspaceMaterialsData.bind(this);
+    this.loadWorkspaceUsersData = this.loadWorkspaceUsersData.bind(this);
     this.loadWorkspaceHelpData = this.loadWorkspaceHelpData.bind(this);
     this.closeEnrollmentDialog = this.closeEnrollmentDialog.bind(this);
     this.closeSignupDialog = this.closeSignupDialog.bind(this);
@@ -254,6 +255,8 @@ export default class Workspace extends React.Component<
           );
         }
       }
+    } else if (window.location.pathname.includes("/users")) {
+      this.loadWorkspaceUsersData();
     }
   }
 
@@ -559,7 +562,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceAnnouncements
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceAnnouncements(props: RouteComponentProps<any>) {
@@ -597,7 +600,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceAnnouncer
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceAnnouncer(props: RouteComponentProps<any>) {
@@ -653,7 +656,7 @@ export default class Workspace extends React.Component<
 
   /**
    * loadWorkspaceDiscussionData
-   * @param location
+   * @param location location
    */
   loadWorkspaceDiscussionData(location: string[]) {
     if (location.length <= 2) {
@@ -683,7 +686,7 @@ export default class Workspace extends React.Component<
 
   /**
    * loadWorkspaceAnnouncementsData
-   * @param announcementId
+   * @param announcementId announcementId
    */
   loadWorkspaceAnnouncementsData(announcementId: number) {
     this.props.store.dispatch(loadAnnouncement(null, announcementId) as Action);
@@ -691,7 +694,7 @@ export default class Workspace extends React.Component<
 
   /**
    * loadWorkspaceAnnouncerData
-   * @param location
+   * @param location location
    */
   loadWorkspaceAnnouncerData(location: string[]) {
     const actualLocation = location.filter((l) => !!l);
@@ -716,7 +719,7 @@ export default class Workspace extends React.Component<
 
   /**
    * loadWorkspaceMaterialsData
-   * @param id
+   * @param id id
    */
   loadWorkspaceMaterialsData(id: number): void {
     if (id) {
@@ -728,7 +731,7 @@ export default class Workspace extends React.Component<
 
   /**
    * loadWorkspaceHelpData
-   * @param id
+   * @param id id
    */
   loadWorkspaceHelpData(id: number): void {
     if (id) {
@@ -739,8 +742,56 @@ export default class Workspace extends React.Component<
   }
 
   /**
+   * loadWorkspaceUsersData
+   */
+  loadWorkspaceUsersData(): void {
+    const state = this.props.store.getState();
+
+    this.props.store.dispatch(
+      setCurrentWorkspace({
+        workspaceId: state.status.currentWorkspaceId,
+        /**
+         * success
+         * @param workspace workspace
+         */
+        success: (workspace) => {
+          if (!workspace.staffMembers && state.status.loggedIn) {
+            this.props.store.dispatch(
+              loadStaffMembersOfWorkspace({ workspace }) as Action
+            );
+          }
+          if (state.status.permissions.WORSKPACE_LIST_WORKSPACE_MEMBERS) {
+            this.props.store.dispatch(
+              loadStudentsOfWorkspace({
+                workspace,
+                payload: {
+                  q: "",
+                  firstResult: 0,
+                  maxResults: 10,
+                  active: true,
+                },
+              }) as Action
+            );
+            this.props.store.dispatch(
+              loadStudentsOfWorkspace({
+                workspace,
+                payload: {
+                  q: "",
+                  firstResult: 0,
+                  maxResults: 10,
+                  active: false,
+                },
+              }) as Action
+            );
+          }
+        },
+      }) as Action
+    );
+  }
+
+  /**
    * renderWorkspaceMaterials
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceMaterials(props: RouteComponentProps<any>) {
@@ -919,7 +970,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceUsers
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceUsers(props: RouteComponentProps<any>) {
@@ -942,50 +993,7 @@ export default class Workspace extends React.Component<
           state.i18n.text.get("plugin.workspace.users.pageTitle")
         )
       );
-      this.props.store.dispatch(
-        setCurrentWorkspace({
-          workspaceId: state.status.currentWorkspaceId,
-          /**
-           * success
-           * @param workspace workspace
-           */
-          success: (workspace) => {
-            if (!workspace.staffMembers && state.status.loggedIn) {
-              this.props.store.dispatch(
-                loadStaffMembersOfWorkspace({ workspace }) as Action
-              );
-            }
-            if (
-              !workspace.students &&
-              state.status.permissions.WORSKPACE_LIST_WORKSPACE_MEMBERS
-            ) {
-              this.props.store.dispatch(
-                loadStudentsOfWorkspace({
-                  workspace,
-                  payload: {
-                    q: "",
-                    firstResult: 0,
-                    maxResults: 10,
-                    active: true,
-                  },
-                }) as Action
-              );
-              this.props.store.dispatch(
-                loadStudentsOfWorkspace({
-                  workspace,
-                  payload: {
-                    q: "",
-                    firstResult: 0,
-                    maxResults: 10,
-                    active: false,
-                  },
-                }) as Action
-              );
-            }
-          },
-        }) as Action
-      );
-
+      this.loadWorkspaceUsersData();
       this.loadChatSettings();
     }
 
@@ -996,7 +1004,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceJournal
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceJournal(props: RouteComponentProps<any>) {
@@ -1064,7 +1072,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceManagement
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceManagement(props: RouteComponentProps<any>) {
@@ -1160,7 +1168,7 @@ export default class Workspace extends React.Component<
 
   /**
    * renderWorkspaceEvaluation
-   * @param props
+   * @param props props
    * @returns JSX.Element
    */
   renderWorkspaceEvaluation(props: RouteComponentProps<any>) {


### PR DESCRIPTION
Workspace users data loads data again between page changes. Before if changing between already loaded users page and one another, user list was holding earlier fetched list and search query was missing. This is easy compromise to prefent confusing users when changing between workspace pages.

Resolves: #6243 