### PR TITLE
Fix for course suggestions not necessarily returning suitable courses

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/hops/rest/HopsRestService.java
@@ -47,7 +47,6 @@ import fi.otavanopisto.muikku.model.users.OrganizationEntity;
 import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.model.users.UserIdentifierProperty;
 import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
-import fi.otavanopisto.muikku.model.workspace.WorkspaceAccess;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
 import fi.otavanopisto.muikku.plugins.evaluation.EvaluationController;
 import fi.otavanopisto.muikku.plugins.evaluation.model.InterimEvaluationRequest;
@@ -1127,7 +1126,7 @@ public class HopsRestService {
       return Response.ok(suggestedWorkspaces).build();
     }
 
-    // Do the search
+    // Do the search (search method automatically strips unpublished and members only workspaces)
 
     SearchProvider searchProvider = getProvider("elastic-search");
     if (searchProvider != null) {
@@ -1142,13 +1141,6 @@ public class HopsRestService {
             String dataSource = id[1];
             String identifier = id[0];
             SchoolDataIdentifier workspaceIdentifier = new SchoolDataIdentifier(identifier, dataSource);
-
-            // Skip unpublished courses
-
-            Boolean published = (Boolean) result.get("published");
-            if (!published) {
-              continue;
-            }
 
             // OPS of the course and the student must match
 
@@ -1170,12 +1162,6 @@ public class HopsRestService {
 
             WorkspaceEntity workspaceEntity = workspaceEntityController.findWorkspaceByDataSourceAndIdentifier(workspaceIdentifier.getDataSource(), workspaceIdentifier.getIdentifier());
             if (workspaceEntity == null) {
-              continue;
-            }
-
-            // Skip members only courses
-
-            if (workspaceEntity.getAccess() != null && workspaceEntity.getAccess() == WorkspaceAccess.MEMBERS_ONLY) {
               continue;
             }
 

--- a/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
+++ b/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
@@ -526,6 +526,7 @@ public class ElasticSearchProvider implements SearchProvider {
     query.must(termQuery("published", Boolean.TRUE));
     query.must(termQuery("subjects.subjectIdentifier", subjectIdentifier.toId()));
     query.must(termQuery("subjects.courseNumber", courseNumber));
+    query.mustNot(termQuery("access", "MEMBERS_ONLY"));
     
     try {
       SearchResponse response = searchRequest(MUIKKU_WORKSPACE_INDEX, query, 0, 50);


### PR DESCRIPTION
- partially fixes #7646
- for OP1, finding suitable courses with subject + course number returned so many members only courses that the only nonstop course didn't fit in the search results :|