### PR TITLE
Readspeaker image wrong localle fixed

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/binary/image.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/binary/image.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import Zoom from "~/components/general/zoom";
-import { MaterialContentNode } from "~/generated/client";
 import { MaterialContentNodeWithIdAndLogic } from "~/reducers/workspaces";
 
 /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/static/image.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/static/image.tsx
@@ -301,9 +301,8 @@ class Image extends React.Component<ImageProps, ImageState> {
         return (
           <>
             <ReadspeakerMessage
-              text={this.props.t("messages.assignment", {
+              text={this.props.t("messages.image", {
                 ns: "readSpeaker",
-                context: "image",
               })}
             />
             <Zoom key={props.key} imgsrc={props.src}>


### PR DESCRIPTION
Readspeaker locale fixed. Now Readspeaker should read correct message when reading images. 

Why Readspeaker reads alt text and not following rs_skip_always rules when manually selecting content is unknown mystery, also if there are two images side by side Readspeaker will not read latter one if it is not followed by some kind of text content.  Both these are probably related to Readspeaker itself so its not Muikku problem directly.

Resolves: #6939 