### PR TITLE
Huoltajien hakeminen viestimessä

### DIFF
--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRecipientsRESTService.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/communicator/rest/CommunicatorRecipientsRESTService.java
@@ -138,11 +138,21 @@ public class CommunicatorRecipientsRESTService extends PluginRESTService {
       // Additional roles searchable by staff
       roleArchetypeFilter.add(EnvironmentRoleArchetype.STUDY_GUIDER);
       roleArchetypeFilter.add(EnvironmentRoleArchetype.STUDENT);
+      roleArchetypeFilter.add(EnvironmentRoleArchetype.STUDENT_PARENT);
       
       if (sessionController.hasEnvironmentPermission(RoleFeatures.ACCESS_ONLY_GROUP_STUDENTS)) {
         // Study guider limitations - groups where user is a member
         List<UserGroupEntity> userGroups = userGroupEntityController.listUserGroupsByUserIdentifier(sessionController.getLoggedUser());
         userGroupFilters = userGroups.stream().map(userGroup -> userGroup.getId()).collect(Collectors.toSet());
+      }
+      
+      if (userSchoolDataIdentifier.hasRole(EnvironmentRoleArchetype.TEACHER)) {
+        // Workspaces where user is a member
+        List<WorkspaceEntity> workspaces = workspaceUserEntityController.listWorkspaceEntitiesByUserEntity(userSchoolDataIdentifier.getUserEntity());
+        workspaceFilters = new HashSet<>();
+        for (WorkspaceEntity ws : workspaces) {
+          workspaceFilters.add(ws.getId());
+        }
       }
     } else {
       return Response.ok(Collections.EMPTY_LIST).build();

--- a/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserIndexer.java
+++ b/muikku-core-plugins/src/main/java/fi/otavanopisto/muikku/plugins/search/UserIndexer.java
@@ -1,5 +1,7 @@
 package fi.otavanopisto.muikku.plugins.search;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -19,9 +21,11 @@ import fi.otavanopisto.muikku.model.users.UserSchoolDataIdentifier;
 import fi.otavanopisto.muikku.model.workspace.WorkspaceEntity;
 import fi.otavanopisto.muikku.schooldata.SchoolDataBridgeSessionController;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
+import fi.otavanopisto.muikku.schooldata.entity.GuardiansDependent;
 import fi.otavanopisto.muikku.schooldata.entity.User;
 import fi.otavanopisto.muikku.schooldata.entity.UserStudyPeriod;
 import fi.otavanopisto.muikku.search.IndexedUser;
+import fi.otavanopisto.muikku.search.IndexedUserDependant;
 import fi.otavanopisto.muikku.search.IndexedUserStudyPeriod;
 import fi.otavanopisto.muikku.search.SearchIndexer;
 import fi.otavanopisto.muikku.users.UserController;
@@ -132,6 +136,30 @@ public class UserIndexer {
               environmentRoles.contains(EnvironmentRoleArchetype.ADMINISTRATOR)) {
             String userDefaultEmailAddress = userEmailEntityController.getUserDefaultEmailAddress(userEntity, false);
             indexedUser.setEmail(userDefaultEmailAddress);
+          }
+
+          // If the user is a guardian, save basic info on the dependants
+          if (environmentRoles.contains(EnvironmentRoleArchetype.STUDENT_PARENT)) {
+            List<GuardiansDependent> guardiansDependents = userController.listGuardiansDependents(userIdentifier);
+            List<IndexedUserDependant> indexedDependants = new ArrayList<>();
+            for (GuardiansDependent guardiansDependent : guardiansDependents) {
+              SchoolDataIdentifier dependantIdentifier = guardiansDependent.getUserIdentifier();
+              
+              Set<Long> dependantsWorkspaces = workspaceUserEntityController.listActiveWorkspaceEntitiesByUserIdentifier(dependantIdentifier)
+                  .stream().map(WorkspaceEntity::getId).collect(Collectors.toSet());
+              Set<Long> dependantsGroups = userGroupEntityController.listUserGroupsByUserIdentifier(dependantIdentifier)
+                  .stream().map(UserGroupEntity::getId).collect(Collectors.toSet());
+              OffsetDateTime expiryDate = guardiansDependent.getExpiryDate() != null ? guardiansDependent.getExpiryDate().minusDays(1).atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime() : null;
+
+              indexedDependants.add(new IndexedUserDependant(
+                  guardiansDependent.getUserIdentifier().toId(),
+                  expiryDate,
+                  dependantsWorkspaces,
+                  dependantsGroups
+                )
+              );
+            }
+            indexedUser.setDependants(indexedDependants);
           }
         }
         

