### PR TITLE
* Added role="button" to button component

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/button.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/button.tsx
@@ -95,6 +95,7 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
         )
           .map((s) => `button--${s}`)
           .join(" ")}`}
+        role="button"
       >
         {this.props.icon && this.props.iconPosition === "left" && (
           <span
@@ -145,6 +146,7 @@ export class ButtonSocial extends React.Component<ButtonProps, ButtonState> {
         className={`button-social ${
           this.props.className ? this.props.className : ""
         } ${(modifiers || []).map((s) => `button-social--${s}`).join(" ")}`}
+        role="button"
       />
     );
   }
@@ -191,6 +193,7 @@ export class ButtonPill extends React.Component<ButtonPillProps, ButtonState> {
         className={`button-pill ${(modifiers || [])
           .map((s) => `button-pill--${s}`)
           .join(" ")}`}
+        role="button"
       >
         {this.props.icon && (
           <span className={`button-pill__icon icon-${this.props.icon}`}></span>
@@ -242,6 +245,7 @@ export class IconButton extends React.Component<IconButtonProps, ButtonState> {
         className={`button-icon ${
           this.props.className ? this.props.className : ""
         } ${(modifiers || []).map((s) => `button-icon--${s}`).join(" ")}`}
+        role="button"
       >
         {this.props.icon && <span className={`icon-${this.props.icon}`}></span>}
         {this.props.children}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/note-book/note-book.tsx
@@ -297,6 +297,7 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
         <Dropdown openByHover content={<p>{t("actions.add")}</p>}>
           <IconButton
             icon="plus"
+            aria-label={t("actions.add")}
             buttonModifiers={["notebook-action"]}
             onClick={handleAddNewNoteClick}
             disablePropagation={true}
@@ -305,6 +306,7 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
         <Dropdown openByHover content={<p>{t("actions.organize")}</p>}>
           <IconButton
             icon="move"
+            aria-label={t("actions.organize")}
             buttonModifiers={["notebook-action"]}
             onClick={handleEditEntriesOrderClick}
             disablePropagation={true}
@@ -316,6 +318,7 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
         >
           <IconButton
             icon="arrow-down"
+            aria-label={t("actions.openAll", { ns: "common" })}
             buttonModifiers={["notebook-action"]}
             onClick={handleOpenAllClick}
             disablePropagation={true}
@@ -327,15 +330,20 @@ const NoteBook: React.FC<NoteBookProps> = (props) => {
         >
           <IconButton
             icon="arrow-up"
+            aria-label={t("actions.closeAll", { ns: "common" })}
             buttonModifiers={["notebook-action"]}
             onClick={handleCloseAllClick}
             disablePropagation={true}
           />
         </Dropdown>
-        <Dropdown openByHover content={<p>PDF</p>}>
+        <Dropdown
+          openByHover
+          content={<p>{t("actions.openPDF", { ns: "common" })}</p>}
+        >
           <NoteBookPDFDialog notes={notes} workspace={props.currentWorkspace}>
             <IconButton
               icon="pdf"
+              aria-label={t("actions.openPDF", { ns: "common" })}
               buttonModifiers={["notebook-action"]}
               disablePropagation={true}
             />

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
@@ -166,18 +166,22 @@ export const Tabs: React.FC<TabsProps> = (props) => {
             }`}
           >
             {tabs.map((tab: Tab) => (
-              <div
+              <button
                 className={`tabs__tab ${
                   modifier ? "tabs__tab--" + modifier : ""
                 } ${tab.type ? "tabs__tab--" + tab.type : ""} ${
                   tab.id === activeTab ? "active" : ""
                 }`}
                 key={tab.id}
-                id={tab.id}
+                id={"tabControl-" + tab.id}
+                aria-controls={"tabPanel-" + tab.id}
+                role="tab"
+                tabIndex={0}
+                aria-selected={tab.id === activeTab}
                 onClick={onTabChange.bind(this, tab.id, tab.hash)}
               >
                 {tab.name}
-              </div>
+              </button>
             ))}
             {children}
           </div>
