### PR TITLE
"empty" option value is now correctly set to be "" string

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/matriculationExaminationSelectLists/matriculation-examination-selector-components.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/matriculationExaminationSelectLists/matriculation-examination-selector-components.tsx
@@ -146,13 +146,15 @@ export const MatriculationExaminationEnrolledInputGroup: React.FC<
           <FundingSelect
             i={index}
             disabled={readOnly}
-            value={subject.funding}
+            value={subject.funding || ""}
             isFailedBefore={isFailedBefore}
             isSucceedBefore={isSucceedBefore}
             onChange={(e) =>
               onSubjectGroupChange(
                 "funding",
-                e.target.value as MatriculationExamFundingType,
+                e.target.value === ""
+                  ? undefined
+                  : (e.target.value as MatriculationExamFundingType),
                 index
               )
             }
@@ -307,11 +309,13 @@ export const MatriculationExaminationFinishedInputGroup: React.FC<
           <FundingSelect
             i={index}
             disabled={readOnly}
-            value={subject.funding}
+            value={subject.funding || ""}
             onChange={(e) =>
               onSubjectGroupChange(
                 "funding",
-                e.target.value as MatriculationExamFundingType,
+                e.target.value === ""
+                  ? undefined
+                  : (e.target.value as MatriculationExamFundingType),
                 index
               )
             }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/matriculationExaminationSelectLists/matriculation-examination-selector-components.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/matriculationExaminationSelectLists/matriculation-examination-selector-components.tsx
@@ -585,7 +585,7 @@ const MandatorySelect: React.FC<MandatorySelectProps> = (props) => {
         disabled={selectProps.disabled}
         className="matriculation__select"
       >
-        <option>Valitse...</option>
+        <option value="">Valitse...</option>
         <option value="true">Pakollinen</option>
         <option value="false">Ylimääräinen</option>
       </select>
@@ -675,7 +675,7 @@ const GradeSelect: React.FC<GradeSelectProps> = (props) => {
         disabled={selectProps.disabled}
         className="matriculation__select"
       >
-        <option>{t(`labels.select`)}...</option>
+        <option value="">{t(`labels.select`)}...</option>
         {Object.keys(EXAMINATION_GRADES_MAP).map((subjectCode, index) => {
           const subjectName = EXAMINATION_GRADES_MAP[subjectCode];
 
@@ -730,7 +730,7 @@ const FundingSelect: React.FC<FundingSelectProps> = (props) => {
       >
         {isSucceedBefore ? (
           <>
-            <option>{t(`labels.select`)}...</option>
+            <option value="">{t(`labels.select`)}...</option>
             <option value={MatriculationExamFundingType.SelfFunded}>
               {t(`matriculationExamFundings.SELF_FUNDED`, { ns: "hops_new" })}
             </option>
@@ -739,7 +739,7 @@ const FundingSelect: React.FC<FundingSelectProps> = (props) => {
 
         {isFailedBefore ? (
           <>
-            <option>{t(`labels.select`)}...</option>
+            <option value="">{t(`labels.select`)}...</option>
             <option value={MatriculationExamFundingType.SelfFunded}>
               {t(`matriculationExamFundings.SELF_FUNDED`, {
                 ns: "hops_new",
@@ -757,7 +757,7 @@ const FundingSelect: React.FC<FundingSelectProps> = (props) => {
 
         {!isFailedBefore && !isSucceedBefore ? (
           <>
-            <option>{t(`labels.select`)}...</option>
+            <option value="">{t(`labels.select`)}...</option>
             <option value={MatriculationExamFundingType.SelfFunded}>
               {t(`matriculationExamFundings.SELF_FUNDED`, {
                 ns: "hops_new",

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-information-new.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-information-new.tsx
@@ -157,7 +157,10 @@ export const MatriculationExaminationEnrollmentInformationNew = () => {
     const succesfulFinishedExams: string[] = [];
 
     examinationInformation.finishedAttendances.forEach((item) => {
-      if (EXAMINATION_SUCCESS_GRADES_MAP.includes(item.grade)) {
+      // Because there is a case where examination is not yet graded
+      // before next enrollment period starts, we need to include UNKNOWN
+      // to the list of succesful grades to be able to continue with the enrollment
+      if ([...EXAMINATION_SUCCESS_GRADES_MAP, "UNKNOWN"].includes(item.grade)) {
         succesfulFinishedExams.push(item.subject);
       }
     });

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-information-new.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/general/matriculationExaminationWizard/steps/matriculation-examination-enrollment-information-new.tsx
@@ -487,6 +487,10 @@ export const MatriculationExaminationEnrollmentInformationNew = () => {
       if (attendance.subject === "") {
         return true;
       }
+
+      if (compulsoryEducationEligible && attendance.funding === undefined) {
+        return true;
+      }
     }
     for (const attendance of examinationInformation.finishedAttendances) {
       if (
@@ -494,6 +498,10 @@ export const MatriculationExaminationEnrollmentInformationNew = () => {
         attendance.subject === "" ||
         attendance.grade === ""
       ) {
+        return true;
+      }
+
+      if (compulsoryEducationEligible && attendance.funding === undefined) {
         return true;
       }
     }
@@ -504,6 +512,7 @@ export const MatriculationExaminationEnrollmentInformationNew = () => {
     }
     return false;
   }, [
+    compulsoryEducationEligible,
     examinationInformation.enrolledAttendances,
     examinationInformation.finishedAttendances,
     examinationInformation.plannedAttendances,


### PR DESCRIPTION
First select option value is now always "" string as it should be, so validation could work correctly

Resolves #7193 