### PR TITLE
Fronttipolkujen ohjaus

### DIFF
--- a/muikku/src/main/java/fi/otavanopisto/muikku/servlet/SPAForwardingFilter.java
+++ b/muikku/src/main/java/fi/otavanopisto/muikku/servlet/SPAForwardingFilter.java
@@ -1,0 +1,51 @@
+package fi.otavanopisto.muikku.servlet;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Filter that forwards certain paths always to a common (x)html 
+ * page that is expected to handle the paths routing. The html
+ * is likely a Single-Page Application that handles the routing
+ * based on the browser's URL.
+ */
+@WebFilter(urlPatterns = "/*")
+public class SPAForwardingFilter implements Filter {
+  
+  // Entrypoint (likely html file) that initializes the SPA
+  private static final String SPA_ENTRYPOINT = "/index.xhtml";
+  
+  // The paths that are redirected to the SPA Entrypoint
+  private static final Set<String> FRONTEND_PATHS = Set.of(
+      "/announcer",
+      "/communicator",
+      "/coursepicker",
+      "/evaluation",
+      "/guider",
+      "/organization",
+      "/profile"
+  );
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    if (request instanceof HttpServletRequest) {
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
+      if (FRONTEND_PATHS.contains(httpRequest.getServletPath())) {
+        request.getRequestDispatcher(SPA_ENTRYPOINT).forward(httpRequest, response);
+        return;
+      }
+    }
+    
+    chain.doFilter(request, response);
+  }
+
+}


### PR DESCRIPTION
* Lisätty Filter, joka ohjaa määrätyt polut index.(x)html -tiedostoon, jonka jälkeen siellä oleva SPA-kirjasto saa hoitaa routtauksen haluamallaan tavalla

**Tarvitsee edelleen ainakin seuraavia muutoksia**
* Frontin routtauksissa pitää huomioida, että käyttäjä ei välttämättä ole kirjautunut ja kirjautumista pitää vaatia silloin, kun sitä tarvitaan. Helppo todeta, kun menee johonkin polkuun, johon pitäisi olla kirjautunut, esim /communicator
* Alustavasti ohjaa /index.xhtml -tiedostoon, jos tässä ei ole mitään jsf-sidonnaista, niin olisi syytä muuttaa index.html -tiedostoksi
* Bäkkäristä voisi purkaa vanhat rewrite-polut pois, mukaanlukien niiden käyttämät xhtml-tiedostot ja backingbeanit
* Filtterissä oleva lista poluista ei välttämättä ole täydellinen, tämän läpikäynti