### PR TITLE
6932 kurssin tuottajien nimet vaihtelevat listassa paikkaa

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -978,28 +978,6 @@ public class WorkspaceRESTService extends PluginRESTService {
       .build();
   }
 
-  @DELETE
-  @Path("/workspaces/{WORKSPACEENTITYID}/materialProducers/{ID}")
-  @RESTPermit (handling = Handling.INLINE, requireLoggedIn = true)
-  public Response deleteWorkspaceMaterialProducer(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, @PathParam("ID") Long workspaceMaterialProducerId) {
-    WorkspaceEntity workspaceEntity = workspaceController.findWorkspaceEntityById(workspaceEntityId);
-    if (workspaceEntity == null) {
-      return Response.status(Status.NOT_FOUND).build();
-    }
-
-    if (!sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MATERIAL_PRODUCERS, workspaceEntity)) {
-      return Response.status(Status.FORBIDDEN).build();
-    }
-
-    WorkspaceMaterialProducer materialProducer = workspaceController.findWorkspaceMaterialProducer(workspaceMaterialProducerId);
-
-    workspaceController.deleteWorkspaceMaterialProducer(materialProducer);
-
-    return Response
-      .noContent()
-      .build();
-  }
-
   @PUT
   @Path("/workspaces/{ID}/details")
   @RESTPermit (handling = Handling.INLINE, requireLoggedIn = true)

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -901,7 +901,7 @@ public class WorkspaceRESTService extends PluginRESTService {
   @POST
   @Path("/workspaces/{WORKSPACEENTITYID}/materialProducers")
   @RESTPermit (handling = Handling.INLINE)
-  public Response createWorkspaceMaterialProducer(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, List<String> payload) {
+  public Response createWorkspaceMaterialProducers(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, List<String> payload) {
     WorkspaceEntity workspaceEntity = workspaceController.findWorkspaceEntityById(workspaceEntityId);
     if (workspaceEntity == null) {
       return Response.status(Status.NOT_FOUND).build();

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/workspace/rest/WorkspaceRESTService.java
@@ -901,7 +901,7 @@ public class WorkspaceRESTService extends PluginRESTService {
   @POST
   @Path("/workspaces/{WORKSPACEENTITYID}/materialProducers")
   @RESTPermit (handling = Handling.INLINE)
-  public Response createWorkspaceMaterialProducer(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, WorkspaceMaterialProducer payload) {
+  public Response createWorkspaceMaterialProducer(@PathParam("WORKSPACEENTITYID") Long workspaceEntityId, List<String> payload) {
     WorkspaceEntity workspaceEntity = workspaceController.findWorkspaceEntityById(workspaceEntityId);
     if (workspaceEntity == null) {
       return Response.status(Status.NOT_FOUND).build();
@@ -910,11 +910,23 @@ public class WorkspaceRESTService extends PluginRESTService {
     if (!sessionController.hasWorkspacePermission(MuikkuPermissions.MANAGE_WORKSPACE_MATERIAL_PRODUCERS, workspaceEntity)) {
       return Response.status(Status.FORBIDDEN).build();
     }
-
-    WorkspaceMaterialProducer materialProducer = workspaceController.createWorkspaceMaterialProducer(workspaceEntity, payload.getName());
+    
+    // Out with the old
+    
+    List<WorkspaceMaterialProducer> producers = workspaceController.listWorkspaceMaterialProducers(workspaceEntity);
+    for (WorkspaceMaterialProducer producer : producers) {
+      workspaceController.deleteWorkspaceMaterialProducer(producer);
+    }
+    
+    // In with the new
+    
+    producers = new ArrayList<>();
+    for (String producer : payload) {
+      producers.add(workspaceController.createWorkspaceMaterialProducer(workspaceEntity, producer));
+    }
 
     return Response
-      .ok(createRestModel(materialProducer))
+      .ok(createRestModel(producers.toArray(new WorkspaceMaterialProducer[0])))
       .build();
   }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/index.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/actions/workspaces/index.ts
@@ -1454,50 +1454,13 @@ const updateWorkspace: UpdateWorkspaceTriggerType = function updateWorkspace(
 
       // Then producers
       if (appliedProducers) {
-        const existingProducers = currentWorkspace.producers;
-        const workspaceProducersToAdd =
-          existingProducers.length == 0
-            ? appliedProducers
-            : appliedProducers.filter((producer) => {
-                if (!producer.id) {
-                  return producer;
-                }
-              });
-
-        const workspaceProducersToDelete = existingProducers.filter(
-          (producer) => {
-            if (producer.id) {
-              return !appliedProducers.find(
-                (keepProducer) => keepProducer.id === producer.id
-              );
-            }
-          }
-        );
-
-        await Promise.all(
-          workspaceProducersToAdd.map((p) =>
-            workspaceApi.createWorkspaceMaterialProducer({
-              workspaceEntityId: currentWorkspace.id,
-              createWorkspaceMaterialProducerRequest: p,
-            })
-          )
-        );
-
-        await Promise.all(
-          workspaceProducersToDelete.map((p) =>
-            workspaceApi.deleteWorkspaceMaterialProducer({
-              workspaceEntityId: currentWorkspace.id,
-              producerId: p.id,
-            })
-          )
-        );
-
-        // For some reason the results of the request don't give the new workspace producers
-        // it's a mess but whatever
-        data.update.producers =
-          await workspaceApi.getWorkspaceMaterialProducers({
+        const updatedProducersList =
+          await workspaceApi.createWorkspaceMaterialProducers({
             workspaceEntityId: currentWorkspace.id,
+            requestBody: appliedProducers.map((p) => p.name),
           });
+
+        data.update.producers = updatedProducersList;
       }
 
       // All saved and stitched together again, dispatch to state
@@ -2084,50 +2047,11 @@ const updateWorkspaceProducersForCurrentWorkspace: UpdateWorkspaceProducersForCu
 
       try {
         const state = getState();
-        const existingProducers = state.workspaces.currentWorkspace.producers;
 
-        const workspaceProducersToAdd =
-          existingProducers.length == 0
-            ? data.appliedProducers
-            : data.appliedProducers.filter((producer) => {
-                if (!producer.id) {
-                  return producer;
-                }
-              });
-
-        const workspaceProducersToDelete = existingProducers.filter(
-          (producer) => {
-            if (producer.id) {
-              return !data.appliedProducers.find(
-                (keepProducer) => keepProducer.id === producer.id
-              );
-            }
-          }
-        );
-
-        await Promise.all(
-          workspaceProducersToAdd.map((p) =>
-            workspaceApi.createWorkspaceMaterialProducer({
-              workspaceEntityId: state.workspaces.currentWorkspace.id,
-              createWorkspaceMaterialProducerRequest: p,
-            })
-          )
-        );
-
-        await Promise.all(
-          workspaceProducersToDelete.map((p) =>
-            workspaceApi.deleteWorkspaceMaterialProducer({
-              workspaceEntityId: state.workspaces.currentWorkspace.id,
-              producerId: p.id,
-            })
-          )
-        );
-
-        // For some reason the results of the request don't give the new workspace producers
-        // it's a mess but whatever
-        const newActualWorkspaceProducers =
-          await workspaceApi.getWorkspaceMaterialProducers({
+        const updatedProducersList =
+          await workspaceApi.createWorkspaceMaterialProducers({
             workspaceEntityId: state.workspaces.currentWorkspace.id,
+            requestBody: data.appliedProducers.map((p) => p.name),
           });
 
         const currentWorkspace = getState().workspaces.currentWorkspace;
@@ -2137,7 +2061,7 @@ const updateWorkspaceProducersForCurrentWorkspace: UpdateWorkspaceProducersForCu
           payload: {
             original: currentWorkspace,
             update: {
-              producers: newActualWorkspaceProducers,
+              producers: updatedProducersList,
             },
           },
         });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
@@ -8450,7 +8450,7 @@ paths:
   /rest/workspace/workspaces/{workspaceEntityId}/materialProducers:
     get:
       operationId: getWorkspaceMaterialProducers
-      summary: Returns list of workspace material producers
+      summary: Returns list of workspace material producers list
       tags:
         - Workspace
       parameters:
@@ -8476,8 +8476,8 @@ paths:
           description: Internal server error
 
     post:
-      operationId: createWorkspaceMaterialProducer
-      summary: Creates and returns workspace material producer
+      operationId: createWorkspaceMaterialProducers
+      summary: Creates and returns workspace material producers list
       tags:
         - Workspace
       parameters:
@@ -8489,43 +8489,16 @@ paths:
             type: integer
             format: int64
       requestBody:
-        $ref: "#/components/requestBodies/WorkspaceMaterialProducerCreateRequestBody"
+        $ref: "#/components/requestBodies/WorkspaceMaterialProducersCreateRequestBody"
       responses:
         "200":
           description: Workspace material producer created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkspaceMaterialProducer"
-        "400":
-          description: Invalid request was sent to the server
-        "500":
-          description: Internal server error
-
-  /rest/workspace/workspaces/{workspaceEntityId}/materialProducers/{producerId}:
-    delete:
-      operationId: deleteWorkspaceMaterialProducer
-      summary: Deletes workspace material producer
-      tags:
-        - Workspace
-      parameters:
-        - name: workspaceEntityId
-          in: path
-          description: Workspace entity id
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: producerId
-          in: path
-          description: Workspace material producer id
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "204":
-          description: Workspace material producer deleted successfully
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkspaceMaterialProducer"
         "400":
           description: Invalid request was sent to the server
         "500":
@@ -11382,13 +11355,14 @@ components:
                 type: integer
                 format: int64
 
-    WorkspaceMaterialProducerCreateRequestBody:
+    WorkspaceMaterialProducersCreateRequestBody:
       required: true
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/WorkspaceMaterialProducer"
+            type: array
+            items:
+              type: string
 
     WorkspaceHelpCreateRequestBody:
       content:


### PR DESCRIPTION
Workspace producers list endpoint rework:
- Endpoint now accepts producers as list of string and returns newly created producers list back
- Simplifies frontend and backend code
- Delete endpoint removed as its not anymore needed
- Producers order in list won't be affected how fast or slow backend handles multiple single endpoint calls

Resolves: #6932 