@@ -187,6 +191,10 @@ export const Tabs: React.FC<TabsProps> = (props) => {
               .map((t: Tab) => (
                 <div
                   key={t.id}
+                  role="tabpanel"
+                  id={"tabPanel-" + t.id}
+                  hidden={t.id !== activeTab}
+                  aria-labelledby={"tabControl-" + t.id}
                   className={`tabs__tab-data ${
                     t.type ? "tabs__tab-data--" + t.type : ""
                   }  ${t.id === activeTab ? "active" : ""}`}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
@@ -176,7 +176,6 @@ export const Tabs: React.FC<TabsProps> = (props) => {
                 id={"tabControl-" + tab.id}
                 aria-controls={"tabPanel-" + tab.id}
                 role="tab"
-                tabIndex={0}
                 aria-selected={tab.id === activeTab}
                 onClick={onTabChange.bind(this, tab.id, tab.hash)}
               >
@@ -290,20 +289,28 @@ export const MobileOnlyTabs: React.FC<MobileOnlyTabsProps> = (props) => {
         <>
           <div className="tabs__tab-labels tabs__tab-labels--desktop">
             {tabs.map((tab, index) => (
-              <div
+              <button
                 className={`tabs__tab tabs__tab--mobile-only-tab ${
                   modifier ? "tabs__tab--" + modifier : ""
                 } `}
                 key={tab.id}
+                id={"tabControl-" + tab.id}
+                aria-controls={"tabPanel-" + tab.id}
+                role="tab"
+                aria-selected={tab.id === activeTab}
               >
                 {tab.name}
-              </div>
+              </button>
             ))}
           </div>
           <div className="tabs__tab-data-container tabs__tab-data-container--mobile-tabs">
             {tabs.map((t) => (
               <div
                 key={t.id}
+                role="tabpanel"
+                id={"tabPanel-" + t.id}
+                hidden={t.id !== activeTab}
+                aria-labelledby={"tabControl-" + t.id}
                 className={`tabs__tab-data ${
                   t.type ? "tabs__tab-data--" + t.type : ""
                 }`}

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/content.tsx
@@ -556,6 +556,7 @@ class ContentComponent extends SessionStateComponent<
             <Dropdown openByHover content={<p>{t("actions.openAll")}</p>}>
               <IconButton
                 icon="arrow-down"
+                aria-label={t("actions.openAll")}
                 buttonModifiers={["toc-action"]}
                 onClick={this.handleToggleAllSectionsOpen("open")}
               />
@@ -563,6 +564,7 @@ class ContentComponent extends SessionStateComponent<
             <Dropdown openByHover content={<p>{t("actions.closeAll")}</p>}>
               <IconButton
                 icon="arrow-up"
+                aria-label={t("actions.closeAll")}
                 buttonModifiers={["toc-action"]}
                 onClick={this.handleToggleAllSectionsOpen("close")}
               />
@@ -679,9 +681,16 @@ class ContentComponent extends SessionStateComponent<
                 </>
               }
             >
-              <IconButton icon="filter" buttonModifiers={["toc-action"]} />
+              <IconButton
+                aria-label={t("actions.filterContent")}
+                icon="filter"
+                buttonModifiers={["toc-action"]}
+              />
             </Dropdown>
-            <Dropdown openByHover content={<p>Sisällysluettelo PDF</p>}>
+            <Dropdown
+              openByHover
+              content={<p>{t("actions.openPDF", { ns: "common" })}</p>}
+            >
               <TableOfContentPDFDialog
                 assignmentTypeFilters={this.state.assignmentTypeFilters}
                 materials={this.props.materials}
@@ -690,6 +699,7 @@ class ContentComponent extends SessionStateComponent<
               >
                 <IconButton
                   icon="pdf"
+                  aria-label={t("actions.openPDF", { ns: "common" })}
                   buttonModifiers={["toc-action"]}
                   disablePropagation={true}
                 />

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
@@ -22,6 +22,7 @@
       "edit_comment": "Edit comment",
       "download_one": "Download",
       "download_other": "Download all",
+      "filterContent": "Filter content",
       "hide": "Hide",
       "hideAll": "Hide all",
       "hide_comments": "Hide comments",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
@@ -22,6 +22,7 @@
       "edit_comment": "Muokkaa kommenttia",
       "download": "Lataa",
       "downloadAll": "Lataa kaikki",
+      "filterContent": "Suodata sisältöä",
       "hide": "Piilota",
       "hideAll": "Piilota kaikki",
       "hide_comments": "Piilota kommentit",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/colors.scss
@@ -590,7 +590,7 @@ $color-subpanel-header-background: #f8f8f8;
 
 // TAB
 $color-tab-blur-background: #f5f5f5;
-$color-tab-blur-font: #9a9a9a;
+$color-tab-blur-font: #6f6d6d;
 $color-tab-focus-background: $color-default;
 $color-tab-focus-font: $color-text-default;
 $color-tab-border: #5db5c5;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/tabs.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/tabs.scss
@@ -49,7 +49,9 @@
   display: none;
   flex-flow: row nowrap;
   height: 2.25rem;
+  margin-bottom: -1px;
   padding: 0;
+  position: relative;
 
   @include breakpoint($breakpoint-pad) {
     display: flex;
@@ -91,7 +93,10 @@
 }
 
 .tabs__tab {
+  @include text;
+
   background: $color-tab-blur-background;
+  border-bottom: 0;
   border-left: 1px solid $color-tab-blur-background;
   border-radius: 5px 5px 0 0;
   border-right: 1px solid $color-tab-blur-background;
@@ -102,9 +107,12 @@
   flex-grow: 1;
   flex-shrink: 1;
   line-height: 1;
-  margin: 0 2px;
+  margin: 2px;
+  outline-offset: -2px;
   padding: 10px;
+  text-align: left;
   user-select: none;
+  z-index: 1;
 
   &.active {
     background: $color-tab-focus-background;
@@ -112,8 +120,8 @@
     border-right: 1px solid $color-tab-border;
     border-top: 1px solid $color-tab-border;
     color: $color-tab-focus-font;
-    margin-bottom: -1px;
-    padding: 10px 10px 11px;
+    padding: 11px 10px 10px;
+    z-index: 3;
   }
 
   @include breakpoint($breakpoint-pad) {


### PR DESCRIPTION
Closes #6905 #6859

Tabs are now buttons and there fore they can be used via keyboard only. Tabs and tab panels are linked together via aria attributes (aria-controls and aria-labelledby) and active tab is indicated as selected via aria-selected="true" attribute.

Also notebook and ToC icons have correct role and aria-label's have been added.

Added also couple of missing locale strings regarding PDF exporting.