### PR TITLE
Added Java POJO generation from spec

### DIFF
--- a/muikku-core-plugins/pom.xml
+++ b/muikku-core-plugins/pom.xml
@@ -284,6 +284,47 @@
           </dependency>
         </dependencies>
       </plugin>
+    
+      <plugin>
+        <groupId>org.openapitools</groupId>
+        <artifactId>openapi-generator-maven-plugin</artifactId>
+        <version>6.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${project.basedir}/src/main/resources/META-INF/resources/swagger.yaml</inputSpec>
+              <!-- Generate for Java/resteasy -->
+              <generatorName>java</generatorName>
+              <library>resteasy</library>
+              
+              <!-- Package and name suffix for the generated model files -->
+              <modelPackage>fi.otavanopisto.muikku.rest.model</modelPackage>
+              <modelNameSuffix>RestModel</modelNameSuffix>
+              
+              <!-- Generate only models, disable everything else -->
+              <generateApis>false</generateApis>
+              <generateModels>true</generateModels>
+              <generateModelDocumentation>false</generateModelDocumentation>
+              <generateModelTests>false</generateModelTests>
+              <generateSupportingFiles>false</generateSupportingFiles>
+              
+              <configOptions>
+                <!-- Use root: target/generated-sources/openapi -->
+                <sourceFolder>.</sourceFolder>
+
+                <!-- Date library to use -->
+                <dateLibrary>java11</dateLibrary>
+
+                <!-- Disable openapis own classes -->
+                <openApiNullable>false</openApiNullable>
+              </configOptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
Creates Java POJOs from spec to `target/generated-sources/openapi` in maven generate-sources phase (`mvn generate-sources`). Uses `java` generator (https://openapi-generator.tech/docs/generators/java/) with `resteasy` library. Is setup to only generate POJOs.

**For eclipse:** run Maven -> Update project. This should automatically add the source folder (under target) to the project so that the classes can be found.

TODO:
- Spec incorrectly specifies some fields as integer when they should be long
- The Date Library to use is still in the air - this should be prototyped more to establish which type of date(+time) representation we prefer. Current is `java11` (not in the documentation list), which uses java.util.Date and produces timestamps (ms since epoch) in the serialized json - this matches the functionality of some endpoints but likely not all of them.