### PR TITLE
Kannasta puuttuvien tehtäväkenttien lisäys

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/HtmlMaterialChangeListener.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/material/HtmlMaterialChangeListener.java
@@ -94,8 +94,10 @@ public class HtmlMaterialChangeListener {
       if (fieldInDb != null) {
         continue;
       }
+      // Now we know this field wasn't in the database...
       MaterialField newField = newFields.stream().filter(mf -> fieldName.equals(mf.getName())).findFirst().orElse(null);
       if (newField == null) {
+        // ...and now we know it wasn't freshly created
         HtmlMaterialFieldCreateEvent createEvent = new HtmlMaterialFieldCreateEvent(event.getMaterial(), newFieldCollection.getField(fieldName));
         htmlMaterialFieldCreateEvent.fire(createEvent);
       }


### PR DESCRIPTION
Korjaa sivun tallennuksessa tilanteen, jossa sivun sisällössä olisi tehtäväkenttä, jolle ei löydy vastinetta kannasta mutta jota ei kuitenkaan tulkita uudeksi kentäksi, kun tallennettavaa sisältöä verrataan aiemmin tallentuneeseen sisältöön.