### PR TITLE
Poistettu includeTransferCredits ohjaamosta, opinnoista ja kieliprofiilista

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/guider/GuiderRESTService.java
@@ -693,7 +693,6 @@ public class GuiderRESTService extends PluginRESTService {
   public Response listWorkspaceActivities(
       @PathParam("USERIDENTIFIER") String userIdentifier,
       @QueryParam("workspaceIdentifier") String wsIdentifier,
-      @QueryParam("includeTransferCredits") boolean includeTransferCredits,
       @QueryParam("includeAssignmentStatistics") boolean includeAssignmentStatistics) {
 
     // Access check
@@ -722,7 +721,7 @@ public class GuiderRESTService extends PluginRESTService {
     WorkspaceActivityInfo activityInfo = evaluationController.getWorkspaceActivityInfoWithSummary(
         studentIdentifier, 
         workspaceIdentifier, 
-        includeTransferCredits, 
+        true,
         includeAssignmentStatistics);
     return Response.ok(activityInfo).build();
   }

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/transcriptofrecords/rest/TranscriptofRecordsRESTService.java
@@ -277,7 +277,6 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
   public Response listWorkspaceActivities(
       @PathParam("USERIDENTIFIER") String userIdentifier,
       @QueryParam("workspaceIdentifier") String wsIdentifier,
-      @QueryParam("includeTransferCredits") boolean includeTransferCredits,
       @QueryParam("includeAssignmentStatistics") boolean includeAssignmentStatistics) {
 
     // Access check
@@ -308,7 +307,7 @@ public class TranscriptofRecordsRESTService extends PluginRESTService {
     WorkspaceActivityInfo activityInfo = evaluationController.getWorkspaceActivityInfoWithSummary(
         studentIdentifier, 
         workspaceIdentifier, 
-        includeTransferCredits, 
+        true, 
         includeAssignmentStatistics);
     return Response.ok(activityInfo).build();
   }

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
@@ -5800,11 +5800,6 @@ paths:
           description: Workspace identifier
           schema:
             type: string
-        - name: includeTransferCredits
-          in: query
-          description: Include transfer credits
-          schema:
-            type: boolean
         - name: includeAssignmentStatistics
           in: query
           description: Include assignment statistics
@@ -8431,16 +8426,11 @@ paths:
           description: Workspace identifier
           schema:
             type: string
-        - name: includeTransferCredits
-          in: query
-          description: String boolean
-          schema:
-            type: string
         - name: includeAssignmentStatistics
           in: query
-          description: String boolean
+          description: Include assignment statistics
           schema:
-            type: string
+            type: boolean
       responses:
         "200":
           description: Workspace activity

--- a/muikku-frontend/muikkuV3/actions/main-function/guider/index.ts
+++ b/muikku-frontend/muikkuV3/actions/main-function/guider/index.ts
@@ -1221,7 +1221,6 @@ const loadStudent: LoadStudentTriggerType = function loadStudent(id) {
         guiderApi
           .getGuiderUserWorkspaceActivity({
             identifier: id,
-            includeTransferCredits: true,
             includeAssignmentStatistics: true,
           })
           .then(
@@ -1442,7 +1441,6 @@ const loadStudentHistory: LoadStudentTriggerType = function loadStudentHistory(
                   const workspacesWithActivity =
                     guiderApi.getGuiderUserWorkspaceActivity({
                       identifier: id,
-                      includeTransferCredits: true,
                       includeAssignmentStatistics: true,
                     });
 

--- a/muikku-frontend/muikkuV3/actions/main-function/records/index.ts
+++ b/muikku-frontend/muikkuV3/actions/main-function/records/index.ts
@@ -162,8 +162,7 @@ const updateAllStudentUsersAndSetViewToRecords: UpdateAllStudentUsersAndSetViewT
               const workspacesWithActivity =
                 await recordsApi.getWorkspaceActivity({
                   identifier: user.id,
-                  includeTransferCredits: "true",
-                  includeAssignmentStatistics: "true",
+                  includeAssignmentStatistics: true,
                 });
 
               return workspacesWithActivity;

--- a/muikku-frontend/muikkuV3/components/language-profile/body/application/initialization/steps/studies-evaluation.tsx
+++ b/muikku-frontend/muikkuV3/components/language-profile/body/application/initialization/steps/studies-evaluation.tsx
@@ -43,7 +43,6 @@ const AccomplishmentEvaluation = () => {
       try {
         const workspaceActivity = await recordsApi.getWorkspaceActivity({
           identifier: status.userSchoolDataIdentifier,
-          includeTransferCredits: "true",
         });
 
         const workspaceData = workspaceActivity.activities


### PR DESCRIPTION
Jyrätty, koska frontti välittää tuon aina arvolla true, eikä lähitulevaisuudessakaan näy skenaariota, jossa haluttaisiin näyttää opiskelijan suoritustietoja mutta ilman hyväksilukuja.

Bäkkärituki jätetty siksi, että se kysyy tuota Pyramuksesta saakka yksittäisen opiskelijan yksittäisen kurssin tilan selvittämiseksi, jolloin hyväksiluvut eivät kiinnosta bäkkäriä pätkääkään.