### PR TITLE
Hops is now correctly reseted in guider after closing student dialog

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/hops/index.ts
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/reducers/hops/index.ts
@@ -361,6 +361,9 @@ export const hopsNew: Reducer<HopsState> = (
           plan: null,
           results: [],
         },
+        hopsLocked: null,
+        hopsLockedStatus: "IDLE",
+        hopsMode: "READ",
         hopsEditing: {
           ...state.hopsEditing,
           readyToEdit: false,


### PR DESCRIPTION
Hops is now correctly reseted in guider after closing student dialog

Resolves: #7255 