### PR TITLE
Lisätty ehtoja aktiivisen käyttäjän tarkistamiseen

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/CommunicatorController.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -22,7 +20,6 @@ import org.jsoup.safety.Safelist;
 
 import fi.otavanopisto.muikku.controller.TagController;
 import fi.otavanopisto.muikku.model.base.Tag;
-import fi.otavanopisto.muikku.model.users.EnvironmentRoleArchetype;
 import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.model.users.UserGroupEntity;
 import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
@@ -55,8 +52,6 @@ import fi.otavanopisto.muikku.plugins.communicator.model.VacationNotifications;
 import fi.otavanopisto.muikku.plugins.search.CommunicatorMessageIndexer;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.WorkspaceController;
-import fi.otavanopisto.muikku.search.SearchProvider;
-import fi.otavanopisto.muikku.search.SearchResult;
 import fi.otavanopisto.muikku.session.SessionController;
 import fi.otavanopisto.muikku.users.UserEntityController;
 import fi.otavanopisto.muikku.users.UserGroupEntityController;
@@ -121,10 +116,6 @@ public class CommunicatorController {
   
   @Inject
   private WorkspaceController workspaceController;
-  
-  @Inject
-  @Any
-  private Instance<SearchProvider> searchProviders;
   
   private String clean(String html) {
     Document doc = Jsoup.parseBodyFragment(html);
@@ -692,38 +683,6 @@ public class CommunicatorController {
     return communicatorMessageDAO.findNewerThreadId(userEntity, threadId, type, label);
   }
 
-  private SearchProvider getProvider(String name) {
-    for (SearchProvider searchProvider : searchProviders) {
-      if (name.equals(searchProvider.getName())) {
-        return searchProvider;
-      }
-    }
-    return null;
-  }
-  
-  public boolean isActiveUser(UserEntity userEntity) {
-    return isActiveUser(userSchoolDataIdentifierController.findUserSchoolDataIdentifierBySchoolDataIdentifier(userEntity.defaultSchoolDataIdentifier()));
-  }
-  
-  private boolean isActiveUser(UserSchoolDataIdentifier userSchoolDataIdentifier) {
-    EnvironmentRoleArchetype[] staffRoles = {
-        EnvironmentRoleArchetype.ADMINISTRATOR, 
-        EnvironmentRoleArchetype.MANAGER, 
-        EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER,
-        EnvironmentRoleArchetype.STUDY_GUIDER,
-        EnvironmentRoleArchetype.TEACHER
-    };
-    
-    if (!userSchoolDataIdentifier.hasAnyRole(staffRoles)) {
-      SearchProvider searchProvider = getProvider("elastic-search");
-      if (searchProvider != null) {
-        SearchResult searchResult = searchProvider.findUser(userSchoolDataIdentifier.schoolDataIdentifier(), false);
-        return searchResult.getTotalHitCount() > 0;
-      }
-    }
-    return true;
-  }
- 
   public Set<String> tagIdsToStr(Set<Long> tagIds) {
     Set<String> tagsStr = new HashSet<String>();
     for (Long tagId : tagIds) {

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/UserRecipientController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/UserRecipientController.java
@@ -67,10 +67,10 @@ public class UserRecipientController {
     for (UserEntity recipient : userRecipients) {
       // #3758: Only send messages to active users
       
-      Boolean isActiveUser = userEntityController.isActiveUser(recipient);
+      boolean isActiveUser = userEntityController.isActiveUserEntity(recipient);
       if (roles != null) {
         UserSchoolDataIdentifier usdi = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByUserEntity(recipient);
-        Boolean recipientRole = hasAnyRole(roles, usdi);
+        boolean recipientRole = hasAnyRole(roles, usdi);
         
         if (isActiveUser && (roles.isEmpty() || recipientRole)) {
           preparedRecipientList.addRecipient(recipient);
@@ -89,23 +89,23 @@ public class UserRecipientController {
         if (!CollectionUtils.isEmpty(groupUsers)) {
           for (UserGroupUserEntity groupUser : groupUsers) {
             UserSchoolDataIdentifier userSchoolDataIdentifier = groupUser.getUserSchoolDataIdentifier();
-            UserEntity recipient = userSchoolDataIdentifier.getUserEntity();
             // #3758: Only send messages to active students
             // #4920: Only message students' current study programmes
-            Boolean isActiveUser = userEntityController.isActiveUser(recipient);
+            boolean isActiveUser = userEntityController.isActiveUserSchoolDataIdentifier(userSchoolDataIdentifier);
 
             if (!isActiveUser) {
               continue;
             }
             
             if (roles != null) {
-              Boolean recipientRole = hasAnyRole(roles, userSchoolDataIdentifier);
+              boolean recipientRole = hasAnyRole(roles, userSchoolDataIdentifier);
               
               if (!recipientRole) {
                 continue;
               }
             }
             
+            UserEntity recipient = userSchoolDataIdentifier.getUserEntity();
             if ((recipient != null) && !Objects.equals(sender.getId(), recipient.getId())) {
               preparedRecipientList.addUserGroupRecipient(userGroup, recipient);
             }
@@ -123,7 +123,13 @@ public class UserRecipientController {
         if (!CollectionUtils.isEmpty(workspaceUsers)) {
           for (WorkspaceUserEntity workspaceUserEntity : workspaceUsers) {
             UserSchoolDataIdentifier userSchoolDataIdentifier = workspaceUserEntity.getUserSchoolDataIdentifier();
-            UserEntity recipient = userSchoolDataIdentifier.getUserEntity();
+            // #3758: Only send messages to active students
+            // #4920: Only message students' current study programmes
+            boolean isActiveUser = userEntityController.isActiveUserSchoolDataIdentifier(userSchoolDataIdentifier);
+
+            if (!isActiveUser) {
+              continue;
+            }
             
             if (roles != null) {
               Boolean recipientRole = hasAnyRole(roles, userSchoolDataIdentifier);
@@ -133,13 +139,7 @@ public class UserRecipientController {
               }
             }
             
-            // #3758: Only send messages to active students
-            // #4920: Only message students' current study programmes
-            Boolean isActiveUser = userEntityController.isActiveUser(recipient);
-
-            if (!isActiveUser) {
-              continue;
-            }
+            UserEntity recipient = userSchoolDataIdentifier.getUserEntity();
             if ((recipient != null) && !Objects.equals(sender.getId(), recipient.getId())) {
               preparedRecipientList.addWorkspaceStudentRecipient(workspaceEntity, recipient);
             }
@@ -175,16 +175,10 @@ public class UserRecipientController {
     return preparedRecipientList;
   }
   
-  
-  
-  private boolean hasAnyRole (List<EnvironmentRoleArchetype> roles, UserSchoolDataIdentifier userSchoolDataIdentifier) { 
-
+  private boolean hasAnyRole(List<EnvironmentRoleArchetype> roles, UserSchoolDataIdentifier userSchoolDataIdentifier) { 
     EnvironmentRoleArchetype[] roleArray = roles.toArray(new EnvironmentRoleArchetype[0]);
-    
     return userSchoolDataIdentifier.hasAnyRole(roleArray);
   }
-  
-  
   
   /**
    * Cleans list of UserEntities so that there are no duplicates present. Returns the original list.

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRESTService.java
@@ -556,7 +556,7 @@ public class CommunicatorRESTService extends PluginRESTService {
           }
         }
 
-        if (!communicatorController.isActiveUser(recipient)) {
+        if (!userEntityController.isActiveUserEntity(recipient)) {
           logger.log(Level.WARNING, String.format("Inactive student passed as recipient %d", recipientId));
           return Response.status(Status.BAD_REQUEST).entity("One or more of the recipients are inactive and the message cannot be sent to them. Contact support for help.").build();
         }
@@ -740,7 +740,7 @@ public class CommunicatorRESTService extends PluginRESTService {
           }
         }
         
-        if (!communicatorController.isActiveUser(recipient)) {
+        if (!userEntityController.isActiveUserEntity(recipient)) {
           logger.log(Level.WARNING, String.format("Inactive student passed as recipient %d", recipientId));
           return Response.status(Status.BAD_REQUEST).entity("One or more of the recipients are inactive and the message cannot be sent to them. Contact support for help.").build();
         }


### PR DESCRIPTION
isActiveUser:ia täsmennetty
* Jos aktiivisuutta kysytään `UserEntity`:llä, se selvitetään `UserEntity`:n default `UserSchoolDataIdentifier`:n avulla
* Arkistoitu `UserEntity` -> ei aktiivinen käyttäjä **UUSI RAJAUS**
* Arkistoitu `UserSchoolDataIdentifier` -> ei aktiivinen käyttäjä **UUSI RAJAUS**
* Jos aktiivisuutta kysytään `UserSchoolDataIdentifier`:llä, tarkistetaan onko annettu identifier default identifier, jos ei ole -> ei aktiivinen käyttäjä **UUSI RAJAUS**

Muuta
* Siistitty ja uudelleenjäsennelty `UserRecipientControlle`:a, eri lohkot nyt samassa järjestyksessä
* Poistettu duplikaattikoodia `CommunicatorController`:sta, samat `UserEntityController`:ssa
