### PR TITLE
Cleanup: warnings

### DIFF
--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/announcer/AnnouncerPermissionsTestsIT.java
@@ -45,7 +45,7 @@ public class AnnouncerPermissionsTestsIT extends AbstractAnnouncerRESTTestsIT {
       .body(publicAnnouncement)
       .post("/announcer/announcements");
     
-    publicAnnouncementId = new Long(response.body().jsonPath().getInt("id"));
+    publicAnnouncementId = response.body().jsonPath().getLong("id");
   }
   
   @Before
@@ -97,7 +97,7 @@ public class AnnouncerPermissionsTestsIT extends AbstractAnnouncerRESTTestsIT {
       .body(publicAnnouncement)
       .post("/announcer/announcements");
     
-    workspace2AnnouncementId = new Long(response.body().jsonPath().getInt("id"));
+    workspace2AnnouncementId = response.body().jsonPath().getLong("id");
   }
   
   @Before

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/forum/ForumMessagePermissionsTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/forum/ForumMessagePermissionsTestsIT.java
@@ -32,7 +32,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
 
-    forumAreaId = new Long(response.body().jsonPath().getInt("id"));
+    forumAreaId = response.body().jsonPath().getLong("id");
 
     // Create thread
     
@@ -43,7 +43,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(thread)
       .post("/forum/areas/{ID}/threads", forumAreaId);
     
-    threadId = new Long(response.body().jsonPath().getInt("id"));
+    threadId = response.body().jsonPath().getLong("id");
 
     // Create reply
     
@@ -55,7 +55,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(reply)
       .post("/forum/areas/{ID}/threads/{ID2}/replies", forumAreaId, threadId);
 
-    replyId = new Long(response.body().jsonPath().getInt("id"));
+    replyId = response.body().jsonPath().getLong("id");
   }
   
   @After
