### PR TITLE
Added two new study programme that can use uppersecondary pedagogy form

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/pedagogical-support-form/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/pedagogical-support-form/index.tsx
@@ -24,7 +24,11 @@ import PedagogyToolbar from "./pedagogy-toolbar";
 import { UserRole } from "~/@types/pedagogy-form";
 
 // Visibility settings which study programmes have access to the form
-export const UPPERSECONDARY_PEDAGOGYFORM = ["Nettilukio"];
+export const UPPERSECONDARY_PEDAGOGYFORM = [
+  "Nettilukio",
+  "Aikuislukio",
+  "Nettilukio/yksityisopiskelu (aineopintoina)",
+];
 
 /**
  * The props for the UpperSecondaryPedagogicalSupportForm component.


### PR DESCRIPTION
Added two new study programme that can use uppersecondary pedagogy form:

- Aikuislukio
- Nettilukio/yksityisopiskelu (aineopintoina)

Resolves: #6717 