### PR TITLE
Students see now even hidden materials if they have already answered …

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/evaluation/evaluation-assessment-list.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/evaluation/evaluation-assessment-list.tsx
@@ -79,14 +79,23 @@ const AssessmentList: React.FC<AssessmentListProps> = (props) => {
 
   /**
    * Shows hidden evaluation assignment if it's has been submitted and assignment
-   * is set to be hidden
+   * is set to be hidden or even if student has answered it before it was set to hidden then
+   * other states are also shown as they are part of evaluation
    *
    * @param compositeReply assignment compositereply
    * @returns boolean whether to show assignment or not
    */
   const showAsHiddenEvaluationAssignment = (
     compositeReply?: MaterialCompositeRepliesType
-  ): boolean => compositeReply && compositeReply.submitted !== null;
+  ): boolean =>
+    compositeReply &&
+    (compositeReply.submitted !== null ||
+      compositeReply.state === "ANSWERED" ||
+      compositeReply.state === "SUBMITTED" ||
+      compositeReply.state === "WITHDRAWN" ||
+      compositeReply.state === "PASSED" ||
+      compositeReply.state === "FAILED" ||
+      compositeReply.state === "INCOMPLETE");
 
   /**
    * Handles close specific material content
@@ -118,17 +127,13 @@ const AssessmentList: React.FC<AssessmentListProps> = (props) => {
     setListOfAssignmentIds(updatedList);
   };
 
-  /**
-   * renderEvaluationAssessmentAssignments
-   */
+  // renderEvaluationAssessmentAssignments
   const renderEvaluationAssessmentAssignments =
     evaluation.evaluationCurrentStudentAssigments.data &&
     evaluation.evaluationCurrentStudentAssigments.data.assigments.length > 0 ? (
       evaluation.evaluationCurrentStudentAssigments.data.assigments.map(
         (item, i) => {
-          /**
-           * Possible composite reply
-           */
+          // Possible composite reply
           const compositeReply =
             evaluation.evaluationCompositeReplies &&
             evaluation.evaluationCompositeReplies.data &&
@@ -138,17 +143,13 @@ const AssessmentList: React.FC<AssessmentListProps> = (props) => {
 
           let showAsHidden = false;
 
-          /**
-           * If item is set to be hidden check is student has submitted it before
-           * it was set to hidden
-           */
+          // If item is set to be hidden check is student has submitted it before
+          // it was set to hidden
           if (item.hidden) {
             showAsHidden = showAsHiddenEvaluationAssignment(compositeReply);
           }
 
-          /**
-           * Don't show assignment
-           */
+          // Don't show assignment
           if (item.hidden && !showAsHidden) {
             return null;
           }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
@@ -677,11 +677,20 @@ class WorkspaceMaterials extends React.Component<
 
           let showEvenIfHidden = false;
 
-          // if student has submitted something before material has been set to hidden
+          // if student has submitted something before material has been set to hidden or
+          // if student has answered something before material has been set to hidden then also
+          // other states are also shown as they are part of evaluation
           // It will be still shown to student
           if (node.hidden && compositeReplies) {
             showEvenIfHidden =
-              compositeReplies && compositeReplies.submitted !== null;
+              compositeReplies &&
+              (compositeReplies.submitted !== null ||
+                compositeReplies.state === "ANSWERED" ||
+                compositeReplies.state === "SUBMITTED" ||
+                compositeReplies.state === "WITHDRAWN" ||
+                compositeReplies.state === "PASSED" ||
+                compositeReplies.state === "FAILED" ||
+                compositeReplies.state === "INCOMPLETE");
           }
 
           // Actual page material


### PR DESCRIPTION
Students see now even hidden materials if they have already answered and not submitted those. Those cases works like normal materials from that point on with small visual difference. Evaluation has also corresponding changed made.

Resolves: #6407 