### PR TITLE
Ckeditor dissapearing bug fixed

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/signature-update.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/signature-update.tsx
@@ -61,6 +61,25 @@ class CommunicatorSignatureUpdateDialog extends React.Component<
   }
 
   /**
+   * componentDidUpdate
+   * @param prevProps prevProps
+   * @param prevState prevState
+   */
+  componentDidUpdate(
+    prevProps: Readonly<CommunicatorSignatureUpdateDialogProps>,
+    prevState: Readonly<CommunicatorSignatureUpdateDialogState>
+  ): void {
+    // On first render signature might be null
+    // so we need to check if it's changes from null to something
+    // and update state
+    if (prevProps.signature !== this.props.signature) {
+      this.setState({
+        signature: this.props.signature ? this.props.signature.signature : "",
+      });
+    }
+  }
+
+  /**
    * handleKeydown
    * @param code code
    * @param closeDialog closeDialog
@@ -128,11 +147,9 @@ class CommunicatorSignatureUpdateDialog extends React.Component<
     const content = (closeDialog: () => any) => (
       <div className="env-dialog__row">
         <div className="env-dialog__form-element-container">
-          {this.state.signature && (
-            <CKEditor onChange={this.onCKEditorChange} autofocus>
-              {this.state.signature}
-            </CKEditor>
-          )}
+          <CKEditor onChange={this.onCKEditorChange} autofocus>
+            {this.state.signature}
+          </CKEditor>
         </div>
       </div>
     );


### PR DESCRIPTION
Communicator signature dialog ckeditor should be now visible again with correct value.

Resolves: #6588  