### PR TITLE
Always randomize assignments on exam start

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/ExamController.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/ExamController.java
@@ -116,13 +116,8 @@ public class ExamController {
     return settingsEntity;
   }
   
-  public ExamAttendance createAttendance(Long workspaceFolderId, Long userEntityId, boolean randomizeAssignments) {
-    if (randomizeAssignments) {
-      return examAttendanceDAO.create(workspaceFolderId, userEntityId, randomizeAssignments(workspaceFolderId));
-    }
-    else {
-      return examAttendanceDAO.create(workspaceFolderId, userEntityId);
-    }
+  public ExamAttendance createAttendance(Long workspaceFolderId, Long userEntityId) {
+    return examAttendanceDAO.create(workspaceFolderId, userEntityId);
   }
   
   public void removeAttendance(ExamAttendance attendance, boolean permanent) {
@@ -177,18 +172,11 @@ public class ExamController {
   public ExamAttendance startExam(Long workspaceFolderId, Long userEntityId) {
     ExamAttendance attendance = findAttendance(workspaceFolderId, userEntityId);
     if (attendance == null) {
-      attendance = createAttendance(workspaceFolderId, userEntityId, true);
+      attendance = createAttendance(workspaceFolderId, userEntityId);
     }
-    else {
-      if (StringUtils.isBlank(attendance.getWorkspaceMaterialIds())) {
-        String assignments = randomizeAssignments(workspaceFolderId);
-        if (!StringUtils.isBlank(assignments)) {
-          attendance = examAttendanceDAO.updateWorkspaceMaterialIds(attendance, assignments);
-        }
-      }
-      if (attendance.getEnded() != null) {
-        attendance = examAttendanceDAO.updateEnded(attendance, null);
-      }
+    attendance = examAttendanceDAO.updateWorkspaceMaterialIds(attendance, randomizeAssignments(workspaceFolderId));
+    if (attendance.getEnded() != null) {
+      attendance = examAttendanceDAO.updateEnded(attendance, null);
     }
     attendance = examAttendanceDAO.updateStarted(attendance, new Date());
     return attendance;

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/dao/ExamAttendanceDAO.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/dao/ExamAttendanceDAO.java
@@ -17,14 +17,9 @@ public class ExamAttendanceDAO extends CorePluginsDAO<ExamAttendance> {
   private static final long serialVersionUID = 8315904028267869957L;
   
   public ExamAttendance create(Long workspaceFolderId, Long userEntityId) {
-    return create(workspaceFolderId, userEntityId, null);
-  }
-  
-  public ExamAttendance create(Long workspaceFolderId, Long userEntityId, String workspaceMaterialIds) {
     ExamAttendance attendance = new ExamAttendance();
     attendance.setWorkspaceFolderId(workspaceFolderId);
     attendance.setUserEntityId(userEntityId);
-    attendance.setWorkspaceMaterialIds(workspaceMaterialIds);
     return persist(attendance);
   }
   

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/rest/ExamRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/exam/rest/ExamRESTService.java
@@ -315,7 +315,7 @@ public class ExamRESTService {
     }
     ExamAttendance attendance = examController.findAttendance(workspaceFolderId, userEntityId);
     if (attendance == null) {
-      attendance = examController.createAttendance(workspaceFolderId, userEntityId, true);
+      attendance = examController.createAttendance(workspaceFolderId, userEntityId);
     }
     else if (attendance.getArchived()) {
       attendance = examController.restoreAttendance(attendance);


### PR DESCRIPTION
Fixes the potential problem of adding an attendee to an exam, which previously randomized assignments based on the contents and settings of the exam at that point.

Assignments are now randomized not until the attendee starts the exam, so if the exam has changed since the attendee was added, randomization is based on the exam's current state.

Also, if an exam allows retrying, each retry is given a new set of randomized assignments.