### PR TITLE
* Rollback of MathQuill as it seem to break matheditor occasionally

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/better-math-field/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/better-math-field/index.tsx
@@ -51,9 +51,9 @@ const ACE_MODE_SRC =
 // This is locally built from Digabi's fork of MathQuill
 // Version number corresponds with Digabi's versioning
 const MQ_DEFAULT_SRC =
-  "//cdn.muikkuverkko.fi/libs/mathquill/0.10.12/mathquill.min.js";
+  "//cdn.muikkuverkko.fi/libs/mathquill/0.10.1/mathquill.min.js";
 const MQ_DEFAULT_CSS =
-  "//cdn.muikkuverkko.fi/libs/mathquill/0.10.12/mathquill.css";
+  "//cdn.muikkuverkko.fi/libs/mathquill/0.10.1/mathquill.css";
 
 /**
  * MathField


### PR DESCRIPTION
Closes #6505 

Solves the issue of MathQuill loading before JQuery by rolling back to previous version of MathQuill. This is a quick fix and by rolling back we break \xrightleftharpoons symbols functionality which was added with the newer forked MathQuill version.

However students are in the need of functional matheditor and we need to fix this issue first and then investigate how we can make the newer version to work optimally.