### PR TITLE
Name extension added back to evaluation  workspace selectt

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application.tsx
@@ -109,7 +109,9 @@ class EvaluationApplication extends React.Component<
     const workspaceOptions = workspaces.map(
       (wItem, i) =>
         ({
-          label: wItem.name,
+          label: wItem.nameExtension
+            ? `${wItem.name} (${wItem.nameExtension})`
+            : wItem.name,
           value: wItem.id,
         } as OptionDefault<number>)
     );


### PR DESCRIPTION
Name extension is added back to evaluation workspace select option if it exist

Resolves: #6521 