### PR TITLE
6916 kuvan lisääminen sivulle ei onnistu tietyssä tilanteessa

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/material.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/material.ts
@@ -1135,7 +1135,9 @@ const deleteWorkspaceMaterialContentNode: DeleteWorkspaceMaterialContentNodeTrig
         } else {
           await workspaceApi.deleteWorkspaceMaterial({
             workspaceEntityId: data.workspace.id,
-            workspaceMaterialId: data.material.workspaceMaterialId,
+            // Please note that first option is for normal materials and second is for files
+            workspaceMaterialId:
+              data.material.workspaceMaterialId || data.material.id,
             removeAnswers: data.removeAnswers || false,
             updateLinkedMaterials: true,
           });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-editor/confirm-remove-attachment.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-editor/confirm-remove-attachment.tsx
@@ -14,7 +14,6 @@ import {
   DeleteWorkspaceMaterialContentNodeTriggerType,
   deleteWorkspaceMaterialContentNode,
 } from "~/actions/workspaces/material";
-import { MaterialContentNode } from "~/generated/client";
 import { withTranslation, WithTranslation } from "react-i18next";
 
 /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-editor/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-editor/index.tsx
@@ -1279,7 +1279,6 @@ class MaterialEditor extends React.Component<
               hintText={t("content.add", { ns: "materials", context: "file" })}
               deleteFileText={t("actions.remove")}
               downloadFileText={t("actions.download")}
-              showURL
               notificationOfSuccessText={t("notifications.uploadSuccess", {
                 ns: "files",
               })}


### PR DESCRIPTION
Changes:
- Material attachments and images can be now added even after material title name has been changed
- Attachment url paths are updated as well when material title name has been changed
- Attachment urls are now hidden

Resolves: #6916 #5002