--- a/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
+++ b/muikku-core-plugins/src/main/resources/META-INF/resources/swagger.yaml
@@ -15664,9 +15664,14 @@ components:
         - firstName
         - lastName
         - continuedViewPermission
+        - state
       properties:
         identifier:
           type: string
+        userEntityId:
+          description: May be undefined especially when the guardian doesn't have an account
+          type: integer
+          format: int64
         firstName:
           type: string
         lastName:
@@ -15676,6 +15681,12 @@ components:
         continuedViewPermissionModified:
           type: string
           format: date-time
+        state:
+          type: string
+          enum:
+            - INVITED
+            - ACTIVE
+            - INACTIVE
 
     GuidanceCounselorContact:
       type: object

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/entity/Guardian.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/entity/Guardian.java
@@ -1,5 +1,6 @@
 package fi.otavanopisto.muikku.schooldata.entity;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
@@ -9,13 +10,16 @@ public class Guardian {
   public Guardian() {
   }
   
-  public Guardian(SchoolDataIdentifier identifier, String firstName, String lastName, GuardianState state, boolean continuedViewPermission, OffsetDateTime continuedViewPermissionModified) {
+  public Guardian(SchoolDataIdentifier identifier, SchoolDataIdentifier studentParentIdentifier, String firstName, String lastName, 
+      GuardianState state, boolean continuedViewPermission, OffsetDateTime continuedViewPermissionModified, LocalDate expires) {
     this.identifier = identifier;
+    this.studentParentIdentifier = studentParentIdentifier;
     this.firstName = firstName;
     this.lastName = lastName;
     this.state = state;
     this.continuedViewPermission = continuedViewPermission;
     this.continuedViewPermissionModified = continuedViewPermissionModified;
+    this.expires = expires;
   }
   
   public String getFirstName() {
@@ -66,10 +70,31 @@ public class Guardian {
     this.continuedViewPermissionModified = continuedViewPermissionModified;
   }
 
+  /**
+   * @return The School Data Identifier of the User. May not exist especially when the state is INVITED.
+   */
+  public SchoolDataIdentifier getStudentParentIdentifier() {
+    return studentParentIdentifier;
+  }
+
+  public void setStudentParentIdentifier(SchoolDataIdentifier studentParentIdentifier) {
+    this.studentParentIdentifier = studentParentIdentifier;
+  }
+
+  public LocalDate getExpires() {
+    return expires;
+  }
+
+  public void setExpires(LocalDate expires) {
+    this.expires = expires;
+  }
+
   private SchoolDataIdentifier identifier;
+  private SchoolDataIdentifier studentParentIdentifier;
   private String firstName;
   private String lastName;
   private GuardianState state;
   private boolean continuedViewPermission;
   private OffsetDateTime continuedViewPermissionModified;
+  private LocalDate expires;
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/entity/GuardiansDependent.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/schooldata/entity/GuardiansDependent.java
@@ -27,4 +27,6 @@ public interface GuardiansDependent {
   LocalDate getStudyTimeEnd();
   
   LocalDate getStudyEndDate();
+  
+  LocalDate getExpiryDate();
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedUser.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedUser.java
@@ -14,6 +14,8 @@ import fi.otavanopisto.muikku.search.annotations.Indexable;
 import fi.otavanopisto.muikku.search.annotations.IndexableFieldMultiField;
 import fi.otavanopisto.muikku.search.annotations.IndexableFieldOption;
 import fi.otavanopisto.muikku.search.annotations.IndexableFieldType;
+import fi.otavanopisto.muikku.search.annotations.IndexableSubObject;
+import fi.otavanopisto.muikku.search.annotations.IndexableSubObjectType;
 
 @Indexable (
   indexName = IndexedUser.INDEX_NAME,
@@ -64,6 +66,12 @@ import fi.otavanopisto.muikku.search.annotations.IndexableFieldType;
     @IndexableFieldOption (
       name = "organizationIdentifier",
       type = IndexableFieldType.KEYWORD
+    )
+  },
+  subObjects = {
+    @IndexableSubObject (
+      name = "dependants",
+      type = IndexableSubObjectType.NESTED
     )
   }
 )
@@ -301,6 +309,14 @@ public class IndexedUser {
     this.birthday = birthday;
   }
 
+  public List<IndexedUserDependant> getDependants() {
+    return dependants;
+  }
+
+  public void setDependants(List<IndexedUserDependant> dependants) {
+    this.dependants = dependants;
+  }
+
   private String identifier;
   private String schoolDataSource;
   private String firstName;
@@ -328,4 +344,5 @@ public class IndexedUser {
   private Set<Long> groups;
   private List<IndexedUserStudyPeriod> studyPeriods;
   private LocalDate birthday;
+  private List<IndexedUserDependant> dependants;
 }

--- a/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedUserDependant.java
+++ b/muikku-core/src/main/java/fi/otavanopisto/muikku/search/IndexedUserDependant.java
@@ -1,0 +1,55 @@
+package fi.otavanopisto.muikku.search;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+public class IndexedUserDependant {
+ 
+  public IndexedUserDependant() {
+  }
+  
+  public IndexedUserDependant(String studentIdentifier, OffsetDateTime relationExpiryDate, Set<Long> workspaces, Set<Long> groups) {
+    this.studentIdentifier = studentIdentifier;
+    expires = relationExpiryDate;
+    this.workspaces = workspaces;
+    this.groups = groups;
+  }
+  
+  public String getStudentIdentifier() {
+    return studentIdentifier;
+  }
+
+  public void setStudentIdentifier(String studentIdentifier) {
+    this.studentIdentifier = studentIdentifier;
+  }
+
+  public Set<Long> getWorkspaces() {
+    return workspaces;
+  }
+
+  public void setWorkspaces(Set<Long> workspaces) {
+    this.workspaces = workspaces;
+  }
+
+  public Set<Long> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(Set<Long> groups) {
+    this.groups = groups;
+  }
+
+  public OffsetDateTime getExpires() {
+    return expires;
+  }
+
+  public void setExpires(OffsetDateTime expires) {
+    this.expires = expires;
+  }
+
+  private String studentIdentifier;
+  private OffsetDateTime expires;
+  private Set<Long> workspaces;
+  private Set<Long> groups;
+  
+}

--- a/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
+++ b/muikku-elastic-search/src/main/java/fi/otavanopisto/muikku/plugins/search/ElasticSearchProvider.java
@@ -326,16 +326,26 @@ public class ElasticSearchProvider implements SearchProvider {
         query.filter(
             boolQuery()
             .should(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))))
+            .should(nestedQuery("dependants", boolQuery().must(termsQuery("dependants.groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0])))), ScoreMode.Avg))
             .should(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))))
+            .should(nestedQuery("dependants", boolQuery().must(termsQuery("dependants.workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0])))), ScoreMode.Avg))
           );
       }
       else {
         if (groups != null) {
-          query.filter(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))));
+          query.filter(
+              boolQuery()
+              .should(termsQuery("groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0]))))
+              .should(nestedQuery("dependants", boolQuery().must(termsQuery("dependants.groups", ArrayUtils.toPrimitive(groups.toArray(new Long[0])))), ScoreMode.Avg))
+          );
         }
 
         if (workspaces != null) {
-          query.filter(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))));
+          query.filter(
+              boolQuery()
+              .should(termsQuery("workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0]))))
+              .should(nestedQuery("dependants", boolQuery().must(termsQuery("dependants.workspaces", ArrayUtils.toPrimitive(workspaces.toArray(new Long[0])))), ScoreMode.Avg))
+          );
         }
       }
 
@@ -447,6 +457,14 @@ public class ElasticSearchProvider implements SearchProvider {
           archetypeToIndexString(EnvironmentRoleArchetype.STUDY_GUIDER),
           archetypeToIndexString(EnvironmentRoleArchetype.STUDY_PROGRAMME_LEADER),
           archetypeToIndexString(EnvironmentRoleArchetype.ADMINISTRATOR))
+        )
+        .should(boolQuery()
+          .must(termQuery("roles", archetypeToIndexString(EnvironmentRoleArchetype.STUDENT_PARENT)))
+          .must(nestedQuery("dependants",
+              boolQuery()
+                .should(boolQuery().mustNot(existsQuery("dependants.expires")))
+                .should(rangeQuery("dependants.expires").gte(now))
+              , ScoreMode.Avg))
         )
         .should(boolQuery()
           .must(termQuery("roles", archetypeToIndexString(EnvironmentRoleArchetype.STUDENT)))

--- a/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
+++ b/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
@@ -252,8 +252,42 @@ class StateOfStudies extends React.Component<
                           ),
                         };
 
+                  const guardianActions = (
+                    <>
+                    {guardian.userEntityId && guardian.state === "ACTIVE" && (
+                      <CommunicatorNewMessage
+                        extraNamespace="guidance-counselor"
+                        initialSelectedItems={[
+                          {
+                            type: "staff",
+                            value: {
+                              id: guardian.userEntityId,
+                              name: getName(guardian, true),
+                            },
+                          },
+                        ]}
+                      >
+                        <ButtonPill
+                          icon="envelope"
+                          aria-label={this.props.i18n.t("labels.send", {
+                            ns: "messaging",
+                          })}
+                          title={this.props.i18n.t("labels.send", {
+                            ns: "messaging",
+                          })}
+                          buttonModifiers={[
+                            "new-message",
+                            "new-message-to-staff",
+                          ]}
+                        ></ButtonPill>
+                      </CommunicatorNewMessage>
+                    )}
+                    </>
+                  );
+                        
                   return (
                     <ContactCard
+                      actions={guardianActions}
                       key={"guardian" + index}
                       fullName={getName(guardian, true)}
                       state={

--- a/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
+++ b/muikku-frontend/muikkuV3/components/guider/dialogs/student/tabs/state-of-studies.tsx
@@ -254,37 +254,37 @@ class StateOfStudies extends React.Component<
 
                   const guardianActions = (
                     <>
-                    {guardian.userEntityId && guardian.state === "ACTIVE" && (
-                      <CommunicatorNewMessage
-                        extraNamespace="guidance-counselor"
-                        initialSelectedItems={[
-                          {
-                            type: "staff",
-                            value: {
-                              id: guardian.userEntityId,
-                              name: getName(guardian, true),
+                      {guardian.userEntityId && guardian.state === "ACTIVE" && (
+                        <CommunicatorNewMessage
+                          extraNamespace="guidance-counselor"
+                          initialSelectedItems={[
+                            {
+                              type: "staff",
+                              value: {
+                                id: guardian.userEntityId,
+                                name: getName(guardian, true),
+                              },
                             },
-                          },
-                        ]}
-                      >
-                        <ButtonPill
-                          icon="envelope"
-                          aria-label={this.props.i18n.t("labels.send", {
-                            ns: "messaging",
-                          })}
-                          title={this.props.i18n.t("labels.send", {
-                            ns: "messaging",
-                          })}
-                          buttonModifiers={[
-                            "new-message",
-                            "new-message-to-staff",
                           ]}
-                        ></ButtonPill>
-                      </CommunicatorNewMessage>
-                    )}
+                        >
+                          <ButtonPill
+                            icon="envelope"
+                            aria-label={this.props.i18n.t("labels.send", {
+                              ns: "messaging",
+                            })}
+                            title={this.props.i18n.t("labels.send", {
+                              ns: "messaging",
+                            })}
+                            buttonModifiers={[
+                              "new-message",
+                              "new-message-to-staff",
+                            ]}
+                          ></ButtonPill>
+                        </CommunicatorNewMessage>
+                      )}
                     </>
                   );
-                        
+
                   return (
                     <ContactCard
                       actions={guardianActions}

--- a/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/model/GuardianRestModel.java
+++ b/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/model/GuardianRestModel.java
@@ -2,17 +2,21 @@ package fi.otavanopisto.muikku.rest.model;
 
 import java.time.OffsetDateTime;
 
+import fi.otavanopisto.muikku.schooldata.entity.GuardianState;
+
 public class GuardianRestModel {
 
   public GuardianRestModel() {
   }
 
-  public GuardianRestModel(String identifier, String firstName, String lastName, boolean continuedViewPermission, OffsetDateTime continuedViewPermissionModified) {
+  public GuardianRestModel(String identifier, Long userEntityId, String firstName, String lastName, boolean continuedViewPermission, OffsetDateTime continuedViewPermissionModified, GuardianState state) {
     this.identifier = identifier;
+    this.userEntityId = userEntityId;
     this.firstName = firstName;
     this.lastName = lastName;
     this.continuedViewPermission = continuedViewPermission;
     this.continuedViewPermissionModified = continuedViewPermissionModified;
+    this.state = state;
   }
   
   public String getIdentifier() {
@@ -55,9 +59,27 @@ public class GuardianRestModel {
     this.continuedViewPermissionModified = continuedViewPermissionModified;
   }
 
+  public Long getUserEntityId() {
+    return userEntityId;
+  }
+
+  public void setUserEntityId(Long userEntityId) {
+    this.userEntityId = userEntityId;
+  }
+
+  public GuardianState getState() {
+    return state;
+  }
+
+  public void setState(GuardianState state) {
+    this.state = state;
+  }
+
   private String identifier;
+  private Long userEntityId;
   private String firstName;
   private String lastName;
   private boolean continuedViewPermission;
   private OffsetDateTime continuedViewPermissionModified;
+  private GuardianState state;
 }

--- a/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
+++ b/muikku-rest/src/main/java/fi/otavanopisto/muikku/rest/user/UserRESTService.java
@@ -1835,12 +1835,16 @@ public class UserRESTService extends AbstractRESTService {
   }
 
   private GuardianRestModel createRestModel(Guardian studentsGuardian) {
+    UserEntity studentParentUserEntity = studentsGuardian.getStudentParentIdentifier() != null ? userEntityController.findUserEntityByUserIdentifier(studentsGuardian.getStudentParentIdentifier()) : null;
+    
     return new GuardianRestModel(
         studentsGuardian.getIdentifier().toId(),
+        studentParentUserEntity != null ? studentParentUserEntity.getId() : null,
         studentsGuardian.getFirstName(), 
         studentsGuardian.getLastName(),
         studentsGuardian.isContinuedViewPermission(),
-        studentsGuardian.getContinuedViewPermissionModified()
+        studentsGuardian.getContinuedViewPermissionModified(),
+        studentsGuardian.getState()
     );
   }
 

--- a/muikku-school-data-pyramus/pom.xml
+++ b/muikku-school-data-pyramus/pom.xml
@@ -126,13 +126,13 @@
     <dependency>
       <groupId>fi.otavanopisto.pyramus</groupId>
       <artifactId>rest-model</artifactId>
-      <version>0.7.265</version>
+      <version>0.7.270-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>fi.otavanopisto.pyramus</groupId>
       <artifactId>pyramus-webhooks</artifactId>
-      <version>0.7.265</version>
+      <version>0.7.270-SNAPSHOT</version>
     </dependency>
 
     <!-- Muikku -->

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUpdater.java
@@ -31,6 +31,7 @@ import fi.otavanopisto.muikku.model.workspace.WorkspaceUserEntity;
 import fi.otavanopisto.muikku.plugins.schooldatapyramus.entities.PyramusSchoolDataEntityFactory;
 import fi.otavanopisto.muikku.plugins.schooldatapyramus.entities.PyramusUserEmail;
 import fi.otavanopisto.muikku.plugins.schooldatapyramus.rest.PyramusClient;
+import fi.otavanopisto.muikku.schooldata.BridgeResponse;
 import fi.otavanopisto.muikku.schooldata.SchoolDataIdentifier;
 import fi.otavanopisto.muikku.schooldata.WorkspaceController;
 import fi.otavanopisto.muikku.schooldata.WorkspaceEntityController;
@@ -72,6 +73,7 @@ import fi.otavanopisto.pyramus.rest.model.StudentGroup;
 import fi.otavanopisto.pyramus.rest.model.StudentGroupStudent;
 import fi.otavanopisto.pyramus.rest.model.StudentGroupUser;
 import fi.otavanopisto.pyramus.rest.model.StudentParent;
+import fi.otavanopisto.pyramus.rest.model.StudentParentRelation;
 import fi.otavanopisto.pyramus.rest.model.StudyProgramme;
 import fi.otavanopisto.pyramus.rest.model.UserRole;
 
@@ -813,6 +815,8 @@ public class PyramusUpdater {
   @Lock (LockType.WRITE)
   @AccessTimeout(value=30000)
   public void updatePerson(Person person) {
+    logger.log(Level.FINE, String.format("Updating person %d", person.getId()));
+    
     Long userEntityId = null;
     
     final SchoolDataIdentifier studentRoleIdentifier = new SchoolDataIdentifier(identifierMapper.getEnvironmentRoleIdentifier(UserRole.STUDENT), SchoolDataPyramusPluginDescriptor.SCHOOL_DATA_SOURCE);
@@ -1081,6 +1085,8 @@ public class PyramusUpdater {
   }
 
   public void updateStaffMember(Long staffMemberId) {
+    logger.log(Level.FINE, String.format("Updating staff member %d", staffMemberId));
+    
     StaffMember staffMember = pyramusClient.get().get(String.format("/staff/members/%d", staffMemberId), StaffMember.class);
     if (staffMember != null) {
       updatePerson(staffMember.getPersonId());
@@ -1090,6 +1096,8 @@ public class PyramusUpdater {
   }
 
   public void updateStudentParent(Long studentParentId) {
+    logger.log(Level.FINE, String.format("Updating student parent %d", studentParentId));
+    
     StudentParent studentParent = pyramusClient.get().get(String.format("/studentparents/studentparents/%d", studentParentId), StudentParent.class);
     if (studentParent != null) {
       updatePerson(studentParent.getPersonId());
@@ -1099,10 +1107,26 @@ public class PyramusUpdater {
   }
 
   public void updateStudent(Long studentId) {
+    logger.log(Level.FINE, String.format("Updating student %d", studentId));
+    
     Student student = pyramusClient.get().get(String.format("/students/students/%d", studentId), Student.class);
     if (student != null) {
       updatePerson(student.getPersonId());
       updateStudyProgrammeMember(student);
+      
+      // Student Parents contain some information in search index, trigger update for them also
+      BridgeResponse<StudentParentRelation[]> studentParentsResponse = pyramusClient.get().responseGet(String.format("/students/students/%d/studentParents", studentId), StudentParentRelation[].class);
+      if (studentParentsResponse.ok()) {
+        StudentParentRelation[] studentParentRelations = studentParentsResponse.getEntity();
+        if (studentParentRelations != null) {
+          for (StudentParentRelation studentParentRelation : studentParentRelations) {
+            updateStudentParent(studentParentRelation.getStudentParentId());
+          }
+        }
+      }
+      else {
+        logger.log(Level.SEVERE, String.format("Couldn't fetch student parents for student %d. Statuscode: %d", studentId, studentParentsResponse.getStatusCode()));
+      }
     } else {
       identifierRemoved(identifierMapper.getStudentIdentifier(studentId));
     }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUserSchoolDataBridge.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/PyramusUserSchoolDataBridge.java
@@ -1856,7 +1856,8 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
             address,
             student.getStudyStartDate(),
             student.getStudyTimeEnd(),
-            student.getStudyEndDate()
+            student.getStudyEndDate(),
+            student.getRelationExpiry()
         ));
       }
     }
@@ -1911,11 +1912,13 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
       for (StudentParentInvitation studentParentInvitation : studentParentInvitations.getEntity()) {
         result.add(new Guardian(
           identifierMapper.getStudentParentInvitationIdentifier(studentParentInvitation.getId()),
+          null,
           studentParentInvitation.getFirstName(),
           studentParentInvitation.getLastName(),
           GuardianState.INVITED,
           studentParentInvitation.isContinuedViewPermission(),
-          studentParentInvitation.getContinuedViewPermissionModified()
+          studentParentInvitation.getContinuedViewPermissionModified(),
+          null
         ));
       }
     }
@@ -1926,13 +1929,16 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
 
     if (studentParents.ok()) {
       for (StudentParentRelation studentParentRelation : studentParents.getEntity()) {
+        SchoolDataIdentifier studentParentIdentifier = studentParentRelation.getStudentParentId() != null ? identifierMapper.getStudentParentIdentifier(studentParentRelation.getStudentParentId()) : null;
         result.add(new Guardian(
           identifierMapper.getStudentParentChildIdentifier(studentParentRelation.getId()),
+          studentParentIdentifier,
           studentParentRelation.getFirstName(), 
           studentParentRelation.getLastName(),
           studentParentRelation.isActiveParent() ? GuardianState.ACTIVE : GuardianState.INACTIVE,
           studentParentRelation.isContinuedViewPermission(),
-          studentParentRelation.getContinuedViewPermissionModified()
+          studentParentRelation.getContinuedViewPermissionModified(),
+          studentParentRelation.getExipres()
         ));
       }
     }
@@ -1957,11 +1963,13 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
         StudentParentInvitation studentParentInvitation = response.getEntity();
         Guardian guardian = new Guardian(
           identifierMapper.getStudentParentInvitationIdentifier(studentParentInvitation.getId()),
+          null,
           studentParentInvitation.getFirstName(),
           studentParentInvitation.getLastName(),
           GuardianState.INVITED,
           studentParentInvitation.isContinuedViewPermission(),
-          studentParentInvitation.getContinuedViewPermissionModified()
+          studentParentInvitation.getContinuedViewPermissionModified(),
+          null
         );
         return new BridgeResponse<Guardian>(response.getStatusCode(), guardian, response.getMessage());
       }
@@ -1978,13 +1986,16 @@ public class PyramusUserSchoolDataBridge implements UserSchoolDataBridge {
 
       if (response.ok()) {
         StudentParentRelation studentParentRelation = response.getEntity();
+        SchoolDataIdentifier studentParentIdentifier = studentParentRelation.getStudentParentId() != null ? identifierMapper.getStudentParentIdentifier(studentParentRelation.getStudentParentId()) : null;
         Guardian guardian = new Guardian(
           identifierMapper.getStudentParentChildIdentifier(studentParentRelation.getId()),
+          studentParentIdentifier,
           studentParentRelation.getFirstName(), 
           studentParentRelation.getLastName(),
           studentParentRelation.isActiveParent() ? GuardianState.ACTIVE : GuardianState.INACTIVE,
           studentParentRelation.isContinuedViewPermission(),
-          studentParentRelation.getContinuedViewPermissionModified()
+          studentParentRelation.getContinuedViewPermissionModified(),
+          studentParentRelation.getExipres()
         );
         return new BridgeResponse<Guardian>(response.getStatusCode(), guardian, response.getMessage());
       }

--- a/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/entities/PyramusGuardiansDependent.java
+++ b/muikku-school-data-pyramus/src/main/java/fi/otavanopisto/muikku/plugins/schooldatapyramus/entities/PyramusGuardiansDependent.java
@@ -9,7 +9,7 @@ public class PyramusGuardiansDependent implements GuardiansDependent {
 
   public PyramusGuardiansDependent(SchoolDataIdentifier userIdentifier, String firstName, String lastName,
       String nickname, String studyProgrammeName, String email, String phoneNumber, String address,
-      LocalDate studyStartDate, LocalDate studyTimeEnd, LocalDate studyEndDate) {
+      LocalDate studyStartDate, LocalDate studyTimeEnd, LocalDate studyEndDate, LocalDate expiryDate) {
     this.userIdentifier = userIdentifier;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -21,6 +21,7 @@ public class PyramusGuardiansDependent implements GuardiansDependent {
     this.studyStartDate = studyStartDate;
     this.studyTimeEnd = studyTimeEnd;
     this.studyEndDate = studyEndDate;
+    this.expiryDate = expiryDate;
   }
 
   @Override
@@ -78,6 +79,11 @@ public class PyramusGuardiansDependent implements GuardiansDependent {
     return studyEndDate;
   }
 
+  @Override
+  public LocalDate getExpiryDate() {
+    return expiryDate;
+  }
+
   private final SchoolDataIdentifier userIdentifier;
   private final String firstName;
   private final String lastName;
@@ -89,5 +95,5 @@ public class PyramusGuardiansDependent implements GuardiansDependent {
   private LocalDate studyStartDate;
   private LocalDate studyTimeEnd;
   private LocalDate studyEndDate;
-
+  private LocalDate expiryDate;
 }


### PR DESCRIPTION
* Lisätty ohjaamoon nappi jolla voi lähettää viestin-viestin _aktiiviselle_ huoltajalle
* Muutettu huoltajien indeksointia niin, että niitä voidaan hakea viestimen haulla 

Tarvitsee Pyramuksen PR:n https://github.com/otavanopisto/pyramus/pull/1829

Closes #7572