### PR TITLE
Added maven-clean-plugin to remove the compiled frontend in clean phase

### DIFF
--- a/muikku-core-plugins/pom.xml
+++ b/muikku-core-plugins/pom.xml
@@ -259,6 +259,29 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/resources/META-INF/resources/scripts/dist</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>src/main/resources/META-INF/resources/scripts/src/generated</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      
+      <plugin>
         <groupId>org.bsc.maven</groupId>
         <artifactId>maven-processor-plugin</artifactId>
         <version>2.2.4</version>


### PR DESCRIPTION
This cleans the compiled frontend files (generated and dist) in maven clean phase. As the frontend compilation doesn't seem to reuse the files in any way (like partial recompilation etc), it could be a useful addition to ensure that the stage is clean for a full build.

Are there any unintended consequences that come to mind?