### PR TITLE
Annotation-related warning fixes

### DIFF
--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/guidancerequest/GuidanceRequest.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/guidancerequest/GuidanceRequest.java
@@ -7,13 +7,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 
 @Entity
-@PrimaryKeyJoinColumn(name="id")
+@Inheritance(strategy=InheritanceType.SINGLE_TABLE)
 public class GuidanceRequest {
 
   public Long getId() {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/guidancerequest/WorkspaceGuidanceRequest.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/guidancerequest/WorkspaceGuidanceRequest.java
@@ -2,11 +2,8 @@ package fi.otavanopisto.muikku.plugins.guidancerequest;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 
 @Entity
-@Inheritance(strategy=InheritanceType.JOINED)
 public class WorkspaceGuidanceRequest extends GuidanceRequest {
 
   public Long getWorkspace() {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/HtmlMaterial.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/material/model/HtmlMaterial.java
@@ -1,29 +1,23 @@
 package fi.otavanopisto.muikku.plugins.material.model;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Transient;
-
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import javax.validation.constraints.NotEmpty;
 
 @Entity
-@Cacheable
 @PrimaryKeyJoinColumn(name="id")
-@Cache (usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class HtmlMaterial extends Material {
 
   public String getHtml() {
-		return html;
-	}
+    return html;
+  }
   
   public void setHtml(String html) {
-		this.html = html;
-	}
+    this.html = html;
+  }
   
   @Override
   @Transient

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialAudioFieldAnswerClip.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialAudioFieldAnswerClip.java
@@ -7,13 +7,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
-import javax.validation.constraints.NotEmpty;
-
 @Entity
-@PrimaryKeyJoinColumn(name="id")
 public class WorkspaceMaterialAudioFieldAnswerClip {
   
   public Long getId() {

--- a/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialFileFieldAnswerFile.java
+++ b/muikku-core-plugins-persistence/src/main/java/fi/otavanopisto/muikku/plugins/workspace/model/WorkspaceMaterialFileFieldAnswerFile.java
@@ -7,13 +7,10 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
-import javax.validation.constraints.NotEmpty;
-
 @Entity
-@PrimaryKeyJoinColumn(name="id")
 public class WorkspaceMaterialFileFieldAnswerFile {
   
   public Long getId() {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/AccessToken.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/AccessToken.java
@@ -1,13 +1,8 @@
-  package fi.otavanopisto.muikku.model.oauth;
+package fi.otavanopisto.muikku.model.oauth;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Entity;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
-@Cacheable (true)
-@Cache (usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class AccessToken extends Token {
 
   public AccessToken() {

--- a/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/RequestToken.java
+++ b/muikku-persistence/src/main/java/fi/otavanopisto/muikku/model/oauth/RequestToken.java
@@ -1,17 +1,11 @@
-  package fi.otavanopisto.muikku.model.oauth;
+package fi.otavanopisto.muikku.model.oauth;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import javax.validation.constraints.NotEmpty;
-
 @Entity
-@Cacheable (true)
-@Cache (usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class RequestToken extends Token {
 
   public RequestToken() {


### PR DESCRIPTION
Fixed a bunch of annotation-related warnings that were present in console

* `GuidanceRequest` / `WorkspaceGuidanceRequest` had inheritance backwards, inheritance strategy should be specified in the superclass and it's completely ignored in the subclass
* `@PrimaryKeyJoinColumn` was specified in classes that didn't have JOINED or any inheritance strategy what so ever. This should be used only in cases with JOINED inheritance strategy
* Cache annotations are ignored (as per warn in console) for subclasses so they were removed. In these cases the superclass had the same annotations which are still present