### PR TITLE
Coursepicker course component has keyboard support for opening and cl…

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application/courses/course.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/coursepicker/body/application/courses/course.tsx
@@ -191,6 +191,17 @@ class Course extends React.Component<CourseProps, CourseState> {
   };
 
   /**
+   * handleCourseKeyDown
+   * @param e e
+   */
+  handleCourseKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this.toggleExpanded();
+    }
+  };
+
+  /**
    * render
    * @returns JSX.Element
    */
@@ -199,11 +210,28 @@ class Course extends React.Component<CourseProps, CourseState> {
 
     return (
       <ApplicationListItem
+        tabIndex={-1}
         className={`course ${this.state.expanded ? "course--open" : ""}`}
       >
         <ApplicationListItemHeader
+          tabIndex={0}
+          role="button"
           className="application-list__item-header--course"
           onClick={this.toggleExpanded}
+          onKeyDown={this.handleCourseKeyDown}
+          aria-label={
+            this.state.expanded
+              ? this.props.t("wcag.expandWorkspaceInfo", {
+                  ns: "workspace",
+                  workspaceName: this.props.workspace.name,
+                })
+              : this.props.t("wcag.collapseWorkspaceInfo", {
+                  ns: "workspace",
+                  workspaceName: this.props.workspace.name,
+                })
+          }
+          aria-expanded={this.state.expanded}
+          aria-controls={"workspace" + this.props.workspace.id}
         >
           <span
             className={`application-list__header-icon icon-books ${
@@ -230,14 +258,17 @@ class Course extends React.Component<CourseProps, CourseState> {
           </span>
         </ApplicationListItemHeader>
         {!this.state.loading && this.state.expanded ? (
-          <div>
+          <div id={"workspace" + this.props.workspace.id}>
             <ApplicationListItemBody
               content={this.props.workspace.description}
               className="application-list__item-body--course"
             />
             <ApplicationListItemFooter className="application-list__item-footer--course">
               <Button
-                aria-label={this.props.workspace.name}
+                aria-label={this.props.t("wcag.continueWorkspace", {
+                  ns: "workspace",
+                  workspaceName: this.props.workspace.name,
+                })}
                 buttonModifiers={[
                   "primary-function-content ",
                   "coursepicker-course-action",
@@ -259,7 +290,10 @@ class Course extends React.Component<CourseProps, CourseState> {
                   }}
                 >
                   <Button
-                    aria-label={this.props.workspace.name}
+                    aria-label={this.props.t("wcag.signUpWorkspace", {
+                      ns: "workspace",
+                      workspaceName: this.props.workspace.name,
+                    })}
                     buttonModifiers={[
                       "primary-function-content",
                       "coursepicker-course-action",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
@@ -1634,9 +1634,13 @@
     },
     "wcag": {
       "announcementSelect": "Select announcement",
+      "collapseWorkspaceInfo": "Collapse course {{workspaceName}} info",
+      "continueWorkspace": "Continue course {{workspaceName}}",
       "editingMasterSwitch": "Master switch for editing",
+      "expandWorkspaceInfo": "Expand course {{workspaceName}} info",
       "journalSelect": "Select journal",
       "materialLicense": "Material license",
+      "signUpWorkspace": "Signup to course {{workspaceName}}",
       "workspaceDescription": "Course description",
       "workspaceImage": "Image of the course front page",
       "workspaceLicense": "Course license"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
@@ -1634,9 +1634,13 @@
     },
     "wcag": {
       "announcementSelect": "Aseta tiedote valituksi",
+      "collapseWorkspaceInfo": "Pienennä kurssin {{workspaceName}} tiedot",
+      "continueWorkspace": "Jatka kurssia {{workspaceName}}",
       "editingMasterSwitch": "Editointitilan valitsin",
+      "expandWorkspaceInfo": "Laajenna kurssin {{workspaceName}} tiedot",
       "journalSelect": "Valitse oppimispäiväkirja",
       "materialLicense": "Materiaalin lisenssi",
+      "signUpWorkspace": "Ilmoittaudu kurssille {{workspaceName}}",
       "workspaceDescription": "Kurssin kuvaus",
       "workspaceImage": "Kurssin kuva",
       "workspaceLicense": "Kurssin lisenssi"


### PR DESCRIPTION
Coursepicker course component has keyboard support for opening and closing course info with enter or space. Accordion elements also have now aria attributes set to indicate accordion state. Continue and SingUp buttons have now better aria-labels too.

Resolves: #6813 