### PR TITLE
Two studyProgrammeNames added to give access to hops matriculation

### DIFF
--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guardian_hops/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guardian_hops/body/application.tsx
@@ -35,6 +35,8 @@ const UPPERSECONDARY_PROGRAMMES = [
   "Aineopiskelu/yo-tutkinto",
   "Aineopiskelu/lukio",
   "Aineopiskelu/lukio (oppivelvolliset)",
+  "Aineopiskelu/valmistuneet",
+  "Kahden tutkinnon opinnot",
 ];
 
 /**

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/dialogs/student/hops/hops.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/guider/dialogs/student/hops/hops.tsx
@@ -285,6 +285,8 @@ const HopsApplication = (props: HopsApplicationProps) => {
           "Aineopiskelu/yo-tutkinto",
           "Aineopiskelu/lukio",
           "Aineopiskelu/lukio (oppivelvolliset)",
+          "Aineopiskelu/valmistuneet",
+          "Kahden tutkinnon opinnot",
         ].includes(studyProgrammeName);
       default:
         return true;

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application.tsx
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/scripts/src/components/hops/body/application.tsx
@@ -277,6 +277,8 @@ const HopsApplication = (props: HopsApplicationProps) => {
           "Aineopiskelu/yo-tutkinto",
           "Aineopiskelu/lukio",
           "Aineopiskelu/lukio (oppivelvolliset)",
+          "Aineopiskelu/valmistuneet",
+          "Kahden tutkinnon opinnot",
         ].includes(studyProgrammeName);
       default:
         return false;


### PR DESCRIPTION
Added two missing studyprogrammes to give access hops matriculation:
- Aineopiskelu/valmistuneet
- Kahden tutkinnon opinnot

Resolves: #7367 