@@ -78,7 +78,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThread(forumAreaId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThread(forumAreaId, response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -94,7 +94,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThread(forumAreaId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThread(forumAreaId, response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -110,7 +110,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThread(forumAreaId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThread(forumAreaId, response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -126,7 +126,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThread(forumAreaId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThread(forumAreaId, response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -142,7 +142,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThreadReply(forumAreaId, threadId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThreadReply(forumAreaId, threadId, response.body().jsonPath().getLong("id"));
   }
 
   @Test
@@ -158,7 +158,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThreadReply(forumAreaId, threadId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThreadReply(forumAreaId, threadId, response.body().jsonPath().getLong("id"));
   }
 
   @Test
@@ -174,7 +174,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThreadReply(forumAreaId, threadId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThreadReply(forumAreaId, threadId, response.body().jsonPath().getLong("id"));
   }
 
   @Test
@@ -190,7 +190,7 @@ public class ForumMessagePermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
     
-    permanentDeleteThreadReply(forumAreaId, threadId, new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteThreadReply(forumAreaId, threadId, response.body().jsonPath().getLong("id"));
   }
   
   @Test

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/forum/ForumPermissionsTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/plugins/forum/ForumPermissionsTestsIT.java
@@ -23,7 +23,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
     
-    areaId = new Long(response.body().jsonPath().getInt("id"));
+    areaId = response.body().jsonPath().getLong("id");
   }
   
   @After
@@ -43,7 +43,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
 
-    permanentDeleteArea(new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteArea(response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -58,7 +58,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
 
-    permanentDeleteArea(new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteArea(response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -73,7 +73,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
     response.then()
       .statusCode(200);
 
-    permanentDeleteArea(new Long(response.body().jsonPath().getInt("id")));
+    permanentDeleteArea(response.body().jsonPath().getLong("id"));
   }
   
   @Test
@@ -172,7 +172,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
 
-    Long id = new Long(response.body().jsonPath().getInt("id"));
+    Long id = response.body().jsonPath().getLong("id");
 
     Response deleteResponse = asAdmin()
       .delete("/forum/areas/{ID}", id);
@@ -193,7 +193,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
 
-    Long id = new Long(response.body().jsonPath().getInt("id"));
+    Long id = response.body().jsonPath().getLong("id");
 
     asManager()
       .delete("/forum/areas/{ID}", id)
@@ -212,7 +212,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
 
-    Long id = new Long(response.body().jsonPath().getInt("id"));
+    Long id = response.body().jsonPath().getLong("id");
 
     asTeacher()
       .delete("/forum/areas/{ID}", id)
@@ -231,7 +231,7 @@ public class ForumPermissionsTestsIT extends AbstractForumRESTTestsIT {
       .body(forum)
       .post("/forum/areas");
 
-    Long id = new Long(response.body().jsonPath().getInt("id"));
+    Long id = response.body().jsonPath().getLong("id");
 
     asStudent()
       .delete("/forum/areas/{ID}", id)

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/newevaluation/NewEvaluationTestsBase.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/ui/base/newevaluation/NewEvaluationTestsBase.java
@@ -55,7 +55,7 @@ public class NewEvaluationTestsBase extends AbstractUITest {
     try{
       mockBuilder.addStudent(student).addStaffMember(admin).mockLogin(admin).addCourse(course1).build();
 
-      Double price = new Double(75);
+      Double price = 75d;
       WorklistBasePriceRestModel courseBasePrices = new WorklistBasePriceRestModel();
       courseBasePrices.put(course1.getCourseModules().iterator().next().getId(), price);
       

--- a/muikku-core-plugins-persistence/pom.xml
+++ b/muikku-core-plugins-persistence/pom.xml
@@ -49,12 +49,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/announcer/model/Announcement.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/announcer/model/Announcement.java
@@ -12,7 +12,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Announcement {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/announcer/model/AnnouncementAttachment.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/announcer/model/AnnouncementAttachment.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class AnnouncementAttachment {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/model/CeeposOrder.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/model/CeeposOrder.java
@@ -15,7 +15,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/model/CeeposProduct.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/ceepos/model/CeeposProduct.java
@@ -9,7 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class CeeposProduct {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/chat/model/UserChatSettings.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/chat/model/UserChatSettings.java
@@ -9,7 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class UserChatSettings {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessage.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessage.java
@@ -19,7 +19,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.security.ContextReference;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageAttachment.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageAttachment.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class CommunicatorMessageAttachment {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageCategory.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageCategory.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class CommunicatorMessageCategory {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageSignature.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageSignature.java
@@ -10,7 +10,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.security.ContextReference;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageTemplate.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorMessageTemplate.java
@@ -10,7 +10,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.security.ContextReference;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorUserLabel.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/communicator/model/CommunicatorUserLabel.java
@@ -4,7 +4,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.PrimaryKeyJoinColumn;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @PrimaryKeyJoinColumn(name = "id")

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/data/model/ProcessedScript.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/data/model/ProcessedScript.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class ProcessedScript {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/model/WorkspaceMaterialEvaluationAudioClip.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/model/WorkspaceMaterialEvaluationAudioClip.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class WorkspaceMaterialEvaluationAudioClip {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/feed/model/Feed.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/feed/model/Feed.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Feed {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/forum/model/ForumArea.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/forum/model/ForumArea.java
@@ -11,7 +11,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Version;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 import fi.otavanopisto.muikku.model.util.OwnedEntity;

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/forum/model/ForumAreaGroup.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/forum/model/ForumAreaGroup.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/Hops.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/Hops.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Hops {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsGoals.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsGoals.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsGoals {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsHistory.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsHistory.java
@@ -12,7 +12,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsHistory {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsOptionalSuggestion.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsOptionalSuggestion.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsOptionalSuggestion {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsStudentChoice.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsStudentChoice.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsStudentChoice {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsStudyHours.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsStudyHours.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsStudyHours {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsSuggestion.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/hops/model/HopsSuggestion.java
@@ -11,7 +11,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class HopsSuggestion {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/internalauth/model/InternalAuth.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/internalauth/model/InternalAuth.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class InternalAuth {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/BinaryMaterial.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/BinaryMaterial.java
@@ -7,7 +7,7 @@ import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @PrimaryKeyJoinColumn(name="id")

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/HtmlMaterial.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/HtmlMaterial.java
@@ -9,7 +9,7 @@ import javax.persistence.Transient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/Material.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/Material.java
@@ -18,7 +18,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Inheritance(strategy=InheritanceType.JOINED)

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/MaterialProducer.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/MaterialProducer.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryConnectFieldOption.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryConnectFieldOption.java
@@ -10,7 +10,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Inheritance(strategy=InheritanceType.JOINED)

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryField.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryField.java
@@ -12,7 +12,7 @@ import javax.persistence.PersistenceException;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Inheritance(strategy=InheritanceType.JOINED)

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryMultiSelectFieldOption.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QueryMultiSelectFieldOption.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class QueryMultiSelectFieldOption {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QuerySelectFieldOption.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/QuerySelectFieldOption.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class QuerySelectFieldOption {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/matriculation/model/SavedMatriculationEnrollment.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/matriculation/model/SavedMatriculationEnrollment.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/matriculation/model/SentMatriculationEnrollment.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/matriculation/model/SentMatriculationEnrollment.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserEmail.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserEmail.java
@@ -8,8 +8,8 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.Email;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserImage.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserImage.java
@@ -9,7 +9,7 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class LocalUserImage {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserPropertyKey.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/schooldatalocal/model/LocalUserPropertyKey.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/wall/model/AbstractWallEntry.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/wall/model/AbstractWallEntry.java
@@ -14,7 +14,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;
 

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketTicket.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/websocket/WebSocketTicket.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceEntityFile.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceEntityFile.java
@@ -11,7 +11,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class WorkspaceEntityFile {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialAudioFieldAnswerClip.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialAudioFieldAnswerClip.java
@@ -10,7 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @PrimaryKeyJoinColumn(name="id")

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialFileFieldAnswerFile.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialFileFieldAnswerFile.java
@@ -10,7 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @PrimaryKeyJoinColumn(name="id")

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceNode.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceNode.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Inheritance (strategy = InheritanceType.JOINED)

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceToolSettings.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceToolSettings.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Table (

--- a/muikku-core-plugins/pom.xml
+++ b/muikku-core-plugins/pom.xml
@@ -126,12 +126,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Jackson -->
 
     <dependency>

--- a/muikku-example-plugin-3/src/main/java/fi/muikku/plugins/fish/model/FishMessage.java
+++ b/muikku-example-plugin-3/src/main/java/fi/muikku/plugins/fish/model/FishMessage.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 import javax.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class FishMessage {

--- a/muikku-persistence/pom.xml
+++ b/muikku-persistence/pom.xml
@@ -66,12 +66,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Muikku -->
 
     <dependency>

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/SchoolDataSource.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/SchoolDataSource.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/SystemSetting.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/SystemSetting.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class SystemSetting {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/Tag.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/base/Tag.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Tag {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/coursemeta/CourseIdentifierSchoolDataIdentifier.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/coursemeta/CourseIdentifierSchoolDataIdentifier.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/grading/GradingScaleEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/grading/GradingScaleEntity.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/grading/GradingScaleItemEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/grading/GradingScaleItemEntity.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/notifier/NotifierActionEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/notifier/NotifierActionEntity.java
@@ -5,7 +5,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class NotifierActionEntity {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/notifier/NotifierMethodEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/notifier/NotifierMethodEntity.java
@@ -5,7 +5,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class NotifierMethodEntity {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/Consumer.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/Consumer.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/ConsumerPermission.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/ConsumerPermission.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/ConsumerScope.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/ConsumerScope.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/RequestToken.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/RequestToken.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Cacheable (true)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/Token.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/Token.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.users.UserEntity;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/Plugin.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/Plugin.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 import javax.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Plugin {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/PluginSettingKey.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/PluginSettingKey.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Table (

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/PluginUserSettingKey.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/plugins/PluginUserSettingKey.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Table (

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/AuthSource.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/AuthSource.java
@@ -6,8 +6,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class AuthSource {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/AuthSourceSetting.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/AuthSourceSetting.java
@@ -7,8 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
-import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class AuthSourceSetting {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/Permission.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/Permission.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Permission {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/UserIdentification.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/security/UserIdentification.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.users.UserEntity;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/Flag.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/Flag.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Flag {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/OrganizationEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/OrganizationEntity.java
@@ -13,7 +13,7 @@ import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/RoleEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/RoleEntity.java
@@ -9,7 +9,7 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Inheritance(strategy=InheritanceType.JOINED)

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/RoleSchoolDataIdentifier.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/RoleSchoolDataIdentifier.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEmailEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEmailEntity.java
@@ -13,8 +13,8 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.Email;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.security.ContextReference;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEntityFile.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEntityFile.java
@@ -14,7 +14,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.users.UserEntity;
 

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEntityProperty.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserEntityProperty.java
@@ -11,7 +11,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Table (

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserGroupEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserGroupEntity.java
@@ -9,7 +9,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserGroupUserEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserGroupUserEntity.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.security.ContextReference;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserIdentifierProperty.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserIdentifierProperty.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 @Table (

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserPendingEmailChange.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserPendingEmailChange.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 
 @Entity

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserPendingPasswordChange.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserPendingPasswordChange.java
@@ -11,7 +11,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 
 @Entity

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserSchoolDataIdentifier.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/users/UserSchoolDataIdentifier.java
@@ -11,7 +11,7 @@ import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/Widget.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/Widget.java
@@ -9,7 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class Widget {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/WidgetSetting.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/WidgetSetting.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class WidgetSetting {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/WidgetSpace.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/widgets/WidgetSpace.java
@@ -7,7 +7,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class WidgetSpace {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceEntity.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.base.SchoolDataSource;
 import fi.otavanopisto.muikku.model.users.OrganizationEntity;

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceMaterialProducer.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceMaterialProducer.java
@@ -7,7 +7,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @Entity
 public class WorkspaceMaterialProducer {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceUserEntity.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/workspace/WorkspaceUserEntity.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
 import fi.otavanopisto.muikku.model.util.ArchivableEntity;

--- a/muikku-timed-notifications-plugin-persistence/pom.xml
+++ b/muikku-timed-notifications-plugin-persistence/pom.xml
@@ -30,12 +30,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Muikku -->
     <dependency>
       <groupId>fi.otavanopisto.muikku</groupId>

--- a/muikku-timed-notifications-plugin/pom.xml
+++ b/muikku-timed-notifications-plugin/pom.xml
@@ -56,12 +56,6 @@
       <scope>provided</scope>
     </dependency>
     
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Muikku -->
 
     <dependency>

--- a/muikku/pom.xml
+++ b/muikku/pom.xml
@@ -83,12 +83,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Commons -->
 
     <dependency>


### PR DESCRIPTION
Cleaned up two types of eclipse warnings that required low amount of effort:
* Some deprecated constructors like `new Long` - not all occurences as some will need more delicate care
* References to deprecated Hibernate Validators which are now found in JavaEE