### PR TITLE
6491 notebook after review and testing fixes

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/button.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/button.tsx
@@ -239,9 +239,9 @@ export class IconButton extends React.Component<IconButtonProps, ButtonState> {
             ? reactivationDelayWrapper.bind(null, this.props.onClick)
             : null
         }
-        className={`button-icon ${(modifiers || [])
-          .map((s) => `button-icon--${s}`)
-          .join(" ")}`}
+        className={`button-icon ${
+          this.props.className ? this.props.className : ""
+        } ${(modifiers || []).map((s) => `button-icon--${s}`).join(" ")}`}
       >
         {this.props.icon && <span className={`icon-${this.props.icon}`}></span>}
         {this.props.children}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
@@ -33,6 +33,7 @@ import { IconButton } from "../button";
 import { useScroll } from "./hooks/useScroll";
 import { useDragDropManager } from "react-dnd";
 import Dropdown from "~/components/general/dropdown";
+import { useLocalStorage } from "usehooks-ts";
 
 export const HTML5toTouch: MultiBackendOptions = {
   backends: [
@@ -82,7 +83,12 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
 
   const notebookBodyRef = React.useRef<HTMLDivElement>(null);
 
-  const [openedItems, setOpenedItems] = React.useState<number[]>([]);
+  const openString = `opened-notes-${props.currentWorkspace.id}-${props.status.userId}`;
+
+  const [openedItems, setOpenedItems] = useLocalStorage<number[]>(
+    openString,
+    []
+  );
   const [editOrder, setEditOrder] = React.useState<boolean>(false);
 
   React.useEffect(() => {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
@@ -83,10 +83,8 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
 
   const notebookBodyRef = React.useRef<HTMLDivElement>(null);
 
-  const openString = `opened-notes-${props.currentWorkspace.id}-${props.status.userId}`;
-
   const [openedItems, setOpenedItems] = useLocalStorage<number[]>(
-    openString,
+    `opened-notes-${props.currentWorkspace.id}-${props.status.userId}`,
     []
   );
   const [editOrder, setEditOrder] = React.useState<boolean>(false);

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-editor.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-editor.tsx
@@ -105,6 +105,8 @@ class NoteEditor extends SessionStateComponent<
   NoteEditorProps,
   NoteEditorState
 > {
+  private inputRef: React.RefObject<HTMLInputElement> = React.createRef();
+  private focusIsUsed = false;
   /**
    * Constructor
    *
@@ -135,6 +137,8 @@ class NoteEditor extends SessionStateComponent<
    * componentDidMount
    */
   componentDidMount() {
+    this.inputRef.current.focus();
+
     this.setState(
       this.getRecoverStoredState(
         {
@@ -156,6 +160,13 @@ class NoteEditor extends SessionStateComponent<
     prevProps: Readonly<NoteEditorProps>,
     prevState: Readonly<NoteEditorState>
   ): void {
+    // Focus input if editor is opened, this is done only once for each active editor
+    // and is reset when note is changed or editor is closed
+    if (this.props.editorOpen && !this.focusIsUsed) {
+      this.inputRef.current.focus();
+      this.focusIsUsed = true;
+    }
+
     if (prevProps.note?.id !== this.props.note?.id) {
       const { status, currentWorkspace } = this.props;
 
@@ -235,6 +246,7 @@ class NoteEditor extends SessionStateComponent<
           );
 
           this.props.toggleNotebookEditor({ open: false });
+          this.focusIsUsed = false;
         },
       });
     } else {
@@ -256,6 +268,7 @@ class NoteEditor extends SessionStateComponent<
           );
 
           this.props.toggleNotebookEditor({ open: false });
+          this.focusIsUsed = false;
         },
       });
     }
@@ -266,6 +279,7 @@ class NoteEditor extends SessionStateComponent<
    */
   handleCancelClick = () => {
     this.props.toggleNotebookEditor({ open: false });
+    this.focusIsUsed = false;
   };
 
   /**
@@ -287,6 +301,7 @@ class NoteEditor extends SessionStateComponent<
                 </label>
 
                 <input
+                  ref={this.inputRef}
                   className="form-element__input form-element__input--note-title"
                   id="note-entry-title"
                   value={this.state.noteTitle}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-list.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-list.tsx
@@ -114,7 +114,21 @@ export const NoteListItem: React.FC<NoteListItemProps> = (props) => {
       key={props.note.id}
     >
       <div className="notebook__item-header">
+        <div className="notebook__item-title" onClick={handleOpenClick}>
+          {props.note.title}
+        </div>
         <div className="notebook__item-actions">
+          <Dropdown
+            openByHover
+            content={showContent ? <p>Sulje sisältö</p> : <p>Näytä sisältö</p>}
+          >
+            <IconButton
+              icon="arrow-down"
+              onClick={handleOpenClick}
+              className={showContent ? "state-OPEN" : ""}
+              buttonModifiers={["notebook-item-action", "note-item-content"]}
+            />
+          </Dropdown>
           <Dropdown openByHover content={<p>Muokkaa muistiinpanoa</p>}>
             <IconButton
               icon="pencil"
@@ -133,7 +147,10 @@ export const NoteListItem: React.FC<NoteListItemProps> = (props) => {
           </Dropdown>
         </div>
       </div>
-      <AnimateHeight height={deleteIsActive ? "auto" : 0}>
+      <AnimateHeight
+        height={deleteIsActive ? "auto" : 0}
+        contentClassName="notebook__item-delete-container"
+      >
         <div className="notebook__item-delete">
           <div className="notebook__item-description">
             Haluatko varmasti poistaa muistiinpanon?
@@ -151,10 +168,8 @@ export const NoteListItem: React.FC<NoteListItemProps> = (props) => {
           </div>
         </div>
       </AnimateHeight>
-      <div className="notebook__item-title" onClick={handleOpenClick}>
-        {props.note.title}
-      </div>
-      <AnimateHeight height={showContent ? "auto" : 28}>
+
+      <AnimateHeight height={showContent ? "auto" : 40}>
         <article className="notebook__item-body rich-text">
           <CkeditorContentLoader html={props.note.workspaceNote} />
         </article>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/index.tsx
@@ -27,6 +27,8 @@ import { connect, Dispatch } from "react-redux";
 import { bindActionCreators } from "redux";
 import { StateType } from "~/reducers";
 import { StatusType } from "~/reducers/base/status";
+import SessionStateComponent from "~/components/general/session-state-component";
+import { WorkspaceType } from "~/reducers/workspaces";
 
 export const HTML5toTouch: MultiBackendOptions = {
   backends: [
@@ -64,6 +66,7 @@ interface WorkspaceMaterialsBodyProps {
  */
 interface WorkspaceMaterialBodyState {
   activeTab: ToolTab;
+  draftId: string;
 }
 
 type ToolTab = "notebook" | "table-of-contents" | "journals";
@@ -71,7 +74,7 @@ type ToolTab = "notebook" | "table-of-contents" | "journals";
 /**
  * WorkspaceMaterialsBody
  */
-class WorkspaceMaterialsBody extends React.Component<
+class WorkspaceMaterialsBody extends SessionStateComponent<
   WorkspaceMaterialsBodyProps,
   WorkspaceMaterialBodyState
 > {
@@ -80,13 +83,33 @@ class WorkspaceMaterialsBody extends React.Component<
    * @param props props
    */
   constructor(props: WorkspaceMaterialsBodyProps) {
-    super(props);
+    super(props, "workspace-materials");
+
+    const draftId = `-${this.props.status.userId}`;
 
     this.state = {
-      activeTab: "table-of-contents",
+      ...this.getRecoverStoredState({
+        activeTab: "table-of-contents",
+        draftId,
+      }),
+      draftId,
     };
 
     this.onOpenNavigation = this.onOpenNavigation.bind(this);
+  }
+
+  /**
+   * componentDidMount
+   */
+  componentDidMount(): void {
+    this.setState({
+      ...this.getRecoverStoredState(
+        {
+          activeTab: "table-of-contents",
+        },
+        this.state.draftId
+      ),
+    });
   }
 
   /**
@@ -102,7 +125,7 @@ class WorkspaceMaterialsBody extends React.Component<
    * @param tab change to
    */
   handleActiveTabChange = (tab: ToolTab) => {
-    this.setState({ activeTab: tab });
+    this.setStateAndStore({ activeTab: tab }, this.state.draftId);
   };
 
   /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
@@ -28,7 +28,7 @@ $color-execute: #66b43b;
 $color-execute-contrast: $color-default;
 $color-clear: #ff6600;
 $color-clear-contrast: $color-default;
-$color-cancel: #7391a7;
+$color-cancel: #466175;
 $color-cancel-contrast: $color-default;
 $color-loading: $color-inverse;
 $color-loading-contrast: $color-default;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/buttons.scss
@@ -2273,6 +2273,15 @@
   }
 }
 
