### PR TITLE
All moment old other wrong date locale conversions changed to use loc…

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-act.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-act.tsx
@@ -7,6 +7,7 @@ import { SavingDraftInfo } from "../saving-draft-info";
 import { Textarea } from "../textarea";
 import { TextField } from "../textfield";
 import { useTranslation } from "react-i18next";
+import { localize } from "~/locales/i18n";
 
 /**
  * MatriculationExaminationEnrollmentAct
@@ -176,9 +177,7 @@ const MatriculationExaminationEnrollmentAct = () => {
           <div className="matriculation__form-element-container">
             <TextField
               label={t("labels.date")}
-              value={`${examinationInformation.enrollmentDate.getDate()}.${
-                examinationInformation.enrollmentDate.getMonth() + 1
-              }.${examinationInformation.enrollmentDate.getFullYear()}`}
+              value={localize.date(examinationInformation.enrollmentDate)}
               type="text"
               readOnly
               className="matriculation__input"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-summary-new.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-summary-new.tsx
@@ -17,6 +17,7 @@ import {
   MatriculationExamDegreeType,
   MatriculationExamSchoolType,
 } from "~/generated/client";
+import { localize } from "~/locales/i18n";
 
 /**
  * MatriculationExaminationEnrollmentSummaryProps
@@ -451,9 +452,7 @@ export const MatriculationExaminationEnrollmentSummaryNew: React.FC<
           <div className="matriculation__form-element-container">
             <TextField
               label={t("labels.date")}
-              value={`${enrollmentDate.getDate()}.${
-                enrollmentDate.getMonth() + 1
-              }.${enrollmentDate.getFullYear()}`}
+              value={localize.date(enrollmentDate)}
               type="text"
               readOnly
               className="matriculation__input"

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-change-log.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-change-log.tsx
@@ -1,8 +1,8 @@
-import moment from "moment";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import Avatar from "~/components/general/avatar";
 import { MatriculationExamChangeLogEntry } from "~/generated/client";
+import { localize } from "~/locales/i18n";
 import "~/sass/elements/hops.scss";
 
 /**
@@ -158,7 +158,7 @@ export const ChangeLogItem: React.FC<ChangeLogItemProps> = (props) => {
             {changeTypeString()}
           </span>
           <span className="hops-container__history-event-date">
-            {moment(logEntry.timestamp).format("l")}
+            {localize.date(logEntry.timestamp)}
           </span>
         </div>
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-past-list-item.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-past-list-item.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
-import AnimateHeight from "react-animate-height";
 import { useTranslation } from "react-i18next";
 import { connect, Dispatch } from "react-redux";
 import { bindActionCreators } from "redux";
 import { AnyActionType } from "~/actions";
-import ApplicationList, {
-  ApplicationListItem,
-  ApplicationListItemBody,
-  ApplicationListItemHeader,
-} from "~/components/general/application-list";
 import ApplicationSubPanel from "~/components/general/application-sub-panel";
 import { StateType } from "~/reducers";
 import { MatriculationExamWithHistory } from "~/reducers/hops";
@@ -36,14 +30,6 @@ const MatriculationPastListItem = (props: MatriculationPastListItemProps) => {
 
   const { t } = useTranslation(["hops_new", "common"]);
 
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [showHistory, setShowHistory] = React.useState(false);
-
-  const headerTitle = t(`matriculationTerms.${exam.term}`, {
-    ns: "hops_new",
-    year: exam.year,
-  });
-
   /**
    * toggleDrawer
    */
@@ -51,16 +37,12 @@ const MatriculationPastListItem = (props: MatriculationPastListItemProps) => {
     if (exam.status === "IDLE") {
       loadMatriculationExamHistory(exam.id);
     }
-
-    setIsOpen(!isOpen);
   };
 
-  /**
-   * handleToggleHistoryClick
-   */
-  const handleToggleHistoryClick = () => {
-    setShowHistory(!showHistory);
-  };
+  const headerTitle = t(`matriculationTerms.${exam.term}`, {
+    ns: "hops_new",
+    year: exam.year,
+  });
 
   return (
     <div className="application-sub-panel__notification-item">
@@ -76,7 +58,10 @@ const MatriculationPastListItem = (props: MatriculationPastListItemProps) => {
               </ApplicationSubPanel>
               <ApplicationSubPanel>
                 <ApplicationSubPanel.Body>
-                  <details className="details">
+                  <details
+                    className="details"
+                    onClick={handleToggleDrawerClick}
+                  >
                     <summary className="details__summary">
                       {t("actions.showChangeLog", { ns: "hops_new" })}
                     </summary>

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-past-list.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/enrollment-history/enrollment-past-list.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import ApplicationList from "~/components/general/application-list";
 
 /**
  * MatriculationPastEnrollmentListProps

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/matriculation-enrollment.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application/matriculation/components/matriculation-enrollment.tsx
@@ -14,6 +14,7 @@ import { TFunction } from "i18next";
 import ApplicationSubPanel, {
   ApplicationSubPanelItem,
 } from "~/components/general/application-sub-panel";
+import { localize } from "~/locales/i18n";
 
 /**
  * MatriculationEnrollmentProps
@@ -76,7 +77,7 @@ const MatriculationEnrollmentLink = (
           <Button buttonModifiers={["info"]} disabled={useCase === "GUARDIAN"}>
             {t("actions.signUp", {
               ns: "hops_new",
-              dueDate: new Date(exam.ends).toLocaleDateString("fi-Fi"),
+              dueDate: localize.date(new Date(exam.ends)),
             })}
           </Button>
         </MatriculationExaminationWizardDialog>
@@ -223,9 +224,7 @@ const MatriculationSubmittedEnrollment = (
     year: exam.year,
   });
 
-  const date = new Date(exam.enrollment.enrollmentDate).toLocaleDateString(
-    "fi-Fi"
-  );
+  const date = localize.date(new Date(exam.enrollment.enrollmentDate));
 
   const enrollmentTitle = (
     <span
@@ -253,7 +252,7 @@ const MatriculationSubmittedEnrollment = (
           })}
         >
           <ApplicationSubPanelItem.Content>
-            {new Date(exam.ends).toLocaleDateString("fi-Fi")}
+            {localize.date(new Date(exam.ends))}
           </ApplicationSubPanelItem.Content>
         </ApplicationSubPanelItem>
         <ApplicationSubPanelItem

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/helper-functions/matriculation-functions.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/helper-functions/matriculation-functions.tsx
@@ -78,16 +78,16 @@ export const getPastTerms = () =>
 export const getNextTerms = () => resolveTerms(moment().add(1, "years"), 3);
 
 /**
- * Resolves next 6 terms starting from given date
+ * Resolves next 10 terms (5 years) starting from given date
  *
  * @param date date
  * @returns terms
  */
 export const getNextTermsByDate = (date: Date | string) =>
-  resolveTerms(moment(date), 6);
+  resolveTerms(moment(date), 10);
 
 /**
- * Resolves next 3 terms starting from given date
+ * Resolves next 10 terms (5 years) starting from given date
  *
  * @param date date
  * @param t t


### PR DESCRIPTION
Following changes:
- added 5 years of terms options to matriculation plan subject term selector (described in the issue)
- wrong date locales fixed all around matriculation
- fixed bug that prevented loading past matriculation registration's changelog when clicking summary/details.

Resolves: #7148 