### PR TITLE
6192 application panel refactoring'ish

### DIFF
--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/announcer/AnnouncerTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/announcer/AnnouncerTestsBase.java
@@ -31,7 +31,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
       try{
         login();
         navigate("/announcer", false);
-        waitAndClick("div.application-panel__helper-container.application-panel__helper-container--main-action > a.button--primary-function");
+        waitAndClick(".application-panel__actions-aside  > a.button--primary-function");
         
         waitForPresent(".cke_contents");
         waitForPresent(".env-dialog__row--dates .env-dialog__form-element-container:nth-child(2) input");
@@ -74,7 +74,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
         waitForNotVisible(".dialog.dialog--delete-announcement.dialog--visible");
         waitForNotVisible(".application-list__item-content-header");
         reloadCurrentPage();
-        waitForPresent(".application-panel__main-container");
+        waitForPresent(".application-panel__content-main");
         assertTrue("Element found even though it shouldn't be there", isElementPresent(".application-list__item-content-header") == false);
         navigate("/", false);
         navigate("/announcer#archived", false);
@@ -217,7 +217,7 @@ public class AnnouncerTestsBase extends AbstractUITest {
     createAnnouncement(admin.getId(), "Test title", "Announcer test announcement", date(115, 10, 12), date(115, 10, 15), false, true, null, null);
     try {
       navigate("/announcer", false);
-      waitForPresent("div.application-panel__main-container.loader-empty");
+      waitForPresent(".application-panel__content-main.loader-empty");
       navigate("/", false);
       navigate("/announcer#past", false);
       

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/communicator/CommunicatorTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/communicator/CommunicatorTestsBase.java
@@ -190,8 +190,8 @@ public class CommunicatorTestsBase extends AbstractUITest {
         waitAndClick(".application-list__item-content-aside .form-element--item-selection-container input");
         
         waitAndClick(".icon-trash");
-        waitForPresent(".application-panel__main-container .empty");
-        assertPresent(".application-panel__main-container .empty");
+        waitForPresent(".application-panel__content-main .empty");
+        assertPresent(".application-panel__content-main .empty");
       }finally{
         deleteCommunicatorMessages(); 
       }
@@ -216,8 +216,8 @@ public class CommunicatorTestsBase extends AbstractUITest {
       waitAndClick(".application-list__item-content-aside .form-element--item-selection-container input");
       waitAndClick(".icon-trash");
       
-      waitForPresent(".application-panel__main-container .empty");
-      assertPresent(".application-panel__main-container .empty");
+      waitForPresent(".application-panel__content-main .empty");
+      assertPresent(".application-panel__content-main .empty");
       }finally{
         deleteCommunicatorMessages(); 
       }
@@ -239,8 +239,8 @@ public class CommunicatorTestsBase extends AbstractUITest {
         waitForVisible(".dropdown--communicator-labels input");
         sendKeys(".dropdown--communicator-labels input", "Test");
         waitAndClick(".dropdown--communicator-labels .link--full");
-        waitForPresent(".application-panel__helper-container a[href^='#label-'] span.menu__item-link-text");
-        assertText(".application-panel__helper-container a[href^='#label-'] span.menu__item-link-text", "Test");
+        waitForPresent(".application-panel__content-aside a[href^='#label-'] span.menu__item-link-text");
+        assertText(".application-panel__content-aside a[href^='#label-'] span.menu__item-link-text", "Test");
       }finally{
         deleteCommunicatorUserLabels(getUserIdByEmail(admin.getEmail()));
       }
@@ -272,7 +272,7 @@ public class CommunicatorTestsBase extends AbstractUITest {
         waitForVisible(".application-list__item-footer--communicator-message-labels .label__text");
         assertTextIgnoreCase(".application-list__item-footer--communicator-message-labels .label__text", "test");
         
-        waitAndClick("div.application-panel__content div.application-panel__helper-container a[href^='#label-']");
+        waitAndClick(".application-panel__content-aside a[href^='#label-']");
         waitForPresent(".application-list__item-header--communicator-message .application-list__header-primary span");
         assertText(".application-list__item-header--communicator-message .application-list__header-primary span", "Student Tester (Test Study Programme)");
         waitForPresent(".application-list__item-body--communicator-message span");
@@ -300,7 +300,7 @@ public class CommunicatorTestsBase extends AbstractUITest {
         createCommunicatorMesssage("Test caption", "Test content.", sender, recipient);
         createCommunicatorUserLabel(recipient, "test");
         navigate("/communicator", false);
-        waitAndClick("div.application-panel__content div.application-panel__helper-container a[href^='#label-'] .icon-pencil");
+        waitAndClick(".application-panel__content-aside a[href^='#label-'] .icon-pencil");
         waitForVisible(".dialog--visible .dialog__window--communicator-edit-label .form-element__input--communicator-label-name");
         sleep(500);
         clearElement(".dialog--visible .dialog__window--communicator-edit-label .form-element__input--communicator-label-name");
@@ -308,8 +308,8 @@ public class CommunicatorTestsBase extends AbstractUITest {
         waitAndClick(".dialog--visible .dialog__window--communicator-edit-label .button--standard-ok");
         sleep(500);
         waitForNotVisible(".dialog--visible .dialog__window--communicator-edit-label");
-        waitForPresent("div.application-panel__content div.application-panel__helper-container a[href^='#label-']");
-        assertText("div.application-panel__content div.application-panel__helper-container a[href^='#label-'] .menu__item-link-text", "Dun dun duun");
+        waitForPresent(".application-panel__content-aside a[href^='#label-']");
+        assertText(".application-panel__content-aside a[href^='#label-'] .menu__item-link-text", "Dun dun duun");
       }finally{
         deleteCommunicatorUserLabels(recipient);
         deleteCommunicatorMessages();
@@ -334,7 +334,7 @@ public class CommunicatorTestsBase extends AbstractUITest {
         createCommunicatorUserLabel(recipient, "test");
         navigate("/communicator", false);
         selectFinnishLocale();
-        waitAndClick("div.application-panel__content div.application-panel__helper-container a[href^='#label-'] .icon-pencil");
+        waitAndClick(".application-panel__content-aside a[href^='#label-'] .icon-pencil");
         waitForVisible("div>.dialog>.dialog__window");
         sleep(500);
         waitForClickable("div>.dialog>.dialog__window>.dialog__footer>.dialog__button-set>.button--communicator-remove-label");
@@ -374,7 +374,7 @@ public class CommunicatorTestsBase extends AbstractUITest {
         waitForVisible(".dropdown--communicator-labels input");
         sendKeys(".dropdown--communicator-labels input", "Test");
         waitAndClick(".dropdown--communicator-labels .link--full");
-        waitForPresent("div.application-panel__content div.application-panel__helper-container a[href^='#label-']");
+        waitForPresent(".application-panel__content-aside a[href^='#label-']");
     
         waitAndClick(".application-list__item-content-aside .form-element--item-selection-container input");
         sleep(500);

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/journal/CourseJournalPageTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/journal/CourseJournalPageTestsBase.java
@@ -33,8 +33,8 @@ public class CourseJournalPageTestsBase extends AbstractUITest {
       Workspace workspace = createWorkspace("testcourse", "test course for testing", "1", Boolean.TRUE);
       try {
         navigate(String.format("/workspace/%s/journal", workspace.getUrlName()), false);
-        waitForPresent(".application-panel--workspace-journal select.form-element__select");
-        assertVisible(".application-panel--workspace-journal select.form-element__select");
+        waitForPresent(".application-panel__actions-aside select.form-element__select");
+        assertVisible(".application-panel__actions-aside select.form-element__select");
       } finally {
         deleteWorkspace(workspace.getId());
       }
@@ -65,7 +65,7 @@ public class CourseJournalPageTestsBase extends AbstractUITest {
       try {
         navigate(String.format("/workspace/%s/journal", workspace.getUrlName()), false);
         selectFinnishLocale();
-        waitAndClick(".application-panel--workspace-journal .button--primary-function");
+        waitAndClick(".application-panel__actions-aside .button--primary-function");
         addTextToCKEditor("content");
         sendKeys(".env-dialog__input--new-edit-journal-title", "title");
         click(".button--dialog-execute");
@@ -104,7 +104,7 @@ public class CourseJournalPageTestsBase extends AbstractUITest {
       try {
         navigate(String.format("/workspace/%s/journal", workspace.getUrlName()), false);
         selectFinnishLocale();
-        waitAndClick(".application-panel--workspace-journal .button--primary-function");
+        waitAndClick(".application-panel__actions-aside .button--primary-function");
         addTextToCKEditor("content");
         sendKeys(".env-dialog__input--new-edit-journal-title", "title");
         click(".button--dialog-execute");
@@ -147,7 +147,7 @@ public class CourseJournalPageTestsBase extends AbstractUITest {
       try {
         navigate(String.format("/workspace/%s/journal", workspace.getUrlName()), false);
         selectFinnishLocale();
-        waitAndClick(".application-panel--workspace-journal .button--primary-function");
+        waitAndClick(".application-panel__actions-aside .button--primary-function");
         addTextToCKEditor("content");
         sendKeys(".env-dialog__input--new-edit-journal-title", "title");
         click(".button--dialog-execute");

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/management/CourseManagementTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/management/CourseManagementTestsBase.java
@@ -148,8 +148,8 @@ public class CourseManagementTestsBase extends AbstractUITest {
         waitForVisible(".notification-queue__items");
         sleep(500);
         navigate("/coursepicker", false);
-        waitForPresent(".application-panel__content .application-panel__main-container");
-        assertClassPresent(".application-panel__content .application-panel__main-container", "loader-empty");
+        waitForPresent(".application-panel__content .application-panel__content-main");
+        assertClassPresent(".application-panel__content .application-panel__content-main", "loader-empty");
       }finally{
         deleteWorkspace(workspace.getId());  
       }
@@ -444,10 +444,10 @@ public class CourseManagementTestsBase extends AbstractUITest {
         mockBuilder.mockLogin(student);
         login();
         navigate("/coursepicker", false);
-        waitForVisible("div.application-panel__actions > div.application-panel__helper-container.application-panel__helper-container--main-action");
+        waitForVisible(".application-panel__actions-aside ");
 //        refresh();
-        waitForVisible("div.application-panel__content > div.application-panel__main-container.loader-empty .application-list__item-header--course");
-        waitAndClick("div.application-panel__content > div.application-panel__main-container.loader-empty .application-list__item-header--course");
+        waitForVisible(".application-panel__content-main.loader-empty .application-list__item-header--course");
+        waitAndClick(".application-panel__content-main.loader-empty .application-list__item-header--course");
         waitAndClick(".button--coursepicker-course-action:nth-of-type(2)");
         assertPresent(".dialog--workspace-signup-dialog .button--standard-ok");
       }finally{

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/picker/CoursePickerTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/course/picker/CoursePickerTestsBase.java
@@ -37,19 +37,19 @@ public class CoursePickerTestsBase extends AbstractUITest {
       Workspace workspace = createWorkspace(course1, Boolean.TRUE);
       try {
         navigate("/coursepicker", false);
-        waitForVisible("div.application-panel__actions > div.application-panel__helper-container.application-panel__helper-container--main-action");
+        waitForVisible(".application-panel__actions-aside");
   //      Course selector
-        waitForPresent(".application-panel__helper-container--main-action select > option:nth-child(1)");
-        waitForPresent(".application-panel__helper-container--main-action select > option:nth-child(2)");
-        waitForPresent(".application-panel__helper-container--main-action select > option:nth-child(3)");
+        waitForPresent(".application-panel__actions-aside select > option:nth-child(1)");
+        waitForPresent(".application-panel__actions-aside select > option:nth-child(2)");
+        waitForPresent(".application-panel__actions-aside select > option:nth-child(3)");
   //      Search field
         waitForVisible(".application-panel__toolbar-actions-main input");
   //      Side navigation
-        waitForVisible(".application-panel__helper-container");
+        waitForVisible(".application-panel__content-aside");
   //      Course list and course
 //      CoursePicker seems to have a glitch where sometimes no courses are loaded at all. So workaround for that.
-        waitForElementToAppear(".application-panel__main-container .application-list__item.course", 10, 5000);
-        boolean elementExists = getWebDriver().findElements(By.cssSelector(".application-panel__main-container .application-list__item.course")).size() > 0;
+        waitForElementToAppear(".application-panel__content-main .application-list__item.course", 10, 5000);
+        boolean elementExists = getWebDriver().findElements(By.cssSelector(".application-panel__content-main .application-list__item.course")).size() > 0;
         assertTrue(elementExists);
       }finally{
         deleteWorkspace(workspace.getId());
@@ -75,9 +75,9 @@ public class CoursePickerTestsBase extends AbstractUITest {
       try {
         navigate("/coursepicker", false);
 //      CoursePicker seems to have a glitch where sometimes no courses are loaded at all. So workaround for that.
-        waitForElementToAppear(".application-panel__main-container .application-list__item.course", 10, 5000);
-        waitForPresent("div.application-panel__main-container .application-list__item-header--course .application-list__header-primary");
-        waitAndClick("div.application-panel__main-container .application-list__item-header--course .application-list__header-primary");
+        waitForElementToAppear(".application-panel__content-main .application-list__item.course", 10, 5000);
+        waitForPresent(".application-panel__content-main .application-list__item-header--course .application-list__header-primary");
+        waitAndClick(".application-panel__content-main .application-list__item-header--course .application-list__header-primary");
         waitForVisible(".course--open .application-list__item-content-body p");  
         assertText(".course--open .application-list__item-content-body p", "test course for testing");
       }finally {
@@ -118,8 +118,8 @@ public class CoursePickerTestsBase extends AbstractUITest {
       try {
         navigate("/coursepicker", false);
 //      CoursePicker seems to have a glitch where sometimes no courses are loaded at all. So workaround for that.
-        waitForElementToAppear(".application-panel__main-container .application-list__item.course", 10, 5000);
-        waitForVisible("div.application-panel__content > div.application-panel__main-container.loader-empty .application-list__item-header--course");
+        waitForElementToAppear(".application-panel__content-main .application-list__item.course", 10, 5000);
+        waitForVisible(".application-panel__content-main.loader-empty .application-list__item-header--course");
         scrollToEnd();
         waitForMoreThanSize(".application-list__item.course", 27);
         assertCount(".application-list__item.course", 35);
@@ -155,8 +155,8 @@ public class CoursePickerTestsBase extends AbstractUITest {
       try {
         navigate("/coursepicker", false);
 //      CoursePicker seems to have a glitch where sometimes no courses are loaded at all. So workaround for that.
-        waitForElementToAppear(".application-panel__main-container .application-list__item.course", 10, 5000);
-        waitForVisible("div.application-panel__content > div.application-panel__main-container.loader-empty .application-list__item-header--course");
+        waitForElementToAppear(".application-panel__content-main .application-list__item.course", 10, 5000);
+        waitForVisible(".application-panel__content-main.loader-empty .application-list__item-header--course");
         waitAndSendKeys(".application-panel__toolbar-actions-main input", "pot");
         waitAndSendKeys(".application-panel__toolbar-actions-main input", "ato");
         waitUntilElementCount(".application-list__item-header--course", 1);
@@ -196,9 +196,9 @@ public class CoursePickerTestsBase extends AbstractUITest {
       try {
         navigate("/coursepicker", false);
 //      CoursePicker seems to have a glitch where sometimes no courses are loaded at all. So workaround for that.
-        waitForElementToAppear(".application-panel__main-container .application-list__item.course", 10, 5000);
-        waitForVisible("div.application-panel__content > div.application-panel__main-container.loader-empty .application-list__item-header--course");
-        waitAndClick(".application-panel__helper-container.application-panel__helper-container--coursepicker .menu-wrapper .menu:first-child .menu__item:nth-child(3)");
+        waitForElementToAppear(".application-panel__content-main .application-list__item.course", 10, 5000);
+        waitForVisible(".application-panel__content-main.loader-empty .application-list__item-header--course");
+        waitAndClick(".application-panel__content-aside .menu-wrapper .menu:first-child .menu__item:nth-child(3)");
         waitForVisible(".application-list__item-header--course .application-list__header-primary");
         assertTextIgnoreCase(".application-list__item-header--course .application-list__header-primary", "testcourse 7 (test extension)");
       }finally {

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/discussions/DiscussionTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/discussions/DiscussionTestsBase.java
@@ -40,7 +40,7 @@ public class DiscussionTestsBase extends AbstractUITest {
       Discussion discussion = createDiscussion(discussionGroup.getId(), "test discussion");
       try {
         navigate("/discussion", false);
-        waitAndClick(".application-panel__helper-container--main-action .button--primary-function");
+        waitAndClick(".application-panel__actions-aside .button--primary-function");
         waitAndClick("input.env-dialog__input--new-discussion-thread-title");
         sendKeys("input.env-dialog__input--new-discussion-thread-title", "Test title for discussion");
         addTextToCKEditor("Test text for discussion.");
@@ -160,8 +160,8 @@ public class DiscussionTestsBase extends AbstractUITest {
         waitForVisible(".dialog--delete-area .button--standard-ok");
         waitAndClick(".button--standard-ok");
         waitForNotVisible(".dialog--delete-area");
-        waitForVisible(".application-panel__content .application-panel__main-container.loader-empty");
-        assertTextIgnoreCase(".application-panel__content .application-panel__main-container.loader-empty .empty span", "Ei viestejä");
+        waitForVisible(".application-panel__content .application-panel__content-main.loader-empty");
+        assertTextIgnoreCase(".application-panel__content .application-panel__content-main.loader-empty .empty span", "Ei viestejä");
     } finally {
       deleteDiscussionThread(discussionGroup.getId(), discussion.getId(), thread.getId());
       deleteDiscussion(discussionGroup.getId(), discussion.getId());

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/flags/FlagTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/flags/FlagTestsBase.java
@@ -57,9 +57,9 @@ public class FlagTestsBase extends AbstractUITest {
 
       waitAndClick("div.dropdown--guider-labels .link--full");
       waitAndClick("div.application-panel__toolbar span.icon-flag");
-      waitForVisible(".application-panel__helper-container .icon-flag");
-      waitForVisible(".application-panel__helper-container .icon-flag + span.menu__item-link-text");
-      assertTextIgnoreCase(".application-panel__helper-container .icon-flag + span.menu__item-link-text", "Test flag");
+      waitForVisible(".application-panel__content-aside .icon-flag");
+      waitForVisible(".application-panel__content-aside .icon-flag + span.menu__item-link-text");
+      assertTextIgnoreCase(".application-panel__content-aside .icon-flag + span.menu__item-link-text", "Test flag");
     } finally {
       deleteFlags();
       deleteWorkspace(workspace.getId());
@@ -100,8 +100,8 @@ public class FlagTestsBase extends AbstractUITest {
       navigate("/guider", false);
     
       waitUntilElementCount(".user--guider", 2);
-      waitForVisible(".application-panel__helper-container.application-panel__helper-container--guider .menu__item-link--aside-navigation-guider-flag");
-      click(".application-panel__helper-container.application-panel__helper-container--guider .menu__item-link--aside-navigation-guider-flag");
+      waitForVisible(".application-panel__content-aside .menu__item-link--aside-navigation-guider-flag");
+      click(".application-panel__content-aside .menu__item-link--aside-navigation-guider-flag");
       
       waitUntilElementCount(".user--guider", 1);
       assertTextIgnoreCase(".user--guider .application-list__header-primary span", "Second User");
@@ -147,8 +147,8 @@ public class FlagTestsBase extends AbstractUITest {
     try {
       navigate("/guider", false);
 
-      waitForPresent("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
-      click("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitForPresent(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
+      click(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
       
       waitForVisible("input.form-element__input--guider-label-name");
       click("input.form-element__input--guider-label-name");
@@ -161,9 +161,9 @@ public class FlagTestsBase extends AbstractUITest {
       click(".button--standard-ok");
       
       waitForNotVisible(".dialog--guider-edit-label");
-      waitForVisible(".application-panel__helper-container .icon-flag");
-      waitForVisible(".application-panel__helper-container .icon-flag + span.menu__item-link-text");
-      assertTextIgnoreCase(".application-panel__helper-container .icon-flag + span.menu__item-link-text", "Edited title");
+      waitForVisible(".application-panel__content-aside .icon-flag");
+      waitForVisible(".application-panel__content-aside .icon-flag + span.menu__item-link-text");
+      assertTextIgnoreCase(".application-panel__content-aside .icon-flag + span.menu__item-link-text", "Edited title");
     } finally {
       deleteFlags();
       deleteWorkspace(workspace.getId());
@@ -203,15 +203,15 @@ public class FlagTestsBase extends AbstractUITest {
     flagStudent(student.getId(), flagId);
     try {
       navigate("/guider", false);
-      waitForVisible("div.application-panel__main-container .application-list__item.user:nth-child(1) input");
-      click("div.application-panel__main-container .application-list__item.user:nth-child(1) input");
-      waitAndClick(".application-panel__main-container--actions .icon-flag");
+      waitForVisible(".application-panel__content-main .application-list__item.user:nth-child(1) input");
+      click(".application-panel__content-main .application-list__item.user:nth-child(1) input");
+      waitAndClick(".application-panel__actions-main .icon-flag");
       
       waitForVisible(".dropdown--guider-labels.visible .link--guider-label-dropdown.selected");
       click(".dropdown--guider-labels.visible .link--guider-label-dropdown.selected");
       
-      waitAndClick(".application-panel__helper-container .icon-flag");
-      waitForVisible(".application-panel__helper-container .menu__item-link.active");
+      waitAndClick(".application-panel__content-aside .icon-flag");
+      waitForVisible(".application-panel__content-aside .menu__item-link.active");
       
       assertNotPresent(".application-list__item-header--student");
     } finally {
@@ -256,8 +256,8 @@ public class FlagTestsBase extends AbstractUITest {
     try {
       navigate("/guider", false);
 
-      waitForPresent("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
-      waitAndClick("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitForPresent(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitAndClick(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
       waitUntilAnimationIsDone(".dialog--guider-edit-label");
       sleep(1000);
       waitForVisible(".autocomplete__input input.tag-input__input--guider");
@@ -271,7 +271,7 @@ public class FlagTestsBase extends AbstractUITest {
       click(".dialog--guider-edit-label .button--standard-ok");
       
       waitForNotVisible(".dialog--guider-edit-label");
-      waitForPresent("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitForPresent(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
       
       logout();
       mockBuilder.mockLogin(testPerson);
@@ -279,8 +279,8 @@ public class FlagTestsBase extends AbstractUITest {
 
       navigate("/guider", false);
 
-      waitForVisible("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container .menu__item-link-text");
-      assertTextIgnoreCase("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container .menu__item-link-text", "Test Flaggi");
+      waitForVisible(".application-panel__content-aside .menu__item-link-text");
+      assertTextIgnoreCase(".application-panel__content-aside .menu__item-link-text", "Test Flaggi");
     } finally {
       deleteFlagShares(flagId);
       deleteFlags();
@@ -321,8 +321,8 @@ public class FlagTestsBase extends AbstractUITest {
     try {
       navigate("/guider", false);
       selectFinnishLocale();
-      waitForPresent("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
-      waitAndClick("div.application-panel__body > div.application-panel__content > div.application-panel__helper-container a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitForPresent(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
+      waitAndClick(".application-panel__content-aside a > span.button-pill.button-pill--navigation-edit-label > span");
 
       waitUntilAnimationIsDone(".dialog--guider-edit-label");
       sleep(1000);

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/guider/GuiderTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/guider/GuiderTestsBase.java
@@ -117,9 +117,9 @@ public class GuiderTestsBase extends AbstractUITest {
         .build();
     try {
       navigate("/guider", false);
-      waitAndClick("div.application-panel__helper-container a.menu__item-link");
-      waitUntilAnimationIsDone(".application-panel__main-container");
-      clickAndConfirmElementCount("div.application-panel__helper-container a.menu__item-link", ".application-list .user--guider", 1);
+      waitAndClick(".application-panel__content-aside a.menu__item-link");
+      waitUntilAnimationIsDone(".application-panel__content-main");
+      clickAndConfirmElementCount(".application-panel__content-aside a.menu__item-link", ".application-list .user--guider", 1);
       waitUntilElementCount(".application-list .user--guider", 1);
       waitForPresent(".application-list__item-header .application-list__header-primary span");
       assertTextIgnoreCase(".application-list__item-header .application-list__header-primary span", "Second User");

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcements/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcements/body/application.tsx
@@ -32,15 +32,13 @@ class AnnouncementsApplication extends React.Component<AnnouncementsApplicationP
   render() {
     const title = this.props.i18n.text.get("plugin.announcements.pageTitle");
     return (
-      <div className="reading-panel-wrapper">
-        <ReadingPanel
-          modifier="announcement"
-          title={title}
-          asideAfter={this.props.aside}
-        >
-          <Announcements />
-        </ReadingPanel>
-      </div>
+      <ReadingPanel
+        modifier="announcement"
+        title={title}
+        asideAfter={this.props.aside}
+      >
+        <Announcements />
+      </ReadingPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application.tsx
@@ -50,9 +50,8 @@ class AnnouncerApplication extends React.Component<
 
     //The message view actually appears on top and it's not a replacement, this makes it easier to go back without having to refresh from the server
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
-          modifier="announcer"
           toolbar={toolbar}
           title={title}
           primaryOption={primaryOption}
@@ -64,7 +63,7 @@ class AnnouncerApplication extends React.Component<
         <NewEditAnnouncement>
           <HoverButton icon="plus" modifier="new-announcement" />
         </NewEditAnnouncement>
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/toolbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/announcer/body/application/toolbar.tsx
@@ -160,9 +160,9 @@ class AnnouncerToolbar extends React.Component<
               onClick={this.onGoBackClick}
             />
 
-            <div className="application-panel__tool--current-folder">
-              <span className="application-panel__tool-icon icon-folder"></span>
-              <span className="application-panel__tool-title">
+            <div className="application-panel__mobile-current-folder">
+              <span className="application-panel__mobile-current-folder-icon icon-folder"></span>
+              <span className="application-panel__mobile-current-folder-title">
                 {this.props.i18n.text.get(
                   "plugin.announcer.cat." + this.props.announcements.location
                 )}
@@ -211,9 +211,9 @@ class AnnouncerToolbar extends React.Component<
       return (
         <ApplicationPanelToolbar>
           <ApplicationPanelToolbarActionsMain>
-            <div className="application-panel__tool--current-folder">
-              <span className="glyph application-panel__tool-icon icon-folder"></span>
-              <span className="application-panel__tool-title">
+            <div className="application-panel__mobile-current-folder">
+              <span className="glyph application-panel__mobile-current-folder-icon icon-folder"></span>
+              <span className="application-panel__mobile-current-folder-title">
                 {this.props.i18n.text.get(
                   "plugin.announcer.cat." + this.props.announcements.location
                 )}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application.tsx
@@ -109,9 +109,8 @@ class CommunicatorApplication extends React.Component<
 
     //The message view actually appears on top and it's not a replacement, this makes it easier to go back without having to refresh from the server
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
-          modifier="communicator"
           toolbar={toolbar}
           title={title}
           icon={icon}
@@ -128,7 +127,7 @@ class CommunicatorApplication extends React.Component<
         <NewMessage>
           <HoverButton icon="plus" modifier="new-message" />
         </NewMessage>
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/toolbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/toolbar.tsx
@@ -49,6 +49,7 @@ import {
   ApplicationPanelToolbar,
   ApplicationPanelToolbarActionsMain,
   ApplicationPanelToolbarActionsAside,
+  ApplicationPanelToolsContainer,
 } from "~/components/general/application-panel/application-panel";
 import { ButtonPill } from "~/components/general/button";
 import { SearchFormElement } from "~/components/general/form-element";
@@ -279,12 +280,12 @@ class CommunicatorToolbar extends React.Component<
               onClick={this.onGoBackClick}
             />
 
-            <div className="application-panel__tool--current-folder">
+            <div className="application-panel__mobile-current-folder">
               <span
-                className={`glyph application-panel__tool-icon icon-${currentLocation.icon}`}
+                className={`glyph application-panel__mobile-current-folder-icon icon-${currentLocation.icon}`}
                 style={{ color: currentLocation.color }}
               />
-              <span className="application-panel__tool-title">
+              <span className="application-panel__mobile-current-folder-title">
                 {"  " + currentLocation.text(this.props.i18n)}
               </span>
               {currentLocation.type === "label" ? (
@@ -441,12 +442,12 @@ class CommunicatorToolbar extends React.Component<
 
     return (
       <ApplicationPanelToolbar>
-        <div className="application-panel__tool--current-folder">
+        <div className="application-panel__mobile-current-folder">
           <span
-            className={`glyph application-panel__tool-icon icon-${currentLocation.icon}`}
+            className={`glyph application-panel__mobile-current-folder-icon icon-${currentLocation.icon}`}
             style={{ color: currentLocation.color }}
           />
-          <span className="application-panel__tool-title">
+          <span className="application-panel__mobile-current-folder-title">
             {"  " + currentLocation.text(this.props.i18n)}
           </span>
           {currentLocation.type === "label" ? (
@@ -577,19 +578,19 @@ class CommunicatorToolbar extends React.Component<
             }
           />
         ) : null}
-
-        <SearchFormElement
-          updateField={this.updateSearchWithQuery}
-          name="message-search"
-          id="searchMessages"
-          modifiers="communicator-message-search"
-          onFocus={this.onInputFocus}
-          onBlur={this.onInputBlur}
-          placeholder={this.props.i18n.text.get(
-            "plugin.communicator.search.placeholder"
-          )}
-          value={this.state.searchquery}
-        />
+        <ApplicationPanelToolsContainer>
+          <SearchFormElement
+            updateField={this.updateSearchWithQuery}
+            name="message-search"
+            id="searchMessages"
+            onFocus={this.onInputFocus}
+            onBlur={this.onInputBlur}
+            placeholder={this.props.i18n.text.get(
+              "plugin.communicator.search.placeholder"
+            )}
+            value={this.state.searchquery}
+          />
+        </ApplicationPanelToolsContainer>
       </ApplicationPanelToolbar>
     );
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application.tsx
@@ -110,17 +110,14 @@ class CoursepickerApplication extends React.Component<
       </div>
     );
     return (
-      <div className="application-panel-wrapper">
-        <ApplicationPanel
-          modifier="coursepicker"
-          toolbar={toolbar}
-          title={title}
-          asideBefore={this.props.aside}
-          primaryOption={primaryOption}
-        >
-          <CoursepickerWorkspaces />
-        </ApplicationPanel>
-      </div>
+      <ApplicationPanel
+        toolbar={toolbar}
+        title={title}
+        asideBefore={this.props.aside}
+        primaryOption={primaryOption}
+      >
+        <CoursepickerWorkspaces />
+      </ApplicationPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application/toolbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application/toolbar.tsx
@@ -9,6 +9,7 @@ import { StateType } from "~/reducers";
 import {
   ApplicationPanelToolbar,
   ApplicationPanelToolbarActionsMain,
+  ApplicationPanelToolsContainer,
 } from "~/components/general/application-panel/application-panel";
 import { WorkspacesType } from "~/reducers/workspaces";
 import { SearchFormElement } from "~/components/general/form-element";
@@ -109,17 +110,19 @@ class CoursepickerToolbar extends React.Component<
     return (
       <ApplicationPanelToolbar>
         <ApplicationPanelToolbarActionsMain>
-          <SearchFormElement
-            updateField={this.updateSearchWithQuery}
-            name="workspace-search"
-            id="searchCourses"
-            onFocus={this.onInputFocus}
-            onBlur={this.onInputBlur}
-            placeholder={this.props.i18n.text.get(
-              "plugin.coursepicker.search.placeholder"
-            )}
-            value={this.state.searchquery}
-          />
+          <ApplicationPanelToolsContainer>
+            <SearchFormElement
+              updateField={this.updateSearchWithQuery}
+              name="workspace-search"
+              id="searchCourses"
+              onFocus={this.onInputFocus}
+              onBlur={this.onInputBlur}
+              placeholder={this.props.i18n.text.get(
+                "plugin.coursepicker.search.placeholder"
+              )}
+              value={this.state.searchquery}
+            />
+          </ApplicationPanelToolsContainer>
         </ApplicationPanelToolbarActionsMain>
       </ApplicationPanelToolbar>
     );

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/discussion/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/discussion/body/application.tsx
@@ -62,10 +62,9 @@ class DiscussionApplication extends React.Component<
       ) : null;
 
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
           title={title}
-          modifier="discussion"
           primaryOption={primaryOption}
           toolbar={toolbar}
         >
@@ -73,7 +72,7 @@ class DiscussionApplication extends React.Component<
           <CurrentThread />
         </ApplicationPanel>
         {primaryOptionMobile}
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/discussion/body/application/toolbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/discussion/body/application/toolbar.tsx
@@ -16,7 +16,10 @@ import ModifyArea from "../../dialogs/modify-area";
 import DeleteArea from "../../dialogs/delete-area";
 import { StatusType } from "~/reducers/base/status";
 import { StateType } from "~/reducers";
-import { ApplicationPanelToolbar } from "~/components/general/application-panel/application-panel";
+import {
+  ApplicationPanelToolbar,
+  ApplicationPanelToolbarActionsMain,
+} from "~/components/general/application-panel/application-panel";
 import { ButtonPill } from "~/components/general/button";
 
 /**
@@ -116,49 +119,54 @@ class CommunicatorToolbar extends React.Component<
 
     return (
       <ApplicationPanelToolbar>
-        {this.props.status.permissions.FORUM_CREATEENVIRONMENTFORUM ? (
-          <NewArea>
-            <ButtonPill icon="plus" buttonModifiers={["discussion-toolbar"]} />
-          </NewArea>
-        ) : null}
-        {this.props.status.permissions.FORUM_UPDATEENVIRONMENTFORUM ? (
-          <ModifyArea>
-            <ButtonPill
-              disabled={!this.props.discussion.areaId}
-              icon="pencil"
-              buttonModifiers={["discussion-toolbar"]}
-            />
-          </ModifyArea>
-        ) : null}
-        {this.props.status.permissions.FORUM_DELETEENVIRONMENTFORUM ? (
-          <DeleteArea>
-            <ButtonPill
-              disabled={!this.props.discussion.areaId}
-              icon="trash"
-              buttonModifiers={["discussion-toolbar"]}
-            />
-          </DeleteArea>
-        ) : null}
-        <div className="form-element">
-          <label htmlFor="discussionAreaSelect" className="visually-hidden">
-            {this.props.i18n.text.get("plugin.wcag.areaSelect.label")}
-          </label>
-          <select
-            id="discussionAreaSelect"
-            className="form-element__select form-element__select--toolbar-selector"
-            onChange={this.onSelectChange}
-            value={this.props.discussion.areaId || ""}
-          >
-            <option value="">
-              {this.props.i18n.text.get("plugin.discussion.browseareas.all")}
-            </option>
-            {this.props.discussion.areas.map((area) => (
-              <option key={area.id} value={area.id}>
-                {area.name}
+        <ApplicationPanelToolbarActionsMain>
+          {this.props.status.permissions.FORUM_CREATEENVIRONMENTFORUM ? (
+            <NewArea>
+              <ButtonPill
+                icon="plus"
+                buttonModifiers={["discussion-toolbar"]}
+              />
+            </NewArea>
+          ) : null}
+          {this.props.status.permissions.FORUM_UPDATEENVIRONMENTFORUM ? (
+            <ModifyArea>
+              <ButtonPill
+                disabled={!this.props.discussion.areaId}
+                icon="pencil"
+                buttonModifiers={["discussion-toolbar"]}
+              />
+            </ModifyArea>
+          ) : null}
+          {this.props.status.permissions.FORUM_DELETEENVIRONMENTFORUM ? (
+            <DeleteArea>
+              <ButtonPill
+                disabled={!this.props.discussion.areaId}
+                icon="trash"
+                buttonModifiers={["discussion-toolbar"]}
+              />
+            </DeleteArea>
+          ) : null}
+          <div className="form-element">
+            <label htmlFor="discussionAreaSelect" className="visually-hidden">
+              {this.props.i18n.text.get("plugin.wcag.areaSelect.label")}
+            </label>
+            <select
+              id="discussionAreaSelect"
+              className="form-element__select form-element__select--toolbar-selector"
+              onChange={this.onSelectChange}
+              value={this.props.discussion.areaId || ""}
+            >
+              <option value="">
+                {this.props.i18n.text.get("plugin.discussion.browseareas.all")}
               </option>
-            ))}
-          </select>
-        </div>
+              {this.props.discussion.areas.map((area) => (
+                <option key={area.id} value={area.id}>
+                  {area.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </ApplicationPanelToolbarActionsMain>
       </ApplicationPanelToolbar>
     );
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application.tsx
@@ -66,11 +66,7 @@ class EvaluationApplication extends React.Component<
    * @returns JSX.Element
    */
   render() {
-    const title = (
-      <h1 className="application-panel__header-title">
-        {this.props.i18n.text.get("plugin.evaluation.title")}
-      </h1>
-    );
+    const title = this.props.i18n.text.get("plugin.evaluation.title");
     const currentWorkspace = this.props.currentWorkspace;
 
     const workspaces = [...this.props.evaluations.evaluationWorkspaces];
@@ -135,19 +131,16 @@ class EvaluationApplication extends React.Component<
     const toolBar = <EvaluationToolbar title="" />;
 
     return (
-      <div className="application-panel-wrapper">
-        <ApplicationPanel
-          modifier=""
-          title={title}
-          primaryOption={primaryOption}
-          toolbar={toolBar}
-        >
-          <EvaluationSorters />
-          <div className="evaluation-cards-wrapper">
-            <EvaluationList />
-          </div>
-        </ApplicationPanel>
-      </div>
+      <ApplicationPanel
+        title={title}
+        primaryOption={primaryOption}
+        toolbar={toolBar}
+      >
+        <EvaluationSorters />
+        <div className="evaluation-cards-wrapper">
+          <EvaluationList />
+        </div>
+      </ApplicationPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/toolbar.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/toolbar.tsx
@@ -5,7 +5,10 @@ import { StateType } from "~/reducers";
 import "~/sass/elements/evaluation.scss";
 import { ButtonPill } from "~/components/general/button";
 import Dropdown from "~/components/general/dropdown";
-import { ApplicationPanelToolbar } from "~/components/general/application-panel/application-panel";
+import {
+  ApplicationPanelToolbar,
+  ApplicationPanelToolbarActionsMain,
+} from "~/components/general/application-panel/application-panel";
 import { SearchFormElement } from "~/components/general/form-element";
 import { bindActionCreators } from "redux";
 import { EvaluationState } from "~/reducers/main-function/evaluation/index";
@@ -138,18 +141,22 @@ class EvaluationToolbar extends React.Component<
 
     return (
       <ApplicationPanelToolbar>
-        <SearchFormElement
-          updateField={this.handleSearchFormElementChange}
-          name="guider-search"
-          id="searchUsers"
-          placeholder={this.props.i18n.text.get("plugin.evaluation.freeSearch")}
-          value={this.props.evaluations.evaluationSearch}
-        />
-        {this.props.evaluations.selectedWorkspaceId ? (
-          <Dropdown items={checkboxes}>
-            <ButtonPill buttonModifiers="filter" icon="filter" />
-          </Dropdown>
-        ) : null}
+        <ApplicationPanelToolbarActionsMain>
+          <SearchFormElement
+            updateField={this.handleSearchFormElementChange}
+            name="guider-search"
+            id="searchUsers"
+            placeholder={this.props.i18n.text.get(
+              "plugin.evaluation.freeSearch"
+            )}
+            value={this.props.evaluations.evaluationSearch}
+          />
+          {this.props.evaluations.selectedWorkspaceId ? (
+            <Dropdown items={checkboxes}>
+              <ButtonPill buttonModifiers="filter" icon="filter" />
+            </Dropdown>
+          ) : null}
+        </ApplicationPanelToolbarActionsMain>
       </ApplicationPanelToolbar>
     );
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/application-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/application-panel.tsx
@@ -67,14 +67,14 @@ export default class ApplicationPanel extends React.Component<
               : ""
           }`}
         >
-          <h1
-            className={`application-panel__header   ${
-              this.props.modifier
-                ? "application-panel__header--" + this.props.modifier
-                : ""
-            }`}
-          >
-            {this.props.title ? (
+          {this.props.title ? (
+            <h1
+              className={`application-panel__header   ${
+                this.props.modifier
+                  ? "application-panel__header--" + this.props.modifier
+                  : ""
+              }`}
+            >
               <span
                 className={`application-panel__header-title ${
                   this.props.modifier
@@ -84,20 +84,20 @@ export default class ApplicationPanel extends React.Component<
               >
                 {this.props.title}
               </span>
-            ) : null}
-            {this.props.icon ? (
-              <span
-                className={`application-panel__header-actions ${
-                  this.props.modifier
-                    ? "application-panele__header-actions--" +
-                      this.props.modifier
-                    : ""
-                }`}
-              >
-                {this.props.icon}
-              </span>
-            ) : null}
-          </h1>
+              {this.props.icon ? (
+                <span
+                  className={`application-panel__header-actions ${
+                    this.props.modifier
+                      ? "application-panele__header-actions--" +
+                        this.props.modifier
+                      : ""
+                  }`}
+                >
+                  {this.props.icon}
+                </span>
+              ) : null}
+            </h1>
+          ) : null}
           {this.props.panelTabs ? (
             <Tabs
               modifier="application-panel"
@@ -242,7 +242,7 @@ export class ApplicationPanelToolsContainer extends React.Component<
    */
   render() {
     return (
-      <div className="application-panel__tools-container">
+      <div className="application-panel__toolbar-tools-container">
         {this.props.children}
       </div>
     );

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/components/application-panel-body.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/application-panel/components/application-panel-body.tsx
@@ -63,10 +63,8 @@ export default class ApplicationPanelBody extends React.Component<
         >
           {primaryOption ? (
             <div
-              className={`application-panel__helper-container application-panel__helper-container--main-action ${
-                modifier
-                  ? "application-panel__helper-container--" + modifier
-                  : ""
+              className={`application-panel__actions-aside ${
+                modifier ? "application-panel__actions-aside--" + modifier : ""
               }`}
             >
               {primaryOption}
@@ -74,8 +72,8 @@ export default class ApplicationPanelBody extends React.Component<
           ) : null}
           {toolbar ? (
             <div
-              className={`application-panel__main-container application-panel__main-container--actions ${
-                modifier ? "application-panel__main-container--" + modifier : ""
+              className={`application-panel__actions-main ${
+                modifier ? "application-panel__actions-main--" + modifier : ""
               }`}
             >
               {toolbar}
@@ -89,24 +87,20 @@ export default class ApplicationPanelBody extends React.Component<
         >
           {asideBefore ? (
             <div
-              className={`application-panel__helper-container ${
-                modifier
-                  ? "application-panel__helper-container--" + modifier
-                  : ""
+              className={`application-panel__content-aside ${
+                modifier ? "application-panel__content-aside--" + modifier : ""
               }`}
             >
               {asideBefore}
             </div>
           ) : null}
-          <div className={`application-panel__main-container loader-empty`}>
+          <div className={`application-panel__content-main loader-empty`}>
             {children}
           </div>
           {asideAfter ? (
             <div
-              className={`application-panel__helper-container ${
-                modifier
-                  ? "application-panel__helper-container--" + modifier
-                  : ""
+              className={`application-panel__content-aside ${
+                modifier ? "application-panel__content-aside--" + modifier : ""
               }`}
             >
               {asideAfter}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/body/application.tsx
@@ -57,17 +57,14 @@ class GuiderApplication extends React.Component<
       </div>
     );
     return (
-      <div className="application-panel-wrapper">
-        <ApplicationPanel
-          modifier="guider"
-          primaryOption={primaryOption}
-          toolbar={toolbar}
-          title={title}
-          asideBefore={this.props.aside}
-        >
-          <Students />
-        </ApplicationPanel>
-      </div>
+      <ApplicationPanel
+        primaryOption={primaryOption}
+        toolbar={toolbar}
+        title={title}
+        asideBefore={this.props.aside}
+      >
+        <Students />
+      </ApplicationPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/dialogs/student/tabs/study-history.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/dialogs/student/tabs/study-history.tsx
@@ -11,7 +11,7 @@ import { UserFileType } from "~/reducers/user-index";
 import Workspaces from "../workspaces";
 import MainChart from "~/components/general/graph/main-chart";
 import ApplicationSubPanel from "~/components/general/application-sub-panel";
-import ApplicationPanelBody from "~/components/general/application-panel/components/application-panel-body";
+import ApplicationPanel from "~/components/general/application-panel/application-panel";
 import Navigation, { NavigationElement } from "~/components/general/navigation";
 import {
   AddFileToCurrentStudentTriggerType,
@@ -206,9 +206,9 @@ const StudyHistory: React.FC<StudyHistoryProps> = (props) => {
   };
 
   return (
-    <ApplicationPanelBody modifier="guider-student" asideBefore={aside}>
+    <ApplicationPanel modifier="tabs-with-dialog" asideBefore={aside}>
       {studyHistoryContent()}
-    </ApplicationPanelBody>
+    </ApplicationPanel>
   );
 };
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/organization/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/organization/body/application.tsx
@@ -141,11 +141,7 @@ class OrganizationManagementApplication extends React.Component<
    * render
    */
   render() {
-    const title = (
-      <h2 className="application-panel__header-title">
-        {this.props.i18n.text.get("plugin.organization.pageTitle")}
-      </h2>
-    );
+    const title = this.props.i18n.text.get("plugin.organization.pageTitle");
     const usersPrimaryAction = (
       <UserDialog>
         <ButtonPill buttonModifiers="organization" icon="plus" />
@@ -226,7 +222,6 @@ class OrganizationManagementApplication extends React.Component<
 
     return (
       <ApplicationPanel
-        modifier="organization"
         title={title}
         onTabChange={this.onTabChange}
         activeTab={this.state.activeTab}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/profile/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/profile/body/application.tsx
@@ -41,9 +41,8 @@ class ProfileApplication extends React.Component<
       return null;
     }
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
-          modifier="profile"
           title={this.props.status.profile.displayName}
           asideBefore={this.props.aside}
         >
@@ -55,7 +54,7 @@ class ProfileApplication extends React.Component<
           <WorkList />
           <Purchases />
         </ApplicationPanel>
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/records/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/records/body/application.tsx
@@ -173,11 +173,7 @@ class StudiesApplication extends React.Component<
    * @returns JSX.Element
    */
   render() {
-    const title = (
-      <h1 className="application-panel__header-title">
-        {this.props.i18n.text.get("plugin.records.pageTitle")}
-      </h1>
-    );
+    const title = this.props.i18n.text.get("plugin.records.pageTitle");
 
     let panelTabs: Tab[] = [
       {
@@ -241,7 +237,6 @@ class StudiesApplication extends React.Component<
 
     return (
       <ApplicationPanel
-        modifier="studies"
         title={title}
         onTabChange={this.onTabChange}
         activeTab={this.state.activeTab}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHelp/help/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHelp/help/index.tsx
@@ -708,19 +708,17 @@ class Help extends React.Component<HelpMaterialsProps, HelpMaterialsState> {
     });
 
     return (
-      <div className="content-panel-wrapper">
-        <ContentPanel
-          onOpenNavigation={this.onOpenNavigation}
-          modifier="materials"
-          navigation={this.props.navigation}
-          title={this.props.i18n.text.get("plugin.workspace.helpPage.title")}
-          ref="content-panel"
-        >
-          {results}
-          {emptyMessage}
-          {createSectionElementWhenEmpty}
-        </ContentPanel>
-      </div>
+      <ContentPanel
+        onOpenNavigation={this.onOpenNavigation}
+        modifier="materials"
+        navigation={this.props.navigation}
+        title={this.props.i18n.text.get("plugin.workspace.helpPage.title")}
+        ref="content-panel"
+      >
+        {results}
+        {emptyMessage}
+        {createSectionElementWhenEmpty}
+      </ContentPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceJournal/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceJournal/body/application.tsx
@@ -122,10 +122,9 @@ class WorkspaceJournalApplication extends React.Component<
     }
 
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
           asideBefore={this.props.aside}
-          modifier="workspace-journal"
           toolbar={toolbar}
           title={title}
           primaryOption={primaryOption}
@@ -137,7 +136,7 @@ class WorkspaceJournalApplication extends React.Component<
             <HoverButton icon="plus" modifier="new-message" />
           </NewJournal>
         ) : null}
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceManagement/body/management.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceManagement/body/management.tsx
@@ -698,7 +698,7 @@ class ManagementPanel extends React.Component<
     }
 
     return (
-      <div className="application-panel-wrapper">
+      <>
         <ApplicationPanel
           modifier="workspace-management"
           title={this.props.i18n.text.get(
@@ -1314,7 +1314,7 @@ class ManagementPanel extends React.Component<
             </div>
           </section>
         </ApplicationPanel>
-      </div>
+      </>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
@@ -746,22 +746,18 @@ class WorkspaceMaterials extends React.Component<
       ) : null;
 
     return (
-      <div className="content-panel-wrapper">
-        <ContentPanel
-          aside={progressData}
-          onOpenNavigation={this.onOpenNavigation}
-          modifier="materials"
-          navigation={this.props.navigation}
-          title={this.props.i18n.text.get(
-            "plugin.workspace.materials.pageTitle"
-          )}
-          ref="content-panel"
-        >
-          {results}
-          {emptyMessage}
-          {createSectionElementWhenEmpty}
-        </ContentPanel>
-      </div>
+      <ContentPanel
+        aside={progressData}
+        onOpenNavigation={this.onOpenNavigation}
+        modifier="materials"
+        navigation={this.props.navigation}
+        title={this.props.i18n.text.get("plugin.workspace.materials.pageTitle")}
+        ref="content-panel"
+      >
+        {results}
+        {emptyMessage}
+        {createSectionElementWhenEmpty}
+      </ContentPanel>
     );
   }
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/print.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/print.scss
@@ -2,7 +2,7 @@
   body {
     /* stylelint-disable declaration-no-important */
     background-color: $color-default !important;
-    /* stylelint-ensable declaration-no-important */
+    /* stylelint-enable declaration-no-important */
   }
 
   .content-panel__navigation-open,
@@ -20,10 +20,13 @@
     position: relative;
   }
 
-  .application-panel-wrapper .application-panel,
-  .reading-panel-wrapper .reading-panel,
-  .content-panel-wrapper .content-panel {
-    padding: 1rem 0 0;
+  .application-panel,
+  .reading-panel,
+  .content-panel {
+
+    /* stylelint-disable declaration-no-important */
+    padding: 1rem 0 0 !important;
+    /* stylelint-ensable declaration-no-important */
   }
 
   .screen-container .screen-container__wrapper {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-list.scss
@@ -834,11 +834,10 @@
 }
 
 .application-list__item-content-header--journal-entry {
-  padding: 10px;
+  padding: 20px 0 0;
 
   @include breakpoint($breakpoint-pad) {
     font-size: 1.125rem;
-    padding: 10px 0;
   }
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
@@ -3,6 +3,7 @@
 @import "../base/vars";
 @import "../base/breakpoints";
 
+// THE component
 .application-panel {
   align-items: center;
   display: flex;
@@ -17,22 +18,12 @@
   }
 }
 
-// This removes the unnecessary top-padding in studies and profile view as there is no toolbar present
-.application-panel--studies,
-.application-panel--profile {
-  .application-panel__content {
-    padding: 10px 0;
-  }
-}
-
-.application-panel--workspace-journal {
+// Component when used within tabs within dialog
+.application-panel--tabs-with-dialog {
   padding: 0;
-
-  @include breakpoint($breakpoint-pad) {
-    padding: calc(#{$navbar-desktop-height} * 1.25) 10px 10px;
-  }
 }
 
+// Component's wrapper
 .application-panel__container {
   @include text;
 
@@ -41,36 +32,7 @@
   width: 100%;
 }
 
-.application-panel__body {
-  @include panel-body;
-
-  background-color: $color-application-panel-box-background;
-  box-shadow: 0 2px 3px $color-panel-shadow;
-  display: flex;
-  flex-direction: column;
-
-  @include breakpoint($breakpoint-pad) {
-    border: solid 1px $color-application-panel-box-border;
-    box-shadow: none;
-  }
-}
-
-.application-panel__body--guider-student {
-  @include breakpoint($breakpoint-pad) {
-    border: none;
-  }
-}
-
-.application-panel__body--tabs {
-  @include breakpoint($breakpoint-pad) {
-    border-bottom: solid 1px $color-application-panel-box-border;
-    border-left: solid 1px $color-application-panel-box-border;
-    border-right: solid 1px $color-application-panel-box-border;
-    border-top: 0;
-    box-shadow: none;
-  }
-}
-
+// Component's header that acts as view title
 .application-panel__header {
   display: none;
 
@@ -89,6 +51,7 @@
   }
 }
 
+// Component's actual title (h1 level element)
 .application-panel__header-title {
   display: none;
 
@@ -105,6 +68,7 @@
   }
 }
 
+// Component's header's actions at the header level (ie. signature feature)
 .application-panel__header-actions {
   display: none;
 
@@ -117,6 +81,36 @@
   }
 }
 
+// Component's body that has .application-panel__actions and .application-panel__content as childs
+.application-panel__body {
+  @include panel-body;
+
+  background-color: $color-application-panel-box-background;
+  box-shadow: 0 2px 3px $color-panel-shadow;
+  display: flex;
+  flex-direction: column;
+
+  @include breakpoint($breakpoint-pad) {
+    border: solid 1px $color-application-panel-box-border;
+    box-shadow: none;
+  }
+}
+
+// Component body when used within tabs within dialog
+.application-panel__body--tabs-with-dialog {
+  @include breakpoint($breakpoint-pad) {
+    border: none;
+  }
+}
+
+// Component's body which is used inside tabs
+.application-panel__body--tabs {
+  @include breakpoint($breakpoint-pad) {
+    border-top: 0;
+  }
+}
+
+// Component's actions row that has .application-panel__actions-aside and .application-panel__actions-main as childs
 .application-panel__actions {
   background: $color-default;
   left: 0;
@@ -137,6 +131,7 @@
   }
 }
 
+// Component's actions row which is used inside tabs
 .application-panel__actions--tabs {
   position: static;
 
@@ -145,6 +140,49 @@
   }
 }
 
+// Component's actions aside used for primary functions (ie. new message)
+.application-panel__actions-aside {
+  display: none;
+  height: auto;
+
+  @include breakpoint($breakpoint-pad) {
+    align-items: center;
+    border-bottom: 1px solid $color-main-function-application-panel-actions-border;
+    display: flex;
+    flex-basis: 220px;
+    flex-grow: 0;
+    flex-shrink: 0;
+    height: $navbar-desktop-height;
+    margin: 0;
+    padding: 12px;
+    z-index: 1;
+  }
+}
+
+// Component's actions main container which contains the .application-panel__toolbar
+.application-panel__actions-main {
+  background: $color-default;
+  border-bottom: 2px solid $color-main-function-application-panel-actions-border;
+  flex-basis: auto;
+  flex-flow: row wrap;
+  flex-grow: 1;
+  flex-shrink: 1;
+  height: $navbar-mobile-height;
+  margin: 0;
+  min-width: 0;
+  padding: 10px;
+  position: relative;
+  width: 100%;
+
+  @include breakpoint($breakpoint-pad) {
+    background: transparent;
+    border-width: 1px;
+    height: $navbar-desktop-height;
+    padding: 12px;
+  }
+}
+
+// Component's toolbar that has .application-panel__toolbar-actions-main and .application-panel__toolbar-actions-aside as childs
 .application-panel__toolbar {
   align-items: center;
   display: flex;
@@ -152,39 +190,13 @@
   width: 100%;
 }
 
-.application-panel__tool--current-folder {
-  align-items: center;
+// Component's toolbar's actions aside (usually on the right side with prev and next buttons)
+.application-panel__toolbar-actions-aside {
   display: flex;
-  flex-basis: auto;
-  flex-grow: 1;
-  flex-shrink: 1;
-  font-weight: 400;
-  overflow: hidden;
-  position: relative;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  @include breakpoint($breakpoint-pad) {
-    display: none;
-  }
+  justify-content: flex-end;
 }
 
-.application-panel__tool-icon {
-  font-size: 1rem;
-  height: auto;
-  padding: 0 5px 0 0;
-  width: 22px;
-}
-
-.application-panel__tool-title {
-  display: inline-block;
-  font-size: 1rem;
-  max-width: calc(100% - 44px); // 44px is sum of folders icon and label edit icon widths
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
+// Component's toolbar's actions main that has prominent actions and buttons
 .application-panel__toolbar-actions-main {
   align-items: center;
   display: flex;
@@ -193,18 +205,20 @@
   flex-shrink: 1;
 }
 
-.application-panel__tools-container {
+// Component's toolbar's additional container used primarily for search fields
+.application-panel__toolbar-tools-container {
   display: flex;
   flex-basis: auto;
   flex-grow: 1;
   flex-shrink: 1;
+  margin: 0 0 0 10px;
+
+  @include breakpoint($breakpoint-pad) {
+    margin: 0;
+  }
 }
 
-.application-panel__toolbar-actions-aside {
-  display: flex;
-  justify-content: flex-end;
-}
-
+// Component's content row that has .application-panel__content-aside and .application-panel__content-main as childs
 .application-panel__content {
   padding: $navbar-mobile-height 0 0;
 
@@ -215,10 +229,7 @@
   }
 }
 
-.application-panel__content--tabs {
-  padding: 1.5rem 0 0;
-}
-
+// Component's content header (h2 level header)
 .application-panel__content-header {
   font-size: 1.25rem;
   font-weight: 300;
@@ -231,9 +242,8 @@
   }
 }
 
-// Helper containers
-
-.application-panel__helper-container {
+// Component's content aside used for filters, folders and subnavigations
+.application-panel__content-aside {
   display: none;
   height: auto;
 
@@ -255,28 +265,13 @@
   }
 }
 
-// Helper container's sticky position for Profile and Studies view has different height and top property values
-.application-panel__helper-container--profile,
-.application-panel__helper-container--studies {
-  @include breakpoint($breakpoint-pad) {
-    height: calc(100vh - 97px); // 100 View-port height - top offset which is 77px + <main> 10px padding-bottom + 1px for border + 8px margin-bottom
-    top: 77px;
-  }
-}
-
-.application-panel__helper-container--main-action {
-  align-items: center;
-  border-bottom: 1px solid $color-main-function-application-panel-actions-border;
-  height: $navbar-desktop-height;
-  margin: 0;
-}
-
-.application-panel__helper-container--guider-student {
+// Component's content aside used for filters, folders and subnavigations, this is special version to be used in dialogs within tabs
+.application-panel__content-aside--tabs-with-dialog {
   padding: 0 12px 0 0;
 }
 
-// Main containers
-.application-panel__main-container {
+// Component's content main container for the primary data
+.application-panel__content-main {
   flex-basis: auto;
   flex-grow: 1;
   flex-shrink: 1;
@@ -291,39 +286,35 @@
   }
 }
 
-.application-panel__main-container--actions {
-  background: $color-default;
-  border-bottom: 2px solid $color-main-function-application-panel-actions-border;
-  flex-direction: row;
-  height: $navbar-mobile-height;
-  padding: 10px;
+.application-panel__mobile-current-folder {
+  align-items: center;
+  display: flex;
+  flex-basis: auto;
+  flex-grow: 1;
+  flex-shrink: 1;
+  font-weight: 400;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   @include breakpoint($breakpoint-pad) {
-    background: transparent;
-    border-width: 1px;
-    height: $navbar-desktop-height;
-    padding: 12px;
+    display: none;
   }
 }
 
-.application-panel__main-container--workspace-journal {
-  display: none;
-
-  @include breakpoint($breakpoint-pad) {
-    display: block;
-  }
+.application-panel__mobile-current-folder-icon {
+  font-size: 1rem;
+  height: auto;
+  padding: 0 5px 0 0;
+  width: 22px;
 }
 
-.application-panel__main-container--guider-student {
-  padding: 0 0 0 12px;
-}
-
-.application-panel__main-container--header {
-  justify-content: flex-end;
-}
-
-.application-panel__main-container--content-full {
-  @include breakpoint($breakpoint-pad) {
-    padding-left: 0;
-  }
+.application-panel__mobile-current-folder-title {
+  display: inline-block;
+  font-size: 1rem;
+  max-width: calc(100% - 44px); // 44px is sum of folders icon and label edit icon widths
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
@@ -265,7 +265,7 @@
   }
 }
 
-// Component's content aside used for filters, folders and subnavigations, this is special version to be used in dialogs within tabs
+// Component's content aside when used within tabs within dialog
 .application-panel__content-aside--tabs-with-dialog {
   padding: 0 12px 0 0;
 }
@@ -286,6 +286,7 @@
   }
 }
 
+// Component's mobile folder container
 .application-panel__mobile-current-folder {
   align-items: center;
   display: flex;
@@ -303,6 +304,7 @@
   }
 }
 
+// Component's mobile folder's icon
 .application-panel__mobile-current-folder-icon {
   font-size: 1rem;
   height: auto;
@@ -310,6 +312,7 @@
   width: 22px;
 }
 
+// Component's mobile folder's title
 .application-panel__mobile-current-folder-title {
   display: inline-block;
   font-size: 1rem;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/application-panel.scss
@@ -213,6 +213,11 @@
   flex-shrink: 1;
   margin: 0 0 0 10px;
 
+  // When this container is the first element it usually is the only element as in course picker and we don't want margins then
+  &:first-child {
+    margin: 0;
+  }
+
   @include breakpoint($breakpoint-pad) {
     margin: 0;
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -3,12 +3,6 @@
 @import "../base/vars";
 @import "../base/breakpoints";
 
-.content-panel-wrapper {
-  flex-basis: auto;
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-
 .content-panel {
   align-items: center;
   display: flex;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
@@ -462,11 +462,17 @@ legend {
   border-right: 2px solid $color-main-function-input-field-decoration-background;
   border-top: 2px solid $color-main-function-input-field-border;
   width: 100%;
+}
 
-  &:focus {
-    position: fixed;
-    right: 46px;
-    width: calc(100% - 56px);
+.form-element__input--search:focus {
+  position: fixed;
+  right: 46px;
+  width: calc(100% - 56px);
+
+  @include breakpoint($breakpoint-pad) {
+    position: relative;
+    right: unset;
+    width: 100%;
   }
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
@@ -249,6 +249,8 @@ legend {
 .form-element--add-producer,
 .form-element--search {
   @include form-element-toolbar;
+
+  justify-content: flex-end;
 }
 
 .form-element--search {
@@ -455,9 +457,17 @@ legend {
 .form-element__input--add-producer,
 .form-element__input--add-material-producer {
   background-color: $color-default;
-  border: 2px solid $color-main-function-input-field-border;
-  margin-right: -2px; // Hides the right border and border-radius effect to provide more unified look
+  border-bottom: 2px solid $color-main-function-input-field-border;
+  border-left: 2px solid $color-main-function-input-field-border;
+  border-right: 2px solid $color-main-function-input-field-decoration-background;
+  border-top: 2px solid $color-main-function-input-field-border;
   width: 100%;
+
+  &:focus {
+    position: fixed;
+    right: 46px;
+    width: calc(100% - 56px);
+  }
 }
 
 // TEXTFIELD DECORATION

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/form.scss
@@ -460,15 +460,6 @@ legend {
   width: 100%;
 }
 
-// Communicator Message Search
-.form-element--communicator-message-search {
-  display: none;
-
-  @include breakpoint($breakpoint-pad) {
-    display: flex;
-  }
-}
-
 // TEXTFIELD DECORATION
 .form-element__input-decoration {
   border-radius: 2px;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/wcag.scss
@@ -8,6 +8,7 @@
   left: -10000px;
   overflow: hidden;
   position: absolute;
+  user-select: none;
   width: 1px;
 }
 


### PR DESCRIPTION
Closes #6192 

Minor touches to form-elements, application-list, reading-panel and content-panel

Unified application-panel's views so we don't have to use modifiers normally, therefore reducing potential overlapping via styling.