### PR TITLE
* Sort of fix for RS reading/speaking hidden content

### DIFF
--- a/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -23,6 +23,7 @@
           general: {
             usePost: true,
             enableSkipAlways: true,
+            skipHiddenContent: true,
           },
           ui: {
             tools: {
@@ -37,7 +38,7 @@
           },
         };
       </script>
-
+      
       <script type="text/javascript">
         var CONTEXTPATH = "#{request.contextPath}";
       </script>


### PR DESCRIPTION
Closes #7209 

**HUOM!**

Nyt ReadSpeaker ei lue enää mitään piiloitettua sisältöä eli jos tälläiselle on ollut tarvetta se tarve poistuu nyt.

Samaten harkkatehtävien palautteita, jotka ovat piilossa siihen asti kunnes käyttäjä on palauttanut tehtävän, ReadSpeaker ei onnistu lukemaan vaikka niiden piilotus on poistettu ilman että koko sivu pitää ladta uudestaan. Tälle emme voi mitään.

Vaihtoehtoisesti voimme tutkia myöhemmin jos tekisimme erllisen preprosessoinnin kaikille harkkatehtävien palaute laatikoille jolloin lisäisimme niihin ohjelmallisesti **rs_skip** class:in ja poistaisimme tämän piilotetun sisällön lukueston.