### PR TITLE
Fix for study activity supplementation requests

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
@@ -445,7 +445,7 @@ public class HopsRestService {
               studentEntity.getId(),
               item.getCourseId(),
               Boolean.FALSE);
-          if (supplementationRequest != null && !supplementationRequest.getHandled() && item.getDate().before(supplementationRequest.getRequestDate())) {
+          if (supplementationRequest != null && item.getDate().before(supplementationRequest.getRequestDate())) {
             item.setDate(supplementationRequest.getRequestDate());
             item.setStatus(StudyActivityItemStatus.SUPPLEMENTATIONREQUEST);
           }


### PR DESCRIPTION
When figuring out the state of a course, also consider supplementation requests that have been marked as handled but not removed.