### PR TITLE
Fixes baseUrl for attachments

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncerAttachmentUploadServlet.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/announcer/AnnouncerAttachmentUploadServlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -31,9 +32,12 @@ public class AnnouncerAttachmentUploadServlet extends HttpServlet {
 
   private static final long serialVersionUID = 2018253945748278665L;
 
+  /**
+   * Note: This is Instance as otherwise it's injected too early on container start and is always null.
+   */
   @Inject
   @BaseUrl
-  private String baseUrl;
+  private Instance<String> baseUrlInstance;
   
   @Inject
   private SessionController sessionController;
@@ -87,7 +91,8 @@ public class AnnouncerAttachmentUploadServlet extends HttpServlet {
       sendResponse(resp, "Could not save attachment", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       return;
     }
-    
+
+    String baseUrl = baseUrlInstance.get();
     String uploadedUrl = String.format("%s/rest/announcer/attachment/%s", baseUrl, announcementAttachment.getName());
     
     UploadMeta uploadMeta = new UploadMeta(file.getName(), 1, uploadedUrl);

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorAttachmentUploadServlet.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorAttachmentUploadServlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -31,9 +32,12 @@ public class CommunicatorAttachmentUploadServlet extends HttpServlet {
 
   private static final long serialVersionUID = 5873268027916522922L;
 
+  /**
+   * Note: This is Instance as otherwise it's injected too early on container start and is always null.
+   */
   @Inject
   @BaseUrl
-  private String baseUrl;
+  private Instance<String> baseUrlInstance;
   
   @Inject
   private SessionController sessionController;
@@ -87,7 +91,8 @@ public class CommunicatorAttachmentUploadServlet extends HttpServlet {
       sendResponse(resp, "Could not save attachment", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       return;
     }
-    
+
+    String baseUrl = baseUrlInstance.get();
     String uploadedUrl = String.format("%s/rest/communicator/attachment/%s", baseUrl, communicatorMessageAttachment.getName());
     
     UploadMeta uploadMeta = new UploadMeta(file.getName(), 1, uploadedUrl);


### PR DESCRIPTION
Fixes issue where new Java injects baseUrls before they are programmatically initialized and they remain null forever.