### PR TITLE
Temporary solution. Ckeditor needs work.

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceManagement/body/management.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceManagement/body/management.tsx
@@ -762,14 +762,20 @@ class ManagementPanel extends React.Component<
                           "plugin.workspace.management.title.basicInfo.description"
                         )}
                       </label>
-                      <CKEditor
-                        editorTitle={this.props.i18n.text.get(
-                          "plugin.wcag.workspaceDescription.label"
-                        )}
-                        onChange={this.onDescriptionChange}
-                      >
-                        {this.state.workspaceDescription}
-                      </CKEditor>
+                      {
+                        // TODO: This is a temporary fix for Ckedtior not showing content
+                        // between view changes or refreshes. This should be fixed in CKEditor
+                      }
+                      {this.state.workspaceDescription && (
+                        <CKEditor
+                          editorTitle={this.props.i18n.text.get(
+                            "plugin.wcag.workspaceDescription.label"
+                          )}
+                          onChange={this.onDescriptionChange}
+                        >
+                          {this.state.workspaceDescription}
+                        </CKEditor>
+                      )}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Current solution is only temporary fix for workspace management description blank problem. The actual problem still lies in ckeditor component that for some reason doesn't set data correctly. This pr might change later

Resolves: #6415 