### PR TITLE
Reverse communicator reindex order

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
@@ -446,7 +446,15 @@ public class CommunicatorController {
   public Long countMessagesByUserAndMessageId(UserEntity user, CommunicatorMessageId communicatorMessageId, boolean inTrash) {
     return communicatorMessageDAO.countMessagesByUserAndMessageId(user, communicatorMessageId, inTrash);
   }
-  
+
+  /**
+   * Return the maximum id value of CommunicatorMessages
+   * @return the maximum id value of CommunicatorMessages
+   */
+  public Long getMaximumCommunicatorMessageId() {
+    return communicatorMessageDAO.getMaximumCommunicatorMessageId();
+  }
+
   public Long countTotalMessages() {
     return communicatorMessageDAO.count();
   }
@@ -621,6 +629,18 @@ public class CommunicatorController {
   
   public List<CommunicatorMessage> listAllMessages(int firstResult, int maxResults) {
     return communicatorMessageDAO.listAll(firstResult, maxResults);
+  }
+
+  /**
+   * Lists all messages in reverse order (i.e. having smaller or equal index 
+   * than supplied).
+   * 
+   * @param highestId highest index returned
+   * @param maxResults how many results at most
+   * @return at most maxResults messages that have smaller than or equal index to highestIndex
+   */
+  public List<CommunicatorMessage> listAllMessagesInReverseFromId(Long highestId, int maxResults) {
+    return communicatorMessageDAO.listAllMessagesInReverseFromId(highestId, maxResults);
   }
 
   public List<CommunicatorMessageRecipient> listAllRecipients() {
@@ -818,4 +838,5 @@ public class CommunicatorController {
   public VacationNotifications findVacationNotification(UserEntity sender, UserEntity receiver) {
     return vacationNotificationsDAO.findNotification(sender, receiver);
   }
+
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
@@ -632,12 +632,12 @@ public class CommunicatorController {
   }
 
   /**
-   * Lists all messages in reverse order (i.e. having smaller or equal index 
-   * than supplied).
+   * Lists all messages in reverse order starting from given index 
+   * (i.e. having smaller or equal id than supplied).
    * 
-   * @param highestId highest index returned
+   * @param highestId highest id returned
    * @param maxResults how many results at most
-   * @return at most maxResults messages that have smaller than or equal index to highestIndex
+   * @return at most maxResults messages that have smaller than or equal id to highestId
    */
   public List<CommunicatorMessage> listAllMessagesInReverseFromId(Long highestId, int maxResults) {
     return communicatorMessageDAO.listAllMessagesInReverseFromId(highestId, maxResults);

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/dao/CommunicatorMessageDAO.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/dao/CommunicatorMessageDAO.java
@@ -528,6 +528,45 @@ public class CommunicatorMessageDAO extends CorePluginsDAO<CommunicatorMessage> 
     return entityManager.createQuery(criteria).getSingleResult();
   }
 
+  /**
+   * Returns the maximum value of the id field of CommunicatorMessage.
+   * 
+   * @return the max id
+   */
+  public Long getMaximumCommunicatorMessageId() {
+    EntityManager entityManager = getEntityManager(); 
+    
+    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<Long> criteria = criteriaBuilder.createQuery(Long.class);
+    Root<CommunicatorMessage> root = criteria.from(CommunicatorMessage.class);
+
+    criteria.select(criteriaBuilder.max(root.get(CommunicatorMessage_.id)));
+    
+    return entityManager.createQuery(criteria).getSingleResult();
+  }
+
+  /**
+   * Return messages in reverse id order starting from the highest id (included in results).
+   * 
+   * @param highestId message with highest id
+   * @param maxResults maximum results to return
+   * @return messages in reverse order starting from the highest index
+   */
+  public List<CommunicatorMessage> listAllMessagesInReverseFromId(Long highestId, int maxResults) {
+    EntityManager entityManager = getEntityManager(); 
+    
+    CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<CommunicatorMessage> criteria = criteriaBuilder.createQuery(CommunicatorMessage.class);
+    Root<CommunicatorMessage> root = criteria.from(CommunicatorMessage.class);
+
+    criteria.select(root).orderBy(criteriaBuilder.desc(root.get(CommunicatorMessage_.id)));
+    criteria.where(
+        criteriaBuilder.lessThanOrEqualTo(root.get(CommunicatorMessage_.id), highestId)
+    );
+    
+    return entityManager.createQuery(criteria).setMaxResults(maxResults).getResultList();
+  }
+  
   public List<CommunicatorMessage> listMessagesInSentThread(UserEntity sender, CommunicatorMessageId communicatorMessageId, boolean trashed, boolean archived) {
     EntityManager entityManager = getEntityManager(); 
     
@@ -586,5 +625,5 @@ public class CommunicatorMessageDAO extends CorePluginsDAO<CommunicatorMessage> 
   public void delete(CommunicatorMessage e) {
     super.delete(e);
   }
-  
+
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/SchoolDataSearchReindexListener.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/SchoolDataSearchReindexListener.java
@@ -269,10 +269,10 @@ public class SchoolDataSearchReindexListener {
 
         for (CommunicatorMessage message : batch) {
           try {
-            communicatorMessageIndexer.indexMessage(message);
-
             // Move index towards the smallest index in the list
             communicatorIndex = Math.min(communicatorIndex, message.getId().intValue());
+            
+            communicatorMessageIndexer.indexMessage(message);
           }
           catch (Exception e) {
             logger.log(Level.WARNING, "could not index Communicator message #" + message.getId(), e);


### PR DESCRIPTION
Käänteinen indeksointijärjestys viestimen viesteille.

1. Haetaan suurin CommunicatorMessage.id (jos indeksoinnin aikana tulee uusia viestejä niin ne indeksoidaan tallennusvaiheessa, joten ei pitäisi olla ongelmaa niiden suhteen), tallennetaan nykyiseksi indeksointikohdaksi
2. Haetaan batcheissä läjä viestejä käänteisessä id-järjestyksessä alkaen tallennetusta id:stä
3. Indeksoidaan batchin viestit ja pidetään kirjaa siitä, mikä on pienin id, joka batchissä on nähty
4. Batch valmis, valmistaudutaan seuraavaan
    a. Jos batch oli vajaa ja indeksi on edelleen > 1 niin oletettavasti alkupäästä on poistettu viestejä -> lopetetaan
    b. Vähennetään pienimmästä batchistä löytyneestä id:stä yksi ja siirrytään seuraavaan batchiin, jos päästiin nollaan -> lopetetaan
    c. Muutoin id on edelleen > 1 ja batch oli edelleen täysi -> uusi batch
