### PR TITLE
Diary opening changes and bug fixed:

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/helpers.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/helpers.ts
@@ -273,6 +273,12 @@ export async function loadCurrentWorkspaceJournalsHelper(
         journals: currentJournalsList,
         hasMore: (currentJournalState && currentJournalState.hasMore) || false,
         userEntityId,
+        // If user changes, we need to reset the commentsLoaded
+        // because the commentsLoaded holds user based data which is not relevant anymore
+        commentsLoaded:
+          userEntityId === currentJournalState.userEntityId
+            ? currentJournalState.commentsLoaded
+            : [],
         state: journalNextstate,
       },
     },

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceJournal/body/application/workspace-journals-list-item.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceJournal/body/application/workspace-journals-list-item.tsx
@@ -69,7 +69,7 @@ class WorkspaceJournalsListItem extends React.Component<
   /**
    * handleJournalItemClick
    */
-  handleJournalItemClick = () => {
+  handleSetJournalItemClick = () => {
     !this.props.asCurrent &&
       this.props.setCurrentJournal({ currentJournal: this.props.journal });
   };
@@ -129,7 +129,7 @@ class WorkspaceJournalsListItem extends React.Component<
           modifiers={isMandatory && "mandatory"}
         >
           <ApplicationListItemHeader
-            onClick={this.handleJournalItemClick}
+            onClick={this.handleSetJournalItemClick}
             className="application-list__item-header--journal-entry"
             modifiers={
               this.props.asCurrent &&
@@ -218,10 +218,12 @@ class WorkspaceJournalsListItem extends React.Component<
             )}
             {!this.props.asCurrent && (
               <div className="application-list__item-footer-content-aside">
-                {this.props.i18n.text.get(
-                  "plugin.workspace.journal.comments.title"
-                )}{" "}
-                ({this.props.journal.commentCount})
+                <Link onClick={this.handleSetJournalItemClick}>
+                  {this.props.i18n.text.get(
+                    "plugin.workspace.journal.comments.title"
+                  )}{" "}
+                  ({this.props.journal.commentCount})
+                </Link>
               </div>
             )}
           </ApplicationListItemFooter>


### PR DESCRIPTION
- Setting current diary is now done by clicking the diary name or comment link
- Fixed bug where changing user filter would not update loaded comments array in redux state which caused crashing as changing user between users would not load the comments again even though comments would been missing.

Resolves: #6364 