### PR TITLE
Added bindings to LocalizeTime class methods

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/i18n.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/i18n.ts
@@ -37,6 +37,13 @@ export class LocalizeTime {
    */
   constructor(language: string) {
     this.lang = language;
+
+    this.date = this.date.bind(this);
+    this.getLocalizedMoment = this.getLocalizedMoment.bind(this);
+    this.formatDaily = this.formatDaily.bind(this);
+    this.subtract = this.subtract.bind(this);
+    this.add = this.add.bind(this);
+    this.duration = this.duration.bind(this);
   }
 
   /**


### PR DESCRIPTION
Added bindings to LocalizeTime class methods to prevent crashing if methods are used as references with variables

Resolves: #6740 