+.button-icon--note-item-content {
+  transform: rotate(0deg);
+  transition: 0.3s ease-in-out transform;
+
+  &.state-OPEN {
+    transform: rotate(-180deg);
+  }
+}
+
 .button-icon--reading-ruler-active {
   background: $color-default-contrast;
   border-radius: 100%;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/notebook.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/notebook.scss
@@ -91,12 +91,15 @@
   }
 }
 
+.notebook__item-delete-container {
+  padding: 5px 0 10px;
+}
+
 .notebook__item-delete {
   align-items: center;
   background: lighten($color-fatal, 40%);
   display: flex;
   flex-flow: column nowrap;
-  margin: 5px 0 10px;
   padding: 10px;
 }
 
@@ -119,15 +122,14 @@
 .notebook__item-header {
   align-items: flex-start;
   display: flex;
-  flex-flow: column nowrap;
-  justify-content: flex-start;
+  justify-content: space-between;
+  margin: 0 0 10px;
 }
 
 .notebook__item-title {
   cursor: pointer;
   font-size: 0.8125rem;
   font-weight: 600;
-  margin: 0 0 10px;
 
   @include breakpoint($breakpoint-pad) {
     font-size: 0.9375rem;
@@ -138,8 +140,6 @@
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  margin: 0 0 5px;
-  width: 100%;
 }
 
 .notebook__item-body {


### PR DESCRIPTION
- notebook item has show content buttons
- notebook item shows overflowing content if closed
- notebook editor focus on title input when opened
- notebook showOpened items are saved to localstorage
- content tab panel active tab is saved to localstorage
- delete button contrast changes

Resolves: #6491 