### PR TITLE
* Fix for certain symbols rendering inside matheditor's formula

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
@@ -137,7 +137,7 @@ export function toSVG(
       mjOut.setAttribute("xmlns", "http://www.w3.org/2000/svg");
       newImage.src =
         "data:image/svg+xml;base64," +
-        window.btoa(decodeURIComponent(encodeURIComponent(mjOut.outerHTML)));
+        window.btoa(unescape(encodeURIComponent(mjOut.outerHTML)));
     } else {
       newImage.src = errorSrc;
     }


### PR DESCRIPTION
Closes #6258 

This fixes `\sphericalangle` symbol's rendering as part of formula in the MathEditor