### PR TITLE
6861 wcag 1.3.1, 2.1.1 ja 4.1.2  mobiilinakyman sivuvalikossa on isoja saavutettavuusongelmia

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
@@ -5,6 +5,7 @@
  */
 
 import * as React from "react";
+import { WithTranslation } from "react-i18next";
 import $ from "~/lib/jquery";
 import "~/sass/elements/content-panel.scss";
 import "~/sass/elements/loaders.scss";
@@ -12,7 +13,7 @@ import "~/sass/elements/loaders.scss";
 /**
  * ContentPanelProps
  */
-interface ContentPanelProps {
+interface ContentPanelProps extends WithTranslation {
   modifier: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   title?: React.ReactElement<any> | string;
@@ -55,7 +56,7 @@ export default class ContentPanel extends React.Component<
   ContentPanelProps,
   ContentPanelState
 > {
-  private myRef = React.createRef<HTMLDivElement>();
+  myRef = React.createRef<HTMLDivElement>();
 
   private touchCordX: number;
   private touchCordY: number;
@@ -216,6 +217,27 @@ export default class ContentPanel extends React.Component<
   }
 
   /**
+   * handleNavigationButtonKeyDown
+   * @param e e
+   */
+  handleNavigationButtonKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      this.openNavigation();
+    }
+  };
+
+  /**
+   * handleNavigationButtonKeyDown
+   * @param e e
+   */
+  handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.stopPropagation();
+    if (e.key === "Enter" || e.key === " ") {
+      this.closeNavigation();
+    }
+  };
+
+  /**
    * Component render method
    * @returns JSX.Element
    */
@@ -240,6 +262,13 @@ export default class ContentPanel extends React.Component<
                 <div
                   className="content-panel__navigation-open"
                   onClick={this.openNavigation}
+                  onKeyDown={this.handleNavigationButtonKeyDown}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={this.props.t("labels.tableOfContents", {
+                    ns: "materials",
+                  })}
+                  aria-hidden={!this.state.open}
                 >
                   <span className="icon-arrow-left"></span>
                 </div>
