### PR TITLE
6574 note overdue validating by day

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/notebook-pdf-dialog.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/notebook-pdf-dialog.tsx
@@ -58,6 +58,7 @@ const NoteBookPDFDialog = (props: NoteBookPDFDialogProps) => {
       onClose={onClose}
       title="Muistiinpanot"
       content={content}
+      disableScroll
     >
       {children}
     </Dialog>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/table-of-content-pdf-dialog.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/table-of-content-pdf-dialog.tsx
@@ -81,6 +81,7 @@ const TableOfContentPDFDialog = (props: TableOfContentPDFDialogProps) => {
       onClose={onClose}
       title="Sisällysluettelo"
       content={content}
+      disableScroll
     >
       {children}
     </Dialog>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/helper-functions/dates.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/helper-functions/dates.ts
@@ -6,4 +6,4 @@ import * as moment from "moment";
  * @returns Whether note is expired or late
  */
 export const isOverdue = (dueDate: Date | null) =>
-  dueDate !== null && moment(new Date()).isAfter(new Date(dueDate));
+  dueDate !== null && moment(new Date()).isAfter(new Date(dueDate), "day");


### PR DESCRIPTION
IsOverdue would check date based to whole time value including date + time. Now it only check against day value of date.
Pdf background scrolling disabled from table of content and notebook pdfs

Resolves: #6574 