### PR TITLE
* Updated mathjax to 2.7.9

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-mathjax/plugin.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-mathjax/plugin.js
@@ -6,7 +6,7 @@
 
 ( function() {
 
-  var cdn = 'http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
+  var cdn = 'http://cdn.jsdelivr.net/npm/mathjax@2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
 
   CKEDITOR.dialog.add( 'muikku-mathjax', function( editor ) {
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-mathjax/plugin.js
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/ckplugins/muikku-mathjax/plugin.js
@@ -6,7 +6,7 @@
 
 ( function() {
 
-  var cdn = 'http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML';
+  var cdn = 'http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML';
 
   CKEDITOR.dialog.add( 'muikku-mathjax', function( editor ) {
 
@@ -25,7 +25,7 @@
               id: 'isAsciiMath',
               type: 'checkbox',
               label: lang.isAsciiMath,
-              
+
               onLoad: function( widget ) {
               },
 
@@ -289,14 +289,14 @@
         begin = value.indexOf( '\\(' ) + 2;
         end = value.lastIndexOf( '\\)' );
       }
-      
+
       if (begin === -1 || end === -1) {
         return value;
       }
 
       return value.substring( begin, end );
     };
-    
+
     CKEDITOR.plugins.muikkuMathjax.untrim = function(isAsciiMath, value) {
       if (isAsciiMath) {
         return "`" + value + "`";
@@ -304,7 +304,7 @@
         return "\\(" + value + "\\)";
       }
     }
-    
+
     CKEDITOR.plugins.muikkuMathjax.escapeHtmlEntities = function(value) {
       return value ? value
         .replaceAll("&", "&amp;")

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
@@ -35,7 +35,7 @@ export const MATHJAXCONFIG = {
 };
 
 export const MATHJAXSRC =
-  "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_SVG";
+  "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_SVG";
 
 /**
  * loadMathJax

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/lib/mathjax.ts
@@ -35,7 +35,7 @@ export const MATHJAXCONFIG = {
 };
 
 export const MATHJAXSRC =
-  "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_SVG";
+  "//cdn.jsdelivr.net/npm/mathjax@2.7.9/MathJax.js?config=TeX-MML-AM_SVG";
 
 /**
  * loadMathJax


### PR DESCRIPTION
Closes #6900 

This PR only updates mathjax to the most recent 2.x version which we can use as we cannot migrate easily to 3.x version yet.

Mathjax 2.7.9 includes following changes:
* https://github.com/mathjax/MathJax/releases/tag/2.7.8
* https://github.com/mathjax/MathJax/releases/tag/2.7.9