@@ -255,6 +284,7 @@ export default class ContentPanel extends React.Component<
                     this.state.dragging ? "dragging" : ""
                   }`}
                   onClick={this.closeNavigationByOverlay}
+                  onKeyDown={this.handleNavigationKeyDown}
                 >
                   <div
                     className="content-panel__navigation-content"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/content-panel.tsx
@@ -9,6 +9,7 @@ import { WithTranslation } from "react-i18next";
 import $ from "~/lib/jquery";
 import "~/sass/elements/content-panel.scss";
 import "~/sass/elements/loaders.scss";
+import { IconButton } from "~/components/general/button";
 
 /**
  * ContentPanelProps
@@ -220,7 +221,7 @@ export default class ContentPanel extends React.Component<
    * handleNavigationButtonKeyDown
    * @param e e
    */
-  handleNavigationButtonKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  handleNavigationOpenKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter" || e.key === " ") {
       this.openNavigation();
     }
@@ -230,8 +231,26 @@ export default class ContentPanel extends React.Component<
    * handleNavigationButtonKeyDown
    * @param e e
    */
+  handleNavigationCloseKeyDown = (
+    e: React.KeyboardEvent<HTMLAnchorElement>
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      this.closeNavigation();
+    }
+  };
+
+  /**
+   * handleNavigationButtonKeyDown
+   * @param e e
+   */
   handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     e.stopPropagation();
+    const isOverlay = e.target === e.currentTarget;
+
+    if (!isOverlay) {
+      return;
+    }
+
     if (e.key === "Enter" || e.key === " ") {
       this.closeNavigation();
     }
@@ -262,7 +281,7 @@ export default class ContentPanel extends React.Component<
                 <div
                   className="content-panel__navigation-open"
                   onClick={this.openNavigation}
-                  onKeyDown={this.handleNavigationButtonKeyDown}
+                  onKeyDown={this.handleNavigationOpenKeyDown}
                   tabIndex={0}
                   role="button"
                   aria-label={this.props.t("labels.tableOfContents", {
@@ -292,6 +311,16 @@ export default class ContentPanel extends React.Component<
                       right: this.state.drag !== null ? -this.state.drag : null,
                     }}
                   >
+                    <div className="content-panel__navigation-close">
+                      <IconButton
+                        icon="cross"
+                        onClick={this.closeNavigation}
+                        onKeyDown={this.handleNavigationCloseKeyDown}
+                        aria-label={this.props.t("wcag.closeContentPanel", {
+                          ns: "workspace",
+                        })}
+                      />
+                    </div>
                     {this.props.navigation}
                   </div>
                 </nav>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/tabs.tsx
@@ -102,6 +102,7 @@ export const Tabs: React.FC<TabsProps> = (props) => {
    * @param e e
    */
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
       e.preventDefault();
     }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/toc.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/toc.tsx
@@ -9,6 +9,7 @@ import AnimateHeight from "react-animate-height";
 import { useTranslation } from "react-i18next";
 import { useLocalStorage } from "usehooks-ts";
 import "~/sass/elements/toc.scss";
+import { IconButton } from "~/components/general/button";
 
 /**
  * TocProps
@@ -288,3 +289,44 @@ export const TocElement = React.forwardRef<HTMLAnchorElement, TocElementProps>(
 );
 
 TocElement.displayName = "TocElement";
+
+/**
+ * BackToTocProps
+ */
+interface BackToTocProps {
+  tocElementId: string;
+  openToc?: () => void;
+}
+
+/**
+ * BackToToc
+ * @param props props
+ */
+export const BackToToc = (props: BackToTocProps) => {
+  const { t } = useTranslation(["materials"]);
+
+  /**
+   * handleLinkClick
+   */
+  const handleLinkClick = () => {
+    props.openToc && props.openToc();
+
+    // Focus the element after a short delay to ensure that the navigation is open
+    setTimeout(() => {
+      const tocElement = document.getElementById(props.tocElementId);
+
+      if (tocElement) {
+        tocElement.focus();
+      }
+    }, 100);
+  };
+
+  return (
+    <IconButton
+      icon="forward"
+      onClick={handleLinkClick}
+      buttonModifiers={["back-to-toc rs_skip_always"]}
+      aria-label={t("wcag.focusToToc", { ns: "materials" })}
+    />
+  );
+};

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHelp/help/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceHelp/help/index.tsx
@@ -17,7 +17,7 @@ import ContentPanel, {
   ContentPanelItem,
 } from "~/components/general/content-panel";
 import HelpMaterial from "./help-material-page";
-import { ButtonPill, IconButton } from "~/components/general/button";
+import { ButtonPill } from "~/components/general/button";
 import Dropdown from "~/components/general/dropdown";
 import Link from "~/components/general/link";
 import { bindActionCreators } from "redux";
@@ -32,13 +32,10 @@ import {
   SetWorkspaceMaterialEditorStateTriggerType,
   UpdateWorkspaceMaterialContentNodeTriggerType,
 } from "~/actions/workspaces/material";
-import {
-  useTranslation,
-  withTranslation,
-  WithTranslation,
-} from "react-i18next";
+import { withTranslation, WithTranslation } from "react-i18next";
 import { MaterialViewRestriction } from "~/generated/client";
 import ReadSpeakerReader from "~/components/general/readspeaker";
+import { BackToToc } from "~/components/general/toc";
 
 /**
  * HelpMaterialsProps
@@ -75,6 +72,8 @@ const DEFAULT_OFFSET = 67;
  */
 class Help extends React.Component<HelpMaterialsProps, HelpMaterialsState> {
   private flattenedMaterial: MaterialContentNodeWithIdAndLogic[];
+  private contentPanelRef = React.createRef<ContentPanel>();
+
   /**
    * constructor
    * @param props props
@@ -719,6 +718,10 @@ class Help extends React.Component<HelpMaterialsProps, HelpMaterialsState> {
                   anchorItem={
                     <BackToToc
                       tocElementId={`tocElement-${node.workspaceMaterialId}`}
+                      openToc={
+                        this.contentPanelRef.current &&
+                        this.contentPanelRef.current.openNavigation
+                      }
                     />
                   }
                 />
@@ -795,6 +798,10 @@ class Help extends React.Component<HelpMaterialsProps, HelpMaterialsState> {
                     ? `tocTopic-${section.workspaceMaterialId}_${this.props.status.userId}`
                     : `tocTopic-${section.workspaceMaterialId}`
                 }
+                openToc={
+                  this.contentPanelRef.current &&
+                  this.contentPanelRef.current.openNavigation
+                }
               />
             </div>
           </h2>
@@ -820,13 +827,16 @@ class Help extends React.Component<HelpMaterialsProps, HelpMaterialsState> {
         modifier="workspace-instructions"
         navigation={this.props.navigation}
         title={t("labels.instructions", { ns: "workspace" })}
-        ref="content-panel"
         readspeakerComponent={
           <ReadSpeakerReader
             readParameterType="readid"
             readParameters={readSpeakerParameters}
           />
         }
+        t={t}
+        i18n={this.props.i18n}
+        tReady={this.props.tReady}
+        ref={this.contentPanelRef}
       >
         {results}
         {emptyMessage}
@@ -875,38 +885,3 @@ const componentWithTranslation = withTranslation(
 export default connect(mapStateToProps, mapDispatchToProps, null, {
   withRef: true,
 })(componentWithTranslation);
-
-/**
- * BackToTocProps
- */
-interface BackToTocProps {
-  tocElementId: string;
-}
-
-/**
- * BackToToc
- * @param props props
- */
-const BackToToc = (props: BackToTocProps) => {
-  const { t } = useTranslation(["materials"]);
-
-  /**
-   * handleLinkClick
-   */
-  const handleLinkClick = () => {
-    const tocElement = document.getElementById(props.tocElementId);
-
-    if (tocElement) {
-      tocElement.focus();
-    }
-  };
-
-  return (
-    <IconButton
-      icon="forward"
-      onClick={handleLinkClick}
-      buttonModifiers={["back-to-toc"]}
-      aria-label={t("wcag.focusToToc", { ns: "materials" })}
-    />
-  );
-};

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/workspace/workspaceMaterials/materials/index.tsx
@@ -20,7 +20,7 @@ import ContentPanel, {
 import ProgressData from "../../progressData";
 
 import WorkspaceMaterial from "./material";
-import { ButtonPill, IconButton } from "~/components/general/button";
+import { ButtonPill } from "~/components/general/button";
 import Dropdown from "~/components/general/dropdown";
 import Link from "~/components/general/link";
 import { bindActionCreators } from "redux";
@@ -37,11 +37,7 @@ import {
   SetWorkspaceMaterialEditorStateTriggerType,
   UpdateWorkspaceMaterialContentNodeTriggerType,
 } from "~/actions/workspaces/material";
-import {
-  useTranslation,
-  withTranslation,
-  WithTranslation,
-} from "react-i18next";
+import { withTranslation, WithTranslation } from "react-i18next";
 import ReadSpeakerReader from "~/components/general/readspeaker";
 import {
   displayNotification,
@@ -51,6 +47,7 @@ import {
   MaterialCompositeReply,
   MaterialViewRestriction,
 } from "~/generated/client";
+import { BackToToc } from "~/components/general/toc";
 
 /**
  * WorkspaceMaterialsProps
@@ -93,6 +90,8 @@ class WorkspaceMaterials extends React.Component<
   WorkspaceMaterialsState
 > {
   private flattenedMaterial: MaterialContentNodeWithIdAndLogic[];
+  private contentPanelRef = React.createRef<ContentPanel>();
+
   /**
    * constructor
    * @param props props
@@ -779,6 +778,10 @@ class WorkspaceMaterials extends React.Component<
                   anchorItem={
                     <BackToToc
                       tocElementId={`tocElement-${node.workspaceMaterialId}`}
+                      openToc={
+                        this.contentPanelRef.current &&
+                        this.contentPanelRef.current.openNavigation
+                      }
                     />
                   }
                 />
@@ -852,6 +855,10 @@ class WorkspaceMaterials extends React.Component<
                     ? `tocTopic-${section.workspaceMaterialId}_${this.props.status.userId}`
                     : `tocTopic-${section.workspaceMaterialId}`
                 }
+                openToc={
+                  this.contentPanelRef.current &&
+                  this.contentPanelRef.current.openNavigation
+                }
               />
             </div>
           </h2>
@@ -893,7 +900,10 @@ class WorkspaceMaterials extends React.Component<
             readParameters={readSpeakerParameters}
           />
         }
-        ref="content-panel"
+        t={t}
+        i18n={this.props.i18n}
+        tReady={this.props.tReady}
+        ref={this.contentPanelRef}
       >
         {results}
         {emptyMessage}
@@ -945,38 +955,3 @@ const componentWithTranslation = withTranslation(
 export default connect(mapStateToProps, mapDispatchToProps, null, {
   withRef: true,
 })(componentWithTranslation);
-
-/**
- * BackToTocProps
- */
-interface BackToTocProps {
-  tocElementId: string;
-}
-
-/**
- * BackToToc
- * @param props props
- */
-const BackToToc = (props: BackToTocProps) => {
-  const { t } = useTranslation(["materials"]);
-
-  /**
-   * handleLinkClick
-   */
-  const handleLinkClick = () => {
-    const tocElement = document.getElementById(props.tocElementId);
-
-    if (tocElement) {
-      tocElement.focus();
-    }
-  };
-
-  return (
-    <IconButton
-      icon="forward"
-      onClick={handleLinkClick}
-      buttonModifiers={["back-to-toc rs_skip_always"]}
-      aria-label={t("wcag.focusToToc", { ns: "materials" })}
-    />
-  );
-};

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/en.json
@@ -1717,6 +1717,7 @@
     },
     "wcag": {
       "announcementSelect": "Select announcement",
+      "closeContentPanel": "Close content panel",
       "collapseWorkspaceInfo": "Collapse course {{workspaceName}} info",
       "continueWorkspace": "Continue course {{workspaceName}}",
       "editingMasterSwitch": "Master switch for editing",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/locales/translations/fi.json
@@ -1717,6 +1717,7 @@
     },
     "wcag": {
       "announcementSelect": "Aseta tiedote valituksi",
+      "closeContentPanel": "Sulje sisältöpaneeli",
       "collapseWorkspaceInfo": "Pienennä kurssin {{workspaceName}} tiedot",
       "continueWorkspace": "Jatka kurssia {{workspaceName}}",
       "editingMasterSwitch": "Editointitilan valitsin",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/content-panel.scss
@@ -110,6 +110,7 @@
   z-index: 99;
 
   .content-panel__navigation-content {
+    background-color: $color-default;
     right: -90%;
   }
 
@@ -185,6 +186,16 @@
   @include breakpoint($breakpoint-desktop) {
     box-shadow: none;
     width: 100%;
+  }
+}
+
+.content-panel__navigation-close {
+  background-color: $color-default;
+  display: flex;
+  justify-content: flex-end;
+
+  @include breakpoint($breakpoint-desktop) {
+    display: none;
   }
 }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/tabs.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/tabs.scss
@@ -29,7 +29,6 @@
 .tabs--workspace-materials {
   height: 100%;
   margin: 0;
-  padding: 1px 0 0;
 }
 
 .tabs__header-actions {
@@ -202,7 +201,11 @@
   left: 0;
   position: absolute;
   right: 0;
-  top: calc(2.25rem + 1px); // Same value as .tabs__tab-labels height + one pixel for the border
+  top: calc(4.25rem + 1px); // Same value as .tabs__tab-labels + content-panel close height + one pixel for the border
+
+  @include breakpoint($breakpoint-desktop) {
+    top: calc(2.25rem + 1px); // Same value as .tabs__tab-labels height + one pixel for the border
+  }
 }
 
 .tabs__tab-data--guider-student {


### PR DESCRIPTION
Added content-panel__navigation-close element to make content panel navigation more accessible for keyboard users:
- simple close button
- some style changes for button
- couple new locale added

Materiaalit:
![image](https://github.com/user-attachments/assets/8fb64a34-08fe-48c1-b007-61cef7ed440b)

Ohjeet:
![image](https://github.com/user-attachments/assets/7a63ea22-b955-4a61-a5f3-29568429f8f5)

Resolves: #6861 