### PR TITLE
Oppimisen tuen historiafiksi

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/pedagogy/rest/PedagogyRestService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/pedagogy/rest/PedagogyRestService.java
@@ -188,7 +188,7 @@ public class PedagogyRestService {
     // If the form doesn't exist (or exists but isn't yet published to the student), return an empty object
     
     if (form == null || (form.getPublished() == null && userEntityController.isStudent(sessionController.getLoggedUserEntity()))) {
-      return Response.ok(toRestModel(form, userEntity.getId())).build();
+      return Response.ok(toRestModel((PedagogyForm) null, userEntity.getId())).build();
     }
     else {
       


### PR DESCRIPTION
Jos opiskelija yrittää katsoa tukilomaketta, joka on olemassa mutta ei vielä opiskelijalle julkaistu, älä tee siitä historiamerkintää.