### PR TITLE
noto sans for cyrillic texts

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/vars.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/vars.scss
@@ -1,3 +1,6 @@
+
+
+
 // Loader
 $loader-size: 50px;
 $dialog-loader-size: 220px;
@@ -12,7 +15,7 @@ $select-height-mobile: 2.25rem;
 $select-height-desktop: 2.5rem;
 
 // Fonts
-$system-font-family: "Inter", "Arial", "sans-serif";
+$system-font-family: "Inter", "Noto Sans", "sans-serif";
 $branded-font-family: "Exo 2", "Arial", "sans-serif";
 
 // Menu

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/vars.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/base/vars.scss
@@ -1,6 +1,3 @@
-
-
-
 // Loader
 $loader-size: 50px;
 $dialog-loader-size: 220px;
@@ -15,7 +12,7 @@ $select-height-mobile: 2.25rem;
 $select-height-desktop: 2.5rem;
 
 // Fonts
-$system-font-family: "Inter", "Noto Sans", "sans-serif";
+$system-font-family: "Inter", "Arial", "sans-serif";
 $branded-font-family: "Exo 2", "Arial", "sans-serif";
 
 // Menu

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/rich-text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/rich-text.scss
@@ -3,6 +3,7 @@
 @import "../base/vars";
 @import "../base/breakpoints";
 @import "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap";
+@import "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap";
 
 // This file sets styling for every rich text editors content so they are rendered always the same way regardless where they are created.
 
@@ -16,6 +17,11 @@
   line-height: 1.25rem;
   word-wrap: break-word;
   /* stylelint-enable selector-class-pattern */
+
+  &:lang(ru) {
+    font-family: "Noto Sans", sans-serif;
+  }
+  
 
   // This will prevent ckeditor to screw up toolbar (and other elements) rendering becouse of previous rule
   .cke * {

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/rich-text.scss
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/sass/elements/rich-text.scss
@@ -2,7 +2,6 @@
 @import "../base/mixins";
 @import "../base/vars";
 @import "../base/breakpoints";
-@import "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap";
 
 // This file sets styling for every rich text editors content so they are rendered always the same way regardless where they are created.
@@ -21,7 +20,6 @@
   &:lang(ru) {
     font-family: "Noto Sans", sans-serif;
   }
-  
 
   // This will prevent ckeditor to screw up toolbar (and other elements) rendering becouse of previous rule
   .cke * {

--- a/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
+++ b/muikku/src/main/webapp/WEB-INF/templates/base.xhtml
@@ -101,7 +101,11 @@
         href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&amp;display=swap"
         rel="stylesheet"
       />
-
+      
+      <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&amp;family=Noto+Sans:ital,wght@0,100..900;1,100..900&amp;display=swap"
+        rel="stylesheet" 
+      />
+       
       <ui:insert name="styles"></ui:insert>
 
       <!-- Here goes what a page needs, usually their controllers -->


### PR DESCRIPTION
Fixes #7221 

Looks for a rich text inside a tag with lang="ru" .