### PR TITLE
unactive student guiders are not anymore loaded in records

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/main-function.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/containers/main-function.tsx
@@ -1000,7 +1000,12 @@ export default class MainFunction extends React.Component<
       this.loadlib(
         `//cdn.muikkuverkko.fi/libs/ckeditor/${CKEDITOR_VERSION}/ckeditor.js`
       );
-      this.props.store.dispatch(loadContactGroup("counselors") as Action);
+
+      const state = this.props.store.getState();
+
+      if (state.status.isActiveUser) {
+        this.props.store.dispatch(loadContactGroup("counselors") as Action);
+      }
 
       this.props.websocket && this.props.websocket.restoreEventListeners();
       this.props.store.dispatch(


### PR DESCRIPTION
Unactive student guiders are not anymore loaded in records.

Resolves: #6599 