### PR TITLE
Guider student dialog contact and guardian related crash fix

### DIFF
--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/users/WorkspaceUserEntityController.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import fi.otavanopisto.muikku.dao.workspace.WorkspaceUserEntityDAO;
+import fi.otavanopisto.muikku.model.users.EnvironmentRoleArchetype;
 import fi.otavanopisto.muikku.model.users.UserEntity;
 import fi.otavanopisto.muikku.model.users.UserEntityProperty;
 import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
@@ -384,7 +385,25 @@ public class WorkspaceUserEntityController {
   private SchoolDataIdentifier toSchoolDataIdentifier(UserEntity userEntity) {
     return userEntity.defaultSchoolDataIdentifier();
   }
+  
+  /**
+   * Returns true if the teacher has a role TEACHER and
+   * student has a role STUDENT and they have shared workspaces.
+   * 
+   * @param teacher
+   * @param student
+   * @return
+   */
+  public boolean isWorkspaceTeacherOf(UserEntity teacher, UserSchoolDataIdentifier student) {
+    UserSchoolDataIdentifier teacherUSDI = userSchoolDataIdentifierController.findUserSchoolDataIdentifierByUserEntity(teacher);
 
+    if (teacherUSDI != null && teacherUSDI.hasRole(EnvironmentRoleArchetype.TEACHER) && student.hasRole(EnvironmentRoleArchetype.STUDENT)) {
+      return haveSharedWorkspaces(teacher, student.getUserEntity());
+    }
+    
+    return false;
+  }
+  
   /**
    * Returns true if user1 and user2 have any shared workspaces.
    * @param user1 User 1

--- a/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
+++ b/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
@@ -142,11 +142,9 @@ class StateOfStudies extends React.Component<
     // You can use the cheat && after the property
     // eg. guider.currentStudent.property && guider.currentStudent.property.useSubProperty
 
-    const defaultEmailAddress =
-      this.props.guider.currentStudent.contactInfos &&
-      this.props.guider.currentStudent.contactInfos.find(
-        (e) => e.defaultContact
-      ).email;
+    const defaultEmailAddress = (
+      this.props.guider.currentStudent.contactInfos ?? []
+    ).find((e) => e.defaultContact)?.email;
 
     const avatar = (
       <Avatar
@@ -542,9 +540,9 @@ class StateOfStudies extends React.Component<
               </ApplicationSubPanel>
             </ApplicationSubPanel>
 
-            {this.props.guider.currentStudent.contactInfos.length > 0 &&
+            {(this.props.guider.currentStudent.contactInfos ?? []).length > 0 &&
               contacts}
-            {this.props.guider.currentStudent.guardians.length > 0 &&
+            {(this.props.guider.currentStudent.guardians ?? []).length > 0 &&
               studentGuardians}
             <ApplicationSubPanel modifier="counselors">
               <ApplicationSubPanel.Header modifier="with-instructions">

--- a/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
+++ b/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
@@ -1414,7 +1414,8 @@ public class UserRESTService extends AbstractRESTService {
     if (sessionController.getLoggedUser().equals(studentIdentifier) 
         || userController.isGuardianOfStudent(sessionController.getLoggedUser(), studentIdentifier)
         || userSchoolDataController.amICounselor(studentIdentifier) 
-        || sessionController.hasAnyRole(EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER)) {
+        || sessionController.hasAnyRole(EnvironmentRoleArchetype.ADMINISTRATOR, EnvironmentRoleArchetype.MANAGER, EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER)
+        || workspaceUserEntityController.isWorkspaceTeacherOf(sessionController.getLoggedUserEntity(), studentUSDI)) {
       List<Guardian> studentsGuardians = userSchoolDataController.listStudentsGuardians(studentIdentifier);
       return Response.ok(createRestModel(studentsGuardians)).build();
     } else {


### PR DESCRIPTION
Guider student dialog crash fixed:
- condition added to check that specific currentStudent properties exist
- guardians are available to teacher role users
- contacts are available in guider to teacher role users