### PR TITLE
7363 matikkatehtavaa ei voi muokata kun peruuttaa palautuksen

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/better-math-field/field.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/fields/better-math-field/field.tsx
@@ -122,10 +122,11 @@ export default class MathField extends React.Component<FieldProps, FieldState> {
 
   /**
    * shouldComponentUpdate
+   * @param nextProps nextProps
+   * @param nextState nextState
    */
-  shouldComponentUpdate() {
-    // this field is uncontrolled by react
-    return false;
+  shouldComponentUpdate(nextProps: FieldProps, nextState: FieldState) {
+    return nextProps.readOnly !== this.props.readOnly;
   }
 
   /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/index.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/base/material-loader/index.tsx
@@ -433,7 +433,8 @@ class MaterialLoader extends React.Component<
       !isEqual(this.props, nextProps) ||
       !isEqual(this.state.stateConfiguration, nextState.stateConfiguration) ||
       this.state.answersVisible !== nextState.answersVisible ||
-      this.state.answersChecked !== nextState.answersChecked
+      this.state.answersChecked !== nextState.answersChecked ||
+      this.state.answerRegistry !== nextState.answerRegistry
     );
   }
 

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/evaluation/evaluation-material.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/evaluation/body/application/evaluation/evaluation-material.tsx
@@ -108,7 +108,7 @@ export class EvaluationMaterial extends React.Component<
         readOnly
         answersVisible
         modifiers="evaluation-material-page"
-        usedAs={"evaluationTool"}
+        usedAs="evaluationTool"
         userEntityId={this.props.userEntityId}
         answerable={true}
       >


### PR DESCRIPTION
Fixes follwing issues:
- mathfield readonly state not changing when canceling assigment returning
- evaluation not showing answer counter fixed

Resolves: #7363 #7361 