### PR TITLE
Fixes for determining the existance of supplementation requests

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/AssessmentRequestController.java
@@ -133,11 +133,12 @@ public class AssessmentRequestController {
     
     // #7000: Requesting assessment sets supplementation request handled so this is vice versa
     
-    SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(
+    SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndHandledAndArchived(
         studentEntity.getId(),
         workspaceEntity.getId(),
+        Boolean.TRUE,
         Boolean.FALSE);
-    if (supplementationRequest != null && Boolean.TRUE.equals(supplementationRequest.getHandled())) {
+    if (supplementationRequest != null) {
       evaluationController.markSupplementationRequestUnhandled(supplementationRequest);
     }
     

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/rest/AssessmentRequestRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/assessmentrequest/rest/AssessmentRequestRESTService.java
@@ -133,9 +133,10 @@ public class AssessmentRequestRESTService extends PluginRESTService {
     // Price is reset to zero if the user has an active supplementation request on this workspace
     
     if (price != null && price.getPrice() > 0) {
-      SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(
+      SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndHandledAndArchived(
           sessionController.getLoggedUserEntity().getId(),
           workspaceEntityId,
+          Boolean.FALSE,
           Boolean.FALSE);
       if (supplementationRequest != null) {
         price.setPrice(0d);

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationController.java
@@ -226,9 +226,12 @@ public class EvaluationController {
       // Supplementation request, if one exists and is newer than activity date so far
 
       for (WorkspaceAssessmentState assessment : activity.getAssessmentStates()) {
-        SchoolDataIdentifier workspaceSubjectIdentifier = SchoolDataIdentifier.fromId(assessment.getSubjectIdentifier());
-        SupplementationRequest supplementationRequest = findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(
-            userEntity.getId(), workspaceEntity.getId(), workspaceSubjectIdentifier, Boolean.FALSE);
+        SupplementationRequest supplementationRequest = findLatestSupplementationRequestByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(
+            userEntity.getId(),
+            workspaceEntity.getId(),
+            SchoolDataIdentifier.fromId(assessment.getSubjectIdentifier()),
+            Boolean.FALSE,
+            Boolean.FALSE);
         if (supplementationRequest != null && supplementationRequest.getRequestDate().after(assessment.getDate())) {
           assessment.setText(supplementationRequest.getRequestText());
           assessment.setDate(supplementationRequest.getRequestDate());
@@ -557,7 +560,7 @@ public class EvaluationController {
   }
 
   public void markSupplementationRequestHandled(Long studentEntityId, Long workspaceEntityId, SchoolDataIdentifier workspaceSubjectIdentifier) {
-    List<SupplementationRequest> supplementationRequests = supplementationRequestDAO.listByStudentAndWorkspaceAndSubjectAndHandledAndArchived(
+    List<SupplementationRequest> supplementationRequests = supplementationRequestDAO.listByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(
         studentEntityId,
         workspaceEntityId,
         workspaceSubjectIdentifier.toId(),
@@ -699,16 +702,16 @@ public class EvaluationController {
     return supplementationRequestDAO.listByStudentAndWorkspaceAndArchived(studentEntityId, workspaceEntityId, archived);
   }
 
-  public List<SupplementationRequest> listSupplementationRequestsByStudentAndWorkspaceAndSubjectAndHandledAndArchived(Long studentEntityId, Long workspaceEntityId, SchoolDataIdentifier workspaceSubjectIdentifier, Boolean handled, Boolean archived) {
-    return supplementationRequestDAO.listByStudentAndWorkspaceAndSubjectAndHandledAndArchived(studentEntityId, workspaceEntityId, workspaceSubjectIdentifier.toId(), handled, archived);
+  public List<SupplementationRequest> listSupplementationRequestsByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(Long studentEntityId, Long workspaceEntityId, SchoolDataIdentifier subjectIdentifier, Boolean handled, Boolean archived) {
+    return supplementationRequestDAO.listByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(studentEntityId, workspaceEntityId, subjectIdentifier.toId(), handled, archived);
   }
 
-  public SupplementationRequest findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(Long studentEntityId, Long workspaceEntityId, Boolean archived) {
-    return supplementationRequestDAO.findLatestByStudentAndWorkspaceAndArchived(studentEntityId, workspaceEntityId, archived);
+  public SupplementationRequest findLatestSupplementationRequestByStudentAndWorkspaceAndHandledAndArchived(Long studentEntityId, Long workspaceEntityId, Boolean handled, Boolean archived) {
+    return supplementationRequestDAO.findLatestByStudentAndWorkspaceAndHandledAndArchived(studentEntityId, workspaceEntityId, handled, archived);
   }
 
-  public SupplementationRequest findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(Long studentEntityId, Long workspaceEntityId, SchoolDataIdentifier workspaceSubjectIdentifier, Boolean archived) {
-    return supplementationRequestDAO.findLatestByStudentAndWorkspaceAndArchived(studentEntityId, workspaceEntityId, workspaceSubjectIdentifier, archived);
+  public SupplementationRequest findLatestSupplementationRequestByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(Long studentEntityId, Long workspaceEntityId, SchoolDataIdentifier subjectIdentifier, Boolean handled, Boolean archived) {
+    return supplementationRequestDAO.findLatestByStudentAndWorkspaceAndSubjectIdentifierAndHandledAndArchived(studentEntityId, workspaceEntityId, subjectIdentifier, handled, archived);
   }
 
   /**

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/evaluation/EvaluationRESTService.java
@@ -1814,9 +1814,10 @@ public class EvaluationRESTService extends PluginRESTService {
     Date evaluationDate = compositeAssessmentRequest.getEvaluationDate();
     Boolean graded = evaluationDate != null;
     if (userEntity != null) {
-      SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(
+      SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndHandledAndArchived(
           userEntity.getId(),
           workspaceEntity.getId(),
+          Boolean.FALSE,
           Boolean.FALSE);
       if (supplementationRequest != null &&
           (evaluationDate == null || evaluationDate.before(supplementationRequest.getRequestDate())) &&

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
@@ -441,9 +441,10 @@ public class HopsRestService {
       List<StudyActivityItemRestModel> items = response.getEntity();
       for (StudyActivityItemRestModel item : items) {
         if (item.getCourseId() != null && studentEntity != null) {
-          SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndArchived(
+          SupplementationRequest supplementationRequest = evaluationController.findLatestSupplementationRequestByStudentAndWorkspaceAndHandledAndArchived(
               studentEntity.getId(),
               item.getCourseId(),
+              Boolean.FALSE,
               Boolean.FALSE);
           if (supplementationRequest != null && item.getDate().before(supplementationRequest.getRequestDate())) {
             item.setDate(supplementationRequest.getRequestDate());

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/CourseMetaController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/CourseMetaController.java
@@ -14,6 +14,8 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fi.otavanopisto.muikku.schooldata.entity.CourseLengthUnit;
 import fi.otavanopisto.muikku.schooldata.entity.Curriculum;
 import fi.otavanopisto.muikku.schooldata.entity.EducationType;
@@ -47,6 +49,9 @@ public class CourseMetaController {
   /* Subjects */
 
   public Subject findSubjectByCode(String schoolDataSource, String code) {
+    if (StringUtils.isAnyEmpty(schoolDataSource, code)) {
+      return null;
+    }
     if (!subjectCodeCache.containsKey(code)) {
       Subject subject = null;
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(schoolDataSource);
@@ -62,6 +67,9 @@ public class CourseMetaController {
   }
   
   public Subject findSubject(SchoolDataIdentifier identifier) {
+    if (identifier == null) {
+      return null;
+    }
     if (!subjectIdentifierCache.containsKey(identifier)) {
       Subject subject = null;
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
@@ -98,6 +106,9 @@ public class CourseMetaController {
   /* EducationType */
 
   public EducationType findEducationType(SchoolDataIdentifier identifier) {
+    if (identifier == null) {
+      return null;
+    }
     if (!educationTypeCache.containsKey(identifier)) {
       EducationType educationType = null;
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
@@ -125,6 +136,9 @@ public class CourseMetaController {
   /* CourseLenthUnit */
 
   public CourseLengthUnit findCourseLengthUnit(SchoolDataIdentifier identifier) {
+    if (identifier == null) {
+      return null;
+    }
     if (!courseLengthUnitCache.containsKey(identifier)) {
       CourseLengthUnit courseLengthUnit = null;
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
@@ -161,6 +175,9 @@ public class CourseMetaController {
   /* Curriculum */
 
   public Curriculum findCurriculum(SchoolDataIdentifier identifier) {
+    if (identifier == null) {
+      return null;
+    }
     if (!curriculumCache.containsKey(identifier)) {
       Curriculum curriculum = null;
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
@@ -185,9 +202,9 @@ public class CourseMetaController {
     return result;
   }
 
-  public String getCurriculumName(SchoolDataIdentifier curriculumIdentifier) {
-    if (curriculumIdentifier != null) {
-      Curriculum curriculum = findCurriculum(curriculumIdentifier);
+  public String getCurriculumName(SchoolDataIdentifier identifier) {
+    if (identifier != null) {
+      Curriculum curriculum = findCurriculum(identifier);
       return curriculum == null ? null : curriculum.getName();
     }
     return null;

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/CourseMetaController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/CourseMetaController.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,6 +37,11 @@ public class CourseMetaController {
   private ConcurrentHashMap<SchoolDataIdentifier, CourseLengthUnit> courseLengthUnitCache;
   private ConcurrentHashMap<SchoolDataIdentifier, Curriculum> curriculumCache;
   private ConcurrentHashMap<SchoolDataIdentifier, EducationType> educationTypeCache;
+  private ConcurrentSkipListSet<String> unknownSubjectCodes;
+  private ConcurrentSkipListSet<SchoolDataIdentifier> unknownSubjects;
+  private ConcurrentSkipListSet<SchoolDataIdentifier> unknownCurriculums;
+  private ConcurrentSkipListSet<SchoolDataIdentifier> unknownEducationTypes;
+  private ConcurrentSkipListSet<SchoolDataIdentifier> unknownCourseLengthUnits;
   
   @PostConstruct
   public void init() {
@@ -44,12 +50,17 @@ public class CourseMetaController {
     courseLengthUnitCache = new ConcurrentHashMap<>();
     curriculumCache = new ConcurrentHashMap<>();
     educationTypeCache = new ConcurrentHashMap<>();
+    unknownSubjectCodes = new ConcurrentSkipListSet<>();
+    unknownSubjects = new ConcurrentSkipListSet<>();
+    unknownCurriculums = new ConcurrentSkipListSet<>();
+    unknownEducationTypes = new ConcurrentSkipListSet<>();
+    unknownCourseLengthUnits = new ConcurrentSkipListSet<>();
   }
 
   /* Subjects */
 
   public Subject findSubjectByCode(String schoolDataSource, String code) {
-    if (StringUtils.isAnyEmpty(schoolDataSource, code)) {
+    if (StringUtils.isAnyEmpty(schoolDataSource, code) || unknownSubjectCodes.contains(code)) {
       return null;
     }
     if (!subjectCodeCache.containsKey(code)) {
@@ -57,9 +68,12 @@ public class CourseMetaController {
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(schoolDataSource);
       if (schoolDataBridge != null) {
         subject = schoolDataBridge.findSubjectByCode(code);
-        subjectCodeCache.put(code, subject);
         if (subject != null) {
+          subjectCodeCache.put(code, subject);
           subjectIdentifierCache.put(subject.schoolDataIdentifier(), subject);
+        }
+        else {
+          unknownSubjectCodes.add(code);
         }
       }
     }
@@ -67,7 +81,7 @@ public class CourseMetaController {
   }
   
   public Subject findSubject(SchoolDataIdentifier identifier) {
-    if (identifier == null) {
+    if (identifier == null || unknownSubjects.contains(identifier)) {
       return null;
     }
     if (!subjectIdentifierCache.containsKey(identifier)) {
@@ -77,9 +91,12 @@ public class CourseMetaController {
         subject = schoolDataBridge.findSubject(identifier.getIdentifier());
         if (subject != null) {
           subjectCodeCache.put(subject.getCode(), subject);
+          subjectIdentifierCache.put(identifier, subject);
+        }
+        else {
+          unknownSubjects.add(identifier);
         }
       }
-      subjectIdentifierCache.put(identifier, subject);
     }
     return subjectIdentifierCache.get(identifier);
   }
@@ -106,7 +123,7 @@ public class CourseMetaController {
   /* EducationType */
 
   public EducationType findEducationType(SchoolDataIdentifier identifier) {
-    if (identifier == null) {
+    if (identifier == null || unknownEducationTypes.contains(identifier)) {
       return null;
     }
     if (!educationTypeCache.containsKey(identifier)) {
@@ -114,8 +131,13 @@ public class CourseMetaController {
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
       if (schoolDataBridge != null) {
         educationType = schoolDataBridge.findEducationType(identifier.getIdentifier());
+        if (educationType != null) {
+          educationTypeCache.put(identifier, educationType);
+        }
+        else {
+          unknownEducationTypes.add(identifier);
+        }
       }
-      educationTypeCache.put(identifier, educationType);
     }
     return educationTypeCache.get(identifier);
   }
@@ -136,7 +158,7 @@ public class CourseMetaController {
   /* CourseLenthUnit */
 
   public CourseLengthUnit findCourseLengthUnit(SchoolDataIdentifier identifier) {
-    if (identifier == null) {
+    if (identifier == null || unknownCourseLengthUnits.contains(identifier)) {
       return null;
     }
     if (!courseLengthUnitCache.containsKey(identifier)) {
@@ -144,8 +166,13 @@ public class CourseMetaController {
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
       if (schoolDataBridge != null) {
         courseLengthUnit = schoolDataBridge.findCourseLengthUnit(identifier.getIdentifier());
+        if (courseLengthUnit != null) {
+          courseLengthUnitCache.put(identifier, courseLengthUnit);
+        }
+        else {
+          unknownCourseLengthUnits.add(identifier);
+        }
       }
-      courseLengthUnitCache.put(identifier, courseLengthUnit);
     }
     return courseLengthUnitCache.get(identifier);
   }
@@ -175,7 +202,7 @@ public class CourseMetaController {
   /* Curriculum */
 
   public Curriculum findCurriculum(SchoolDataIdentifier identifier) {
-    if (identifier == null) {
+    if (identifier == null || unknownCurriculums.contains(identifier)) {
       return null;
     }
     if (!curriculumCache.containsKey(identifier)) {
@@ -183,8 +210,13 @@ public class CourseMetaController {
       CourseMetaSchoolDataBridge schoolDataBridge = getCourseMetaBridge(identifier.getDataSource());
       if (schoolDataBridge != null) {
         curriculum = schoolDataBridge.findCurriculum(identifier.getIdentifier());
+        if (curriculum != null) {
+          curriculumCache.put(identifier, curriculum);
+        }
+        else {
+          unknownCurriculums.add(identifier);
+        }
       }
-      curriculumCache.put(identifier, curriculum);
     }
     return curriculumCache.get(identifier);
   }


### PR DESCRIPTION
Changed methods returning the latest supplementation request to only return one if it hasn't been handled yet (i.e. not superseded by a newer evaluation action).