### PR TITLE
SchoolDataIdentifier ParamConverter

### DIFF
--- a/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
+++ b/muikku-atests-plugin/src/main/java/fi/otavanopisto/muikku/atests/AcceptanceTestsRESTService.java
@@ -282,6 +282,40 @@ public class AcceptanceTestsRESTService extends PluginRESTService {
     return Response.ok().build();
   }
 
+  @GET
+  @Path("/sdi_paramconverter/{SDI}")
+  @RESTPermit (handling = Handling.UNSECURED)
+  public Response test_schooldataidentifier_paramconverter_path(@PathParam("SDI") SchoolDataIdentifier sdi) {
+    if (sdi != null) {
+      Object sdi_capsule = new Object() {
+        @SuppressWarnings("unused") public String identifier = sdi.getIdentifier();
+        @SuppressWarnings("unused") public String datasource = sdi.getDataSource();
+      };
+
+      return Response.ok().entity(sdi_capsule).build();
+    }
+    else {
+      return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @GET
+  @Path("/sdi_paramconverter_queryparam")
+  @RESTPermit (handling = Handling.UNSECURED)
+  public Response test_schooldataidentifier_paramconverter_query(@QueryParam("SDI") SchoolDataIdentifier sdi) {
+    if (sdi != null) {
+      Object sdi_capsule = new Object() {
+        @SuppressWarnings("unused") public String identifier = sdi.getIdentifier();
+        @SuppressWarnings("unused") public String datasource = sdi.getDataSource();
+      };
+
+      return Response.ok().entity(sdi_capsule).build();
+    }
+    else {
+      return Response.noContent().build();
+    }
+  }
+
   @DELETE
   @Path("/communicator/messages")
   @RESTPermit (handling = Handling.UNSECURED)

--- a/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/SystemRESTTestsIT.java
+++ b/muikku-atests/src/test/java/fi/otavanopisto/muikku/rest/test/SystemRESTTestsIT.java
@@ -3,24 +3,146 @@ package fi.otavanopisto.muikku.rest.test;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import io.restassured.response.Response;
 
 import fi.otavanopisto.muikku.AbstractRESTTest;
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 
 public class SystemRESTTestsIT extends AbstractRESTTest {
+
+  private static final boolean STRICT_JSON = false; 
 
   public SystemRESTTestsIT() {
   }
   
   @Test
-  public void testListAreaGroups() throws NoSuchFieldException {
+  public void testPingPong() {
     Response response = asAdmin()
       .get("/system/ping");
     
     response.then()
       .statusCode(200)
       .body(is("pong"));
+  }
+
+  /**
+   * Tests that SchoolDataIdentifier as a PathParam is parsed correctly.
+   * The SchoolDataIdentifier is returned as an object with the fields 
+   * separated so they can be validated.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_path() {
+    SchoolDataIdentifier sdi = new SchoolDataIdentifier("TESTIDENTIFIER", "TESTDATASOURCE");
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter/%s", sdi.toId()));
+    
+    response.then().statusCode(200);
+    String expected = "{\"identifier\":\"TESTIDENTIFIER\",\"datasource\":\"TESTDATASOURCE\"}";
+    JSONAssert.assertEquals(expected, response.body().asString(), STRICT_JSON);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with a string that isn't 
+   * parseable as SchoolDataIdentifier. The expected result is 400 Bad Request.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_path_fail() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter/%s", "ASDASDASD"));
+    
+    response.then().statusCode(400);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with an empty string. 
+   * The expected result is 404 Not found as the platform can't find 
+   * the endpoint.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_path_notfound() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter/%s", ""));
+    
+    response.then().statusCode(404);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with an empty string. 
+   * The expected result is 404 Not found as the platform can't find 
+   * the endpoint.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_path_notfound2() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter/%s", "     "));
+    
+    response.then().statusCode(404);
+  }
+
+  /**
+   * Tests that SchoolDataIdentifier as a QueryParam is parsed correctly.
+   * The SchoolDataIdentifier is returned as an object with the fields 
+   * separated so they can be validated.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_query() {
+    SchoolDataIdentifier sdi = new SchoolDataIdentifier("TESTIDENTIFIER", "TESTDATASOURCE");
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter_queryparam?SDI=%s", sdi.toId()));
+    
+    response.then().statusCode(200);
+    String expected = "{\"identifier\":\"TESTIDENTIFIER\",\"datasource\":\"TESTDATASOURCE\"}";
+    JSONAssert.assertEquals(expected, response.body().asString(), STRICT_JSON);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with a string that isn't 
+   * parseable as SchoolDataIdentifier. The expected result is 400 Bad Request.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_query_fail() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter_queryparam?SDI=%s", "ASDASDASD"));
+    
+    response.then().statusCode(400);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter without queryparam. 
+   * The expected result is 204 for null queryparam.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_query_notfound() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter_queryparam"));
+    
+    response.then().statusCode(204);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with an empty string. 
+   * The expected result is 204 for null queryparam.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_query_notfound2() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter_queryparam?SDI=%s", ""));
+    
+    response.then().statusCode(204);
+  }
+
+  /**
+   * Tests SchoolDataIdentifier ParamConverter with an empty string. 
+   * The expected result is 204 for null queryparam.
+   */
+  @Test
+  public void testSchoolDataIdentifier_ParamConverter_query_notfound3() {
+    Response response = asAdmin()
+      .get(String.format("/test/sdi_paramconverter_queryparam?SDI=%s", "    "));
+    
+    response.then().statusCode(204);
   }
 
 }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
@@ -483,12 +483,7 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
   @GET
   @Path("/hopseligibility/{STUDENTIDENTIFIER}")
   @RESTPermit(handling = Handling.INLINE, requireLoggedIn = true)
-  public Response retrieveHopsEligibility(@PathParam("STUDENTIDENTIFIER") String studentIdentifierString) {
-    SchoolDataIdentifier studentIdentifier = SchoolDataIdentifier.fromId(studentIdentifierString);
-    if (studentIdentifier == null) {
-      return Response.status(Status.BAD_REQUEST).build();
-    }
-    
+  public Response retrieveHopsEligibility(@PathParam("STUDENTIDENTIFIER") SchoolDataIdentifier studentIdentifier) {
     if (!studentIdentifier.equals(sessionController.getLoggedUser()) && !userController.isGuardianOfStudent(sessionController.getLoggedUser(), studentIdentifier)) {
       return Response.status(Status.NOT_FOUND).build();
     }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/rest/MuikkuParamConverterProvider.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/rest/MuikkuParamConverterProvider.java
@@ -1,0 +1,28 @@
+package fi.otavanopisto.muikku.rest;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
+
+/**
+ * Provider for the ParamConverter classes in Muikku.
+ */
+@Provider
+public class MuikkuParamConverterProvider implements ParamConverterProvider {
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (rawType.equals(SchoolDataIdentifier.class)) {
+      return (ParamConverter<T>) new SchoolDataIdentifierParamConverter();
+    }
+    
+    return null;
+  }
+
+}

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/rest/SchoolDataIdentifierParamConverter.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/rest/SchoolDataIdentifierParamConverter.java
@@ -1,0 +1,45 @@
+package fi.otavanopisto.muikku.rest;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ext.ParamConverter;
+
+import org.apache.commons.lang3.StringUtils;
+
+import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
+
+/**
+ * ParamConverter for SchoolDataIdentifier.
+ * 
+ * Converts between String and SchoolDataIdentifier via the
+ * SchoolDataIdentifier.fromId() and SchoolDataIdentifier.toId()
+ * methods. I.e. the string needs to be in id form.
+ */
+public class SchoolDataIdentifierParamConverter implements ParamConverter<SchoolDataIdentifier> {
+
+  @Override
+  public SchoolDataIdentifier fromString(String value) {
+    /*
+     * If the value is blank, return null - this is probably bit of a compromise
+     * as sometimes it could warrant a Bad Request, but maybe those cases are
+     * left to the endpoint to validate.
+     */
+    if (StringUtils.isBlank(value)) {
+      return null;
+    }
+    
+    SchoolDataIdentifier schoolDataIdentifier = SchoolDataIdentifier.fromId(value);
+    
+    // Value exists, but it couldn't be parsed into a SchoolDataIdentifier, return bad request
+    if (schoolDataIdentifier == null) {
+      throw new BadRequestException();
+    }
+    
+    return schoolDataIdentifier;
+  }
+
+  @Override
+  public String toString(SchoolDataIdentifier value) {
+    return value != null ? value.toId() : null;
+  }
+
+}


### PR DESCRIPTION
Allows SchoolDataIdentifier to be parsed by JAX-RS meaning that SchoolDataIdentifier can be used as a type for `@PathParam`s and `@QueryParam`s. There is one example endpoint changed in this PR.

The motivation for this change is that it could reduce the amount of repetitive code converting Strings to SchoolDataIdentifiers in most endpoints and checking their null status (PathParams are fine without null check [the platform will block the request], QueryParams should still be checked if relevant).

The parsing goes as follows
- If the string is blank (null, empty or whitespace-only), the returned SchoolDataIdentifier is null.
- Otherwise the string is fed to `SchoolDataIdentifier.fromId` and if it parses successfully, the object is returned, otherwise a 400 Bad Request is thrown

This should still be tested more. It does look like Jackson doesn't use ParamConverters so if there are any SchoolDataIdentifiers inside rest models, they should still function as they were. There might be some endpoints where this misbehaves, thus more testing should be done.