### PR TITLE
6752 viestimen haku avaa hakutulosketjun vaarasta kansiosta

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/messages/index.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/messages/index.ts
@@ -4,8 +4,6 @@ import { Dispatch } from "react-redux";
 import {
   MessagesStateType,
   MessagesStatePatch,
-  MessageThreadUpdateType,
-  MessageRecepientType,
   MessagesNavigationItem,
 } from "~/reducers/main-function/messages";
 import { displayNotification } from "~/actions/base/notifications";
@@ -84,7 +82,7 @@ export type UPDATE_ONE_MESSAGE_THREAD = SpecificActionType<
   "UPDATE_ONE_MESSAGE_THREAD",
   {
     thread: MessageThread;
-    update: MessageThreadUpdateType;
+    update: Partial<MessageThread>;
   }
 >;
 export type UPDATE_MESSAGES_SIGNATURE = SpecificActionType<
@@ -509,8 +507,7 @@ const sendMessage: SendMessageTriggerType = function sendMessage(message) {
           state.messages.location === "inbox" ||
           state.messages.location === "unread";
         const weAreOneOfTheRecepients = result.recipients.find(
-          (recipient: MessageRecepientType) =>
-            recipient.userEntityId === status.userId
+          (recipient) => recipient.userEntityId === status.userId
         );
         const isInboxOrUnreadAndWeAreOneOfTheRecepients =
           isInboxOrUnread && weAreOneOfTheRecepients;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/messages/index.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/main-function/messages/index.ts
@@ -475,8 +475,6 @@ const sendMessage: SendMessageTriggerType = function sendMessage(message) {
       }
       dispatch(updateUnreadMessageThreadsCount());
 
-      /* mApi().communicator.sentitems.cacheClear(); */
-
       message.success && message.success();
 
       const state = getState();
@@ -847,8 +845,6 @@ const toggleMessageThreadReadStatus: ToggleMessageThreadReadStatusTriggerType =
           });
         }
       }
-
-      mApi().communicator[getApiId(item)].cacheClear();
 
       if (!dontLockToolbar) {
         dispatch({

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view/message-editor/answer-message-drawer.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view/message-editor/answer-message-drawer.tsx
@@ -7,7 +7,6 @@ import {
   SendMessageTriggerType,
   sendMessage,
 } from "~/actions/main-function/messages/index";
-import { MessageSignatureType } from "~/reducers/main-function/messages";
 import { ContactRecipientType } from "~/reducers/user-index";
 import { StatusType } from "~/reducers/base/status";
 import InputContactsAutofill from "~/components/base/input-contacts-autofill";
@@ -18,6 +17,7 @@ import "~/sass/elements/form.scss";
 import "~/sass/elements/environment-dialog.scss";
 import MApi from "~/api/api";
 import { WithTranslation, withTranslation } from "react-i18next";
+import { CommunicatorSignature } from "~/generated/client";
 
 /**
  * AnswerMessageDrawerProps
@@ -28,7 +28,7 @@ interface AnswerMessageDrawerProps extends WithTranslation {
   messageId?: number;
   extraNamespace?: string;
   initialSelectedItems?: Array<ContactRecipientType>;
-  signature: MessageSignatureType;
+  signature: CommunicatorSignature;
   sendMessage: SendMessageTriggerType;
   initialSubject?: string;
   initialMessage?: string;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view/message.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/message-view/message.tsx
@@ -11,7 +11,6 @@ import "~/sass/elements/label.scss";
 import "~/sass/elements/application-list.scss";
 import "~/sass/elements/link.scss";
 import AnswerMessageDrawer from "./message-editor/answer-message-drawer";
-import { MessageSignatureType } from "~/reducers/main-function/messages";
 import { AnyActionType } from "~/actions";
 import CkeditorLoaderContent from "../../../../base/ckeditor-loader/content";
 import { isStringHTML } from "~/helper-functions/shared";
@@ -20,6 +19,7 @@ import InfoPopover from "~/components/general/info-popover";
 // Message imported as IMessage to avoid conflict with Message component
 // Component can be renamed to something else if needed later
 import {
+  CommunicatorSignature,
   Message as IMessage,
   MessageThreadLabel,
   User,
@@ -31,7 +31,7 @@ import {
 interface MessageProps extends WithTranslation {
   message: IMessage;
   status: StatusType;
-  signature: MessageSignatureType;
+  signature: CommunicatorSignature;
   labels?: MessageThreadLabel[];
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
@@ -25,7 +25,6 @@ import {
 import {
   MessagesStateType,
   MessagesState,
-  MessageSearchResult,
 } from "~/reducers/main-function/messages";
 import ApplicationList, {
   ApplicationListItemContentWrapper,
@@ -39,7 +38,12 @@ import { AnyActionType } from "~/actions";
 import { withTranslation, WithTranslation } from "react-i18next";
 import InfoPopover from "~/components/general/info-popover";
 import Dropdown from "~/components/general/dropdown";
-import { MessageThread, MessageThreadExpanded } from "~/generated/client";
+import {
+  MessageSearchResult,
+  instanceOfMessageThread,
+  MessageThread,
+  MessageThreadExpanded,
+} from "~/generated/client";
 
 /**
  * CommunicatorMessagesProps
@@ -204,14 +208,27 @@ class CommunicatorMessages extends BodyScrollLoader<
   }
 
   /**
+   * Type guard for MessageThread
+   * @param value value
+   * @returns value is MessageThread
+   */
+  isMessageThread = (value: object): value is MessageThread =>
+    instanceOfMessageThread(value);
+
+  /**
    * setCurrentThread
    * @param threadOrSearchResult threadOrSearchResult
    */
   setCurrentThread(threadOrSearchResult: MessageThread | MessageSearchResult) {
-    window.location.hash =
-      window.location.hash.split("/")[0] +
-      "/" +
-      threadOrSearchResult.communicatorMessageId;
+    if (this.isMessageThread(threadOrSearchResult)) {
+      window.location.hash = `${window.location.hash.split("/")[0]}/${
+        threadOrSearchResult.communicatorMessageId
+      }`;
+    } else {
+      window.location.hash = `#${threadOrSearchResult.folder.toLowerCase()}/${
+        threadOrSearchResult.communicatorMessageId
+      }`;
+    }
   }
 
   /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/body/application/messages.tsx
@@ -101,7 +101,7 @@ class CommunicatorMessages extends BodyScrollLoader<
    * @param thread thread
    * @param userId userId
    */
-  getThreadUserNames(thread: MessageThread, userId: number): any {
+  getThreadUserNames(thread: MessageThread, userId: number) {
     if (thread.senderId !== userId || !thread.recipients) {
       if (thread.senderId === userId) {
         return <span>{this.props.t("labels.self")}</span>;
@@ -152,7 +152,7 @@ class CommunicatorMessages extends BodyScrollLoader<
         );
       }
 
-      const name = getName(recipient as any, !this.props.status.isStudent);
+      const name = getName(recipient, !this.props.status.isStudent);
 
       if (recipient.studiesEnded === true) {
         return (

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/new-message.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/new-message.tsx
@@ -9,7 +9,6 @@ import {
   SendMessageTriggerType,
 } from "~/actions/main-function/messages";
 import { AnyActionType } from "~/actions";
-import { MessageSignatureType } from "~/reducers/main-function/messages";
 import { ContactRecipientType } from "~/reducers/user-index";
 import { StateType } from "~/reducers";
 import Button from "~/components/general/button";
@@ -18,6 +17,7 @@ import { StatusType } from "~/reducers/base/status";
 import "~/sass/elements/form.scss";
 import MApi from "~/api/api";
 import { WithTranslation, withTranslation } from "react-i18next";
+import { CommunicatorSignature } from "~/generated/client";
 
 /**
  * CommunicatorNewMessageProps
@@ -31,7 +31,7 @@ interface CommunicatorNewMessageProps extends WithTranslation {
   extraNamespace?: string;
   initialSelectedItems?: Array<ContactRecipientType>;
   refreshInitialSelectedItemsOnOpen?: boolean;
-  signature: MessageSignatureType;
+  signature: CommunicatorSignature;
   sendMessage: SendMessageTriggerType;
   initialSubject?: string;
   initialMessage?: string;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/signature-update.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/communicator/dialogs/signature-update.tsx
@@ -8,11 +8,11 @@ import {
   updateSignature,
   UpdateSignatureTriggerType,
 } from "~/actions/main-function/messages";
-import { MessageSignatureType } from "~/reducers/main-function/messages";
 import { StateType } from "~/reducers";
 import Button from "~/components/general/button";
 import "~/sass/elements/form.scss";
 import { WithTranslation, withTranslation } from "react-i18next";
+import { CommunicatorSignature } from "~/generated/client";
 
 const KEYCODES = {
   ENTER: 13,
@@ -27,7 +27,7 @@ interface CommunicatorSignatureUpdateDialogProps extends WithTranslation {
   isOpen: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onClose: () => any;
-  signature: MessageSignatureType;
+  signature: CommunicatorSignature;
   updateSignature: UpdateSignatureTriggerType;
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/main-function/messages.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/main-function/messages.ts
@@ -2,122 +2,12 @@ import { ActionType } from "~/actions";
 import { Reducer } from "redux";
 import {
   CommunicatorSignature,
+  MessageSearchResult,
   MessageThread,
   MessageThreadExpanded,
-  MessageThreadLabel,
-  User,
-  UserGroup,
 } from "~/generated/client";
 
 export type MessagesStateType = "LOADING" | "LOADING_MORE" | "ERROR" | "READY";
-export type MessagesSearchResultFolderType = "INBOX" | "TRASH" | "SENT";
-/**
- * MessageSignatureType
- */
-export interface MessageSignatureType {
-  id: number;
-  name: string;
-  signature: string;
-}
-
-/**
- * MessageSearchResult
- */
-export interface MessageSearchResult {
-  caption: string;
-  communicatorMessageId: number;
-  created: string;
-  id: number;
-  readByReceiver: boolean;
-  folder: MessagesSearchResultFolderType;
-  labels: Array<{
-    labelColor: number;
-    id: number;
-    labelName: string;
-  }>;
-  sender: {
-    userEntityId: number;
-    firstName: string;
-    lastName: string;
-    nickName: string;
-    studyProgrammeName?: string;
-  };
-  senderId: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tags: any;
-  recipients?: Array<MessageRecepientType>;
-  userGroupRecipients?: UserGroup[];
-  workspaceRecipients?: Array<MessageWorkspaceRecipientType>;
-}
-
-/**
- * MessageThreadLabelUpdateType
- */
-export interface MessageThreadLabelUpdateType {
-  id?: number;
-  labelColor?: number;
-  labelId?: number;
-  labelName?: string;
-  messageThreadId?: number;
-  userEntityId?: number;
-}
-
-/**
- * MessageThreadUpdateType
- */
-export interface MessageThreadUpdateType {
-  communicatorMessageId?: number;
-  senderId?: number;
-  categoryName?: "message";
-  caption?: string;
-  created?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tags?: any;
-  threadLatestMessageDate?: string;
-  unreadMessagesInThread?: boolean;
-  sender?: User;
-  messageCountInThread?: number;
-  labels?: MessageThreadLabel[];
-}
-
-/**
- * MessageRecepientType
- */
-export interface MessageRecepientType {
-  communicatorMessageId: number;
-  userEntityId: number;
-  nickName?: string | null;
-  firstName: string;
-  lastName?: string | null;
-  recipientId: number;
-  archived?: boolean;
-  studiesEnded?: boolean;
-}
-
-/**
- * MessageWorkspaceRecipientType
- */
-export interface MessageWorkspaceRecipientType {
-  archetype: string;
-  workspaceEntityId: number;
-  workspaceExtension?: string;
-  workspaceName: string;
-}
-/* export type MessageThread[] = Array<MessageThread>; */
-
-/**
- * MessagesNavigationItemUpdateType
- */
-export interface MessagesNavigationItemUpdateType {
-  location?: string;
-  type?: string;
-  id?: string | number;
-  icon?: string;
-  color?: string;
-  text: string;
-}
-
-export type NavigationItemTypes = "folder" | "label";
 
 /**
  * MessagesNavigationItem
@@ -136,17 +26,6 @@ export interface MessagesNavigationItem {
   color?: string;
   text: string;
 }
-
-/**
- * LabelType
- */
-export interface LabelType {
-  id: number;
-  color: number;
-  name: string;
-}
-
-export type LabelListType = Array<LabelType>;
 
 const defaultNavigation: MessagesNavigationItem[] = [
   {
@@ -380,18 +259,16 @@ export const messages: Reducer<MessagesState> = (
 
       return {
         ...state,
-        selectedThreads: state.selectedThreads.map(
-          (selectedThread: MessageThread) => {
-            if (
-              selectedThread.communicatorMessageId ===
-              oldThread.communicatorMessageId
-            ) {
-              return newThread;
-            }
-            return selectedThread;
+        selectedThreads: state.selectedThreads.map((selectedThread) => {
+          if (
+            selectedThread.communicatorMessageId ===
+            oldThread.communicatorMessageId
+          ) {
+            return newThread;
           }
-        ),
-        threads: state.threads.map((thread: MessageThread) => {
+          return selectedThread;
+        }),
+        threads: state.threads.map((thread) => {
           if (
             thread.communicatorMessageId === oldThread.communicatorMessageId
           ) {
@@ -552,7 +429,7 @@ export const messages: Reducer<MessagesState> = (
           }),
         })),
 
-        threads: state.threads.map((thread: MessageThread) => ({
+        threads: state.threads.map((thread) => ({
           ...thread,
           labels: thread.labels.map((label) => {
             if (label.labelId === action.payload.labelId) {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/util/base-main-function.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/util/base-main-function.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 import Websocket from "~/util/websocket";
-import mApi from "~/lib/mApi";
 import { Action } from "redux";
 import { updateUnreadMessageThreadsCount } from "~/actions/main-function/messages";
 import { StateType } from "~/reducers";
@@ -42,15 +41,15 @@ export default async function (
     actionsAndCallbacks = {
       "Communicator:newmessagereceived": {
         actions: [updateUnreadMessageThreadsCount],
-        callbacks: [() => mApi().communicator.cacheClear()],
+        callbacks: [],
       },
       "Communicator:messageread": {
         actions: [updateUnreadMessageThreadsCount],
-        callbacks: [() => mApi().communicator.cacheClear()],
+        callbacks: [],
       },
       "Communicator:threaddeleted": {
         actions: [updateUnreadMessageThreadsCount],
-        callbacks: [() => mApi().communicator.cacheClear()],
+        callbacks: [],
       },
     };
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
@@ -12380,7 +12380,7 @@ components:
               type: string
             lastName:
               type: string
-            nickname:
+            nickName:
               type: string
             studyProgrammeName:
               type: string


### PR DESCRIPTION
When clicking item from search result list in communicator doesn't anymore crash. Clicked item loads data now correctly and sets folder filter correctly respectly what clicked search item folder property holds. Also little communicator frontend code cleaning related previously done api refactor.

Resolves: #6752 