### PR TITLE
Changed JS url to not unnecessarily depend on faces

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/audio-field/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/audio-field/index.tsx
@@ -19,8 +19,7 @@ import { createFieldSavedStateClass } from "../../base/index";
 if (!(window as any).MediaRecorder) {
   const script = document.createElement("script");
   // CONTEXTPATHREMOVED
-  script.src =
-    "/javax.faces.resource/scripts/dist/polyfill-mediarecorder.js.jsf";
+  script.src = "/scripts/dist/polyfill-mediarecorder.js";
   script.async = true;
   document.head.appendChild(script);
 }


### PR DESCRIPTION
Closes #6400

This affects audio record field when it is polyfilled (old browsers?). It's a simple change but probably safe to manually test with more cases before